### PR TITLE
Allow to initialise pageparts providing service container

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Entity/AbstractPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/AbstractPagePart.php
@@ -5,6 +5,7 @@ use Kunstmaan\NodeBundle\Entity\PageInterface;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Abstract ORM Pagepart
@@ -27,10 +28,18 @@ abstract class AbstractPagePart extends AbstractEntity implements PagePartInterf
      * Use this method to override the default view for a specific page type.
      * Also, this implementation guarantees backwards compatibility.
      *
+     * @param PageInterface $page The current parent page
      * @return string
      */
     public function getView(PageInterface $page = null)
     {
         return $this->getDefaultView();
     }
+
+    /**
+     * Override this method to initialise data that is not stored in the pagepart's fields.
+     * @param PageInterface $page
+     * @param ContainerInterface $container
+     */
+    public function init(PageInterface $page, ContainerInterface $container){}
 }

--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -117,6 +117,7 @@ class PagePartAdmin
         $pageParts = array();
         foreach ($types as $classname => $ids) {
             $result    = $this->em->getRepository($classname)->findBy(array('id' => $ids));
+            $result[0]->init($this->page, $this->container);
             $pageParts = array_merge($pageParts, $result);
         }
 

--- a/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
+++ b/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
@@ -9,6 +9,7 @@ use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * PagePartRefRepository
@@ -68,12 +69,13 @@ class PagePartRefRepository extends EntityRepository
     }
 
     /**
-     * @param HasPagePartsInterface $page    The page
-     * @param string                $context The pagepart context
+     * @param HasPagePartsInterface $page       The page
+     * @param string                $context    The pagepart context
+     * @param ContainerInterface    $container  The service container
      *
      * @return PagePartInterface[]
      */
-    public function getPageParts(HasPagePartsInterface $page, $context = "main")
+    public function getPageParts(HasPagePartsInterface $page, $context = "main", ContainerInterface $container)
     {
         $pagepartrefs = $this->getPagePartRefs($page, $context);
 
@@ -90,6 +92,7 @@ class PagePartRefRepository extends EntityRepository
         $pageparts = array();
         foreach ($types as $classname => $ids) {
             $result = $this->getEntityManager()->getRepository($classname)->findBy(array('id' => $ids));
+            $result[0]->init($page, $container);
             $pageparts = array_merge($pageparts, $result);
         }
 

--- a/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
+++ b/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
@@ -75,7 +75,7 @@ class PagePartRefRepository extends EntityRepository
      *
      * @return PagePartInterface[]
      */
-    public function getPageParts(HasPagePartsInterface $page, $context = "main")
+    public function getPageParts(HasPagePartsInterface $page, $context = "main", ContainerInterface $container = null)
     {
         $pagepartrefs = $this->getPagePartRefs($page, $context);
 
@@ -92,6 +92,9 @@ class PagePartRefRepository extends EntityRepository
         $pageparts = array();
         foreach ($types as $classname => $ids) {
             $result = $this->getEntityManager()->getRepository($classname)->findBy(array('id' => $ids));
+            if($container){
+                $result[0]->init($page, $container);
+            }
             $pageparts = array_merge($pageparts, $result);
         }
 

--- a/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
+++ b/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
@@ -75,7 +75,7 @@ class PagePartRefRepository extends EntityRepository
      *
      * @return PagePartInterface[]
      */
-    public function getPageParts(HasPagePartsInterface $page, $context = "main", ContainerInterface $container)
+    public function getPageParts(HasPagePartsInterface $page, $context = "main")
     {
         $pagepartrefs = $this->getPagePartRefs($page, $context);
 
@@ -92,7 +92,6 @@ class PagePartRefRepository extends EntityRepository
         $pageparts = array();
         foreach ($types as $classname => $ids) {
             $result = $this->getEntityManager()->getRepository($classname)->findBy(array('id' => $ids));
-            $result[0]->init($page, $container);
             $pageparts = array_merge($pageparts, $result);
         }
 

--- a/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
@@ -20,7 +20,7 @@ services:
     kunstmaan_pageparts.twig.extension:
         class: Kunstmaan\PagePartBundle\Twig\Extension\PagePartTwigExtension
         arguments:
-            - "@doctrine.orm.entity_manager"
+            - "@service_container"
         tags:
             - { name: twig.extension }
             

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -2,10 +2,10 @@
 
 namespace Kunstmaan\PagePartBundle\Twig\Extension;
 
-use Doctrine\ORM\EntityManager;
 use Kunstmaan\PagePartBundle\Repository\PagePartRefRepository;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * PagePartTwigExtension
@@ -21,11 +21,12 @@ class PagePartTwigExtension extends \Twig_Extension
     protected $environment;
 
     /**
-     * @param EntityManager $em
+     * @param ContainerInterface $container
      */
-    public function __construct(EntityManager $em)
+    public function __construct(ContainerInterface $container)
     {
-        $this->em = $em;
+        $this->container = $container;
+        $this->em = $container->get('doctrine.orm.entity_manager');
     }
 
     /**
@@ -60,7 +61,7 @@ class PagePartTwigExtension extends \Twig_Extension
         $template = $this->environment->loadTemplate("KunstmaanPagePartBundle:PagePartTwigExtension:widget.html.twig");
         /* @var $entityRepository PagePartRefRepository */
         $entityRepository = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
-        $pageparts = $entityRepository->getPageParts($page, $contextName);
+        $pageparts = $entityRepository->getPageParts($page, $contextName, $this->container);
         $newTwigContext = array_merge($parameters, array(
             'pageparts' => $pageparts
         ));


### PR DESCRIPTION
This PR allow to have dynamic and extended data in a pagepart, by initialising the pagepart with access to all his fields and to the service container (with locale and entity manager).

Just overriding the **AbstractPagePart** method **init*. Example, this get the **x** last **news** (where is **x** is a Integer field edited in Backoffice, and **news** is an *ArticlePage*):

```
    public function init(PageInterface $page, ContainerInterface $container){

        $locale = $container->getParameter('locale');
        $em = $container->get('doctrine.orm.entity_manager');

        $repository = $em->getRepository('LiipKumaPocBundle:News\NewsPage');
        $news = $repository->getArticles($locale);
        $this->news = array_slice($news, 0, $this->getNumber());
    }
```

The extended content is then available in the webpage and in the backoffice.