### PR TITLE
Reorder nodes in Kunstmaan V3.0

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -457,16 +457,10 @@ class NodeAdminController extends Controller
 
             /* @var NodeTranslation $nodeTranslation */
             $nodeTranslation = $node->getNodeTranslation($this->locale, true);
-            $nodeVersion = $nodeTranslation->getPublicNodeVersion();
-            $page = $nodeVersion->getRef($this->em);
-
-            $this->get('event_dispatcher')->dispatch(Events::PRE_PERSIST, new NodeEvent($node, $nodeTranslation, $nodeVersion, $page));
 
             $nodeTranslation->setWeight($weight);
             $this->em->persist($nodeTranslation);
             $this->em->flush();
-
-            $this->get('event_dispatcher')->dispatch(Events::POST_PERSIST, new NodeEvent($node, $nodeTranslation, $nodeVersion, $page));
 
             $weight++;
         }


### PR DESCRIPTION
Dispatch PRE_PERSIST & POST_PERSIST events didn't work anymore while reordering. It gives an error 500 with Elastica: /vendor/ruflin/elastica/lib/Elastica/Transport/Http.php at line 154.

Since I don't know who is listening these events, (instead of Elastica), neither why Elastica needs it, I removed them.

At first, these lines were here just to do the same as in editAction method of the same class.
