### PR TITLE
Use relative asset paths in stylesheets and asset() twig function

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/public/scss/_vars.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/public/scss/_vars.scss
@@ -9,10 +9,10 @@ $custom-font: 'Open Sans', sans-serif;
 
 
 // Folders
-$btns: "/bundles/kunstmaanadmin/img/btns/";
-$css-bg: "/bundles/kunstmaanadmin/img/css-bg/";
-$dummy: "/bundles/kunstmaanadmin/img/dummy/";
-$general: "/bundles/kunstmaanadmin/img/general/";
-$icons: "/bundles/kunstmaanadmin/img/icons/";
+$btns: "../bundles/kunstmaanadmin/img/btns/";
+$css-bg: "../bundles/kunstmaanadmin/img/css-bg/";
+$dummy: "../bundles/kunstmaanadmin/img/dummy/";
+$general: "../bundles/kunstmaanadmin/img/general/";
+$icons: "../bundles/kunstmaanadmin/img/icons/";
 
-$fontAwesomePath:   "/bundles/kunstmaanadmin/font" !default;
+$fontAwesomePath:   "../bundles/kunstmaanadmin/font" !default;

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -16,10 +16,10 @@
 
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
-    <link rel="shortcut icon" href="/favicon.ico">
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+    <link rel="shortcut icon" href="{{ asset('favicon.ico') }}">
+    <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon.png') }}">
+    <link rel="apple-touch-icon" sizes="72x72" href="{{ asset('apple-touch-icon-72x72.png') }}">
+    <link rel="apple-touch-icon" sizes="114x114" href="{{ asset('apple-touch-icon-114x114.png') }}">
 
     <!--=========== CSS ===========-->
     <!--Combine-->

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/public/scss/config/_paths.scss
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/public/scss/config/_paths.scss
@@ -8,7 +8,7 @@
 
 /* General
    ========================================================================== */
-$root:                  "/bundles/{{ bundle.name|lower|replace({"bundle": ""}) }}";
+$root:                  "../bundles/{{ bundle.name|lower|replace({"bundle": ""}) }}";
 $vendor:                "../../vendor";
 
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_css.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_css.html.twig
@@ -1,11 +1,11 @@
 {% block css %}
     <!--[if IE 7]>
-        <link rel='stylesheet' href='/frontend/css/ie7.min.css?{{ assets_version() }}' type='text/css' />
+        <link rel="stylesheet" href="{{ asset('frontend/css/ie7.min.css') }}" type="text/css" />
     <![endif]-->
     <!--[if IE 8]>
-        <link rel='stylesheet' href='/frontend/css/ie8.min.css?{{ assets_version() }}' type='text/css' />
+        <link rel="stylesheet" href="{{ asset('frontend/css/ie8.min.css') }}" type="text/css" />
     <![endif]-->
     <!--[if gt IE 8]><!-->
-        <link rel='stylesheet' href='/frontend/css/style.min.css?{{ assets_version() }}' type='text/css' />
+        <link rel="stylesheet" href="{{ asset('frontend/css/style.min.css') }}" type="text/css" />
    <!--<![endif]-->
 {% endblock %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_js_footer.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_js_footer.html.twig
@@ -1,4 +1,4 @@
-<script src='/frontend/js/footer.min.js?{{ assets_version() }}'></script>
+<script src="{{ asset('frontend/js/footer.min.js') }}"></script>
 
 <script>
     Modernizr.load([
@@ -46,6 +46,6 @@
 </script>
 
 {% if ga_code is defined %}
-    <script src='/frontend/js/analytics.min.js?{{ assets_version() }}'></script>
+    <script src="{{ asset('frontend/js/analytics.min.js') }}"></script>
     {{ google_analytics_initialize({'account_id': ga_code}) }}
 {% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_js_header.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_js_header.html.twig
@@ -1,3 +1,3 @@
 <!--[if lt IE 9]>
-    <script src='/vendor/html5shiv/dist/html5shiv.js?{{ assets_version() }}'></script>
+    <script src="{{ asset('vendor/html5shiv/dist/html5shiv.js') }}"></script>
 <![endif]-->


### PR DESCRIPTION
This allows a Kunstmaan protect to be run (tested out) from a non-root web path e.g. `http://hostname/projects/kunstmaan-project/web/`

There are still some issues with the views in the `MediaBundle` and `MediaPagePartBundle`, these use different ways to render the (image) urls in multiple places:
* [`KunstmaanMediaBundle:Media:Image/show`](https://github.com/kunstmaan/KunstmaanBundlesCMS/blob/bc779e3471541195373e5df89905a591e3a6a991/src/Kunstmaan/MediaBundle/Resources/views/Media/Image/show.html.twig#L39)
* [`KunstmaanMediaPagePartBundle:ImagePagePart:view`](https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/bc779e3471541195373e5df89905a591e3a6a991/src/Kunstmaan/MediaPagePartBundle/Resources/views/ImagePagePart/view.html.twig#L5)
* [`KunstmaanGeneratorBundle` demosite skeleton `SlidePagePart:view`](https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/bc779e3471541195373e5df89905a591e3a6a991/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/views/PageParts/SlidePagePart/view.html.twig#L3)

The simplest way of `src="{{ image.url }}"` will also fail, as `kuma_media.url` contains a leading slash (e.g. `/uploads/media/abcde.png`)

Any ideas what would be the best way to tackle this?


Anyway, I still think these changes will allow people to easier start out developing a project with the KunstmaanBundleCMS without setting up vhosts.