### PR TITLE
implement mime type guesser factory (so it can be modified on a per proj...

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -7,6 +7,7 @@ use Gaufrette\Filesystem;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Form\File\FileType;
 use Kunstmaan\MediaBundle\Helper\Media\AbstractMediaHandler;
+use Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\HttpFoundation\File\MimeType\FileBinaryMimeTypeGuesser;
@@ -19,7 +20,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class FileHandler extends AbstractMediaHandler
 {
-
     /**
      * @var string
      */
@@ -38,11 +38,9 @@ class FileHandler extends AbstractMediaHandler
     /**
      * Constructor
      */
-    public function __construct()
+    public function __construct(MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory)
     {
-        $this->mimeTypeGuesser = MimeTypeGuesser::getInstance();
-        $this->mimeTypeGuesser->register(new FileBinaryMimeTypeGuesser());
-        $this->mimeTypeGuesser->register(new SVGMimeTypeGuesser());
+        $this->mimeTypeGuesser = $mimeTypeGuesserFactory->get();
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Helper/Image/ImageHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Image/ImageHandler.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Helper\Image;
 
+use Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Kunstmaan\MediaBundle\Helper\File\FileHandler;
 use Kunstmaan\MediaBundle\Entity\Media;
@@ -17,9 +18,9 @@ class ImageHandler extends FileHandler
     /**
      * @param string $aviaryApiKey The aviary key
      */
-    public function __construct($aviaryApiKey)
+    public function __construct(MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory, $aviaryApiKey)
     {
-        parent::__construct();
+        parent::__construct($mimeTypeGuesserFactory);
         $this->aviaryApiKey = $aviaryApiKey;
     }
 

--- a/src/Kunstmaan/MediaBundle/Helper/MimeTypeGuesserFactory.php
+++ b/src/Kunstmaan/MediaBundle/Helper/MimeTypeGuesserFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper;
+
+use Kunstmaan\MediaBundle\Helper\File\SVGMimeTypeGuesser;
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+
+class MimeTypeGuesserFactory implements MimeTypeGuesserFactoryInterface
+{
+    /**
+     * Should return a mime type guesser instance, used for file uploads
+     *
+     * NOTE: If you override this, you'll probably still have to register the SVGMimeTypeGuesser as last guesser...
+     *
+     * @return MimeTypeGuesser
+     */
+    public function get()
+    {
+        $guesser = MimeTypeGuesser::getInstance();
+        $guesser->register(new SVGMimeTypeGuesser());
+
+        return $guesser;
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/MimeTypeGuesserFactoryInterface.php
+++ b/src/Kunstmaan/MediaBundle/Helper/MimeTypeGuesserFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper;
+
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+
+interface MimeTypeGuesserFactoryInterface
+{
+    /**
+     * @return MimeTypeGuesserInterface
+     */
+    public function get();
+}

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -27,7 +27,7 @@ services:
 
     kunstmaan_media.media_handlers.image:
         class: "%kunstmaan_media.media_handler.image.class%"
-        arguments: ["%aviary_api_key%"]
+        arguments: ["@kunstmaan_media.mimetype_guesser.factory", "%aviary_api_key%"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
         tags:
@@ -35,6 +35,7 @@ services:
 
     kunstmaan_media.media_handlers.file:
         class: "%kunstmaan_media.media_handler.file.class%"
+        arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
         tags:
@@ -42,6 +43,7 @@ services:
 
     kunstmaan_media.media_handlers.pdf:
         class: "%kunstmaan_media.media_handler.pdf.class%"
+        arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
             - [ setPdfTransformer, [ "@kunstmaan_media.pdf_transformer" ]]

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ parameters:
     kunstmaan_media.icon_font.default_loader.class: 'Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader'
     kunstmaan_media.media_creator_service.class: 'Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService'
     kunstmaan_media.pdf_transformer.class: 'Kunstmaan\MediaBundle\Helper\Transformer\PdfTransformer'
+    kunstmaan_media.mimetype_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory'
 
 services:
     liip_imagine.data.loader.stream.profile_photos:
@@ -85,3 +86,6 @@ services:
     kunstmaan_media.pdf_transformer:
         class: "%kunstmaan_media.pdf_transformer.class%"
         arguments: ["@kunstmaan_media.imagick"]
+
+    kunstmaan_media.mimetype_guesser.factory:
+        class: "%kunstmaan_media.mimetype_guesser.factory.class%"

--- a/src/Kunstmaan/MediaBundle/Tests/Helper/File/PdfHandlerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Helper/File/PdfHandlerTest.php
@@ -30,10 +30,10 @@ class PdfHandlerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->pdfTransformer = $this->getMock('Kunstmaan\MediaBundle\Helper\Transformer\PreviewTransformerInterface');
-
+        $factory = $this->getMock('Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface');
         $this->filesDir = realpath(__DIR__ . '/../../Files');
 
-        $this->object = new PdfHandler();
+        $this->object = new PdfHandler($factory);
         $this->object->setPdfTransformer($this->pdfTransformer);
     }
 


### PR DESCRIPTION
So it can be modified on a per project/server basis.

Defaults have been reverted back to their normal state (ie. not enforcing the FileBinaryMimeTypeGuesser to be used), so they work correctly on OS X by default.
