### PR TITLE
Add a 'ReferenceEntity class name' in the nodes adminlist

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
@@ -53,6 +53,7 @@ abstract class AbstractDoctrineORMAdminListConfigurator extends AbstractAdminLis
      */
     public function __construct(EntityManager $em, AclHelper $aclHelper = null)
     {
+        parent::setEntityManager($em);
         $this->em = $em;
         $this->aclHelper = $aclHelper;
     }

--- a/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
+++ b/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
@@ -62,6 +62,7 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     public function buildFields()
     {
         $this->addField('title', 'Title', true, 'KunstmaanNodeBundle:Admin:title.html.twig')
+            ->addField('ref', 'Type', false)
             ->addField('created', 'Created At', true)
             ->addField('updated', 'Updated At', true)
             ->addField('online', 'Online', true, 'KunstmaanNodeBundle:Admin:online.html.twig');


### PR DESCRIPTION
It could be very usefull to display the "refered entity's name" of each node displayed in the AdminList (BACKOFFICE/en/admin/nodes/). I had some trouble with the entity manager not present in AbstractAdminListConfigurator, but here's a fast development to do it.

Also, it could be great to be able to filter and order the list on this new "refered entity's name" column. But I guess there's a missing property in NodeTranslation. Maybe a "publicVersionRefEntity" ?

Please tell me what do you think. Thank you very much.

Matthieu Cornut - http://www.liip.ch/en