### PR TITLE
Fix for issue when namespace depth > 1 in KunstmaanGenerateCommand

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -95,15 +95,15 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
     {
         $bundles = array();
         $counter = 1;
-
-        $dir    = dirname($this->getContainer()->getParameter('kernel.root_dir') . '/') . '/src/';
+        $dir = dirname($this->getContainer()->getParameter('kernel.root_dir').'/').'/src/';
         $finder = new Finder();
-        $finder->directories()->in($dir)->depth('== 1');
+        $finder->in($dir)->name('*Bundle.php');
+
         foreach ($finder as $file) {
             $bundles[$counter++] = array(
-                'name'      => $file->getRelativePath() . $file->getFileName(),
-                'namespace' => $file->getRelativePath() . '\\' . $file->getFileName(),
-                'dir'       => $file->getPathname()
+                'name'      => str_replace(DIRECTORY_SEPARATOR, '', $file->getRelativePath()),
+                'namespace' => $file->getRelativePath(),
+                'dir'       => $file->getPath()
             );
         }
 


### PR DESCRIPTION
When working with Bundles with a namespace depth greater than 1, the kuma:generate:page command will fail with: (in this example, the root namespace is "Ten24\SaskTheatre\WebsiteBundle")

```php

  [InvalidArgumentException]
  Bundle "Ten24SaskTheatre" does not exist or it is not enabled. Maybe you forgot to add it in the registerBundles() metho
  d of your AppKernel.php file?

Exception trace:
 () at F:\Users\blair\workspace\sasktheatre\app\bootstrap.php.cache:2386
 Symfony\Component\HttpKernel\Kernel->getBundle() at F:\Users\blair\workspace\sasktheatre\vendor\kunstmaan\bundles-cms\src\Ku
nstmaan\GeneratorBundle\Command\KunstmaanGenerateCommand.php:253
 Kunstmaan\GeneratorBundle\Command\KunstmaanGenerateCommand->askForBundleName() at F:\Users\blair\workspace\sasktheatre\vendo
r\kunstmaan\bundles-cms\src\Kunstmaan\GeneratorBundle\Command\GeneratePageCommand.php:119
 Kunstmaan\GeneratorBundle\Command\GeneratePageCommand->doInteract() at F:\Users\blair\workspace\sasktheatre\vendor\kunstmaan
\bundles-cms\src\Kunstmaan\GeneratorBundle\Command\KunstmaanGenerateCommand.php:38
 Kunstmaan\GeneratorBundle\Command\KunstmaanGenerateCommand->interact() at F:\Users\blair\workspace\sasktheatre\vendor\symfon
y\symfony\src\Symfony\Component\Console\Command\Command.php:244
 Symfony\Component\Console\Command\Command->run() at F:\Users\blair\workspace\sasktheatre\vendor\symfony\symfony\src\Symfony\
Component\Console\Application.php:882
 Symfony\Component\Console\Application->doRunCommand() at F:\Users\blair\workspace\sasktheatre\vendor\symfony\symfony\src\Sym
fony\Component\Console\Application.php:195
 Symfony\Component\Console\Application->doRun() at F:\Users\blair\workspace\sasktheatre\vendor\symfony\symfony\src\Symfony\Bu
ndle\FrameworkBundle\Console\Application.php:96
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at F:\Users\blair\workspace\sasktheatre\vendor\symfony\symfony\s
rc\Symfony\Component\Console\Application.php:126
 Symfony\Component\Console\Application->run() at F:\Users\blair\workspace\sasktheatre\app\console:27
```

The current code in KunstmaanGenerateCommand::getOwnBundles() limits the depth == 1. This fix simply looks for the wildcard "*Bundle.php" within the /src directory, and builds the bundles list from those found files.

Tested with the sample directory structure(s):

src/Crazy/Long/Namespaced/FunBundle
src/Stuff/SampleBundle
src/Ten24/SaskTheatre/WebsiteBundle

And $bundles is then:

```php
Array
(
    [1] => Array
        (
            [name] => CrazyLongNamespacedFunBundle
            [namespace] => Crazy\Long\Namespaced\FunBundle
            [dir] => F:/Users/blair/workspace/sasktheatre/src\Crazy\Long\Namespaced\FunBundle
        )

    [2] => Array
        (
            [name] => StuffSampleBundle
            [namespace] => Stuff\SampleBundle
            [dir] => F:/Users/blair/workspace/sasktheatre/src\Stuff\SampleBundle
        )

    [3] => Array
        (
            [name] => Ten24SaskTheatreWebsiteBundle
            [namespace] => Ten24\SaskTheatre\WebsiteBundle
            [dir] => F:/Users/blair/workspace/sasktheatre/src\Ten24\SaskTheatre\WebsiteBundle
        )

)
```
