### PR TITLE
Update NodeAdminController.php

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -558,7 +558,7 @@ class NodeAdminController extends Controller
 
         $menubuilder = $this->get('kunstmaan_node.actions_menu_builder');
         $menubuilder->setActiveNodeVersion($nodeVersion);
-        $menubuilder->setIsEditableNode(!$isStructureNode);
+        $menubuilder->setEditableNode(!$isStructureNode);
 
         // Building the form
         $propertiesWidget = new FormWidget();


### PR DESCRIPTION
Bugfix for undefined method ActionsMenuBuilder::setIsEditableNode in NodeAdminController

Looks like the method was renamed in dc7f701596d18a6a468ed8ff310b82d10eb1159c, but this call was missed in the refactoring...?

