### PR TITLE
Update AbstractAdminListConfigurator.php

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -164,10 +164,13 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
 
         $friendlyName = explode("\\", $this->getEntityName());
         $friendlyName = array_pop($friendlyName);
+        $re = '/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/';
+        $a = preg_split($re, $friendlyName);
+        $superFriendlyName = implode(' ', $a);
 
         return array(
-            strtolower($friendlyName) => array('path' => $this->getPathByConvention($this::SUFFIX_ADD),
-                                                        'params' => $params)
+            $superFriendlyName => array('path'   => $this->getPathByConvention($this::SUFFIX_ADD),
+                                        'params' => $params)
         );
     }
 


### PR DESCRIPTION
Added regex to make nicer Admin List add button labels based on entity's name.

The current label for adminlist buttons isn't visually appealing - it simply takes the entities name, and lowercases it.

This PR takes the entity's name, and does some regex-fu to convert it to a nice, human string.

ie. MyGreatWonderfulEntity => "Add new My Great Wonderful Entity"

Tested, and should work for (most) any entity naming conventions, ie:

EntityName => "Add new Entity Name"
ENTITYName => "Add new ENTITY Name"
EntityNAMEAgain => "Add new Entity NAME Again"
entityname => "Add new entityname"