### PR TITLE
Allow to reorder the nodes in Backoffice's sidebar's jstree

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/public/js/script.js
+++ b/src/Kunstmaan/AdminBundle/Resources/public/js/script.js
@@ -22,17 +22,29 @@ function init_tree() {
         topLevelTreeElements = topLevelTreeElements + $(this).attr('id'); + ",";
     });
     $('.tree').jstree({
-        "plugins" : [ "themes", "html_data", "types", "search" ] ,
+        "plugins" : [ "themes", "html_data", "dnd", "crrm", "types", "search" ] ,
         "themes" : {
             "theme" : "OMNext",
             "dots" : true,
             "icons" : true
         },
         "core": {
-                    "animation": 0,
-                    "open_parents": true,
-                    "initially_open": [topLevelTreeElements]
-                },
+            "animation": 0,
+            "open_parents": true,
+            "initially_open": [topLevelTreeElements]
+        },
+        "crrm":{
+            "move": {
+                // Move only to current parent folder
+                "check_move": function(m){
+                    return m.op.is(m.np);
+                }
+            }
+        },
+        "dnd" : {
+            "drag_target": false,
+            "drop_target": false
+        },
         "types" : {
             "types" : {
                 //Page
@@ -96,7 +108,29 @@ function init_tree() {
         "search" : {
             "show_only_matches" : true
         }
-    });
+    }).bind("move_node.jstree", function(e, jstreeData){
+
+            var $parentNode = jstreeData.args[0].np,
+                url = $(this).data('reorder-url'),
+                params = {
+                    nodes : []
+                };
+
+            $parentNode.find(" > ul > li").each(function(){
+                var id = $(this).attr("id").replace(/node-/,'');
+                params.nodes.push(id);
+            });
+
+            $.post(
+                url,
+                params,
+                function(result){
+                    // Could display a success message from here.
+                }
+            );
+        }
+    );
+
     $("#treeform").submit(function() {
         $('.tree').jstree('search', $('#treeform #searchVal').val());
         return false;

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/sidebar.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/sidebar.html.twig
@@ -15,7 +15,7 @@
                 <button id="search" class="btn search"><i class="icon-search"></i></button>
             </form>
         </div>
-        <div class="tree clearfix">
+        <div class="tree clearfix" data-reorder-url="{{ path('KunstmaanNodeBundle_nodes_reorder') }}">
             {% set currentMenuItem = adminmenu.current %}
    	        <ul>
                 {% if lowestTopChild.appearInSidebar %}


### PR DESCRIPTION
With this PR, editor can reorder the nodes by drag&drop inside the "jsTree" of the sidebar, in the backoffice. It allows only to move a node inside his parent, so there's no "AllowedChild problem".

It just resets the **weight** property of all NodeTranslation instances inside a same parent.
