### PR TITLE
Fix redirect add admin action and possible others.

### DIFF
--- a/src/Kunstmaan/ArticleBundle/Controller/AbstractArticleAuthorAdminListController.php
+++ b/src/Kunstmaan/ArticleBundle/Controller/AbstractArticleAuthorAdminListController.php
@@ -85,7 +85,7 @@ abstract class AbstractArticleAuthorAdminListController extends AdminListControl
      */
     public function addAction(Request $request)
     {
-        return parent::doAddAction($this->getAdminListConfigurator(), $request);
+        return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
     /**

--- a/src/Kunstmaan/ArticleBundle/Controller/AbstractArticlePageAdminListController.php
+++ b/src/Kunstmaan/ArticleBundle/Controller/AbstractArticlePageAdminListController.php
@@ -86,7 +86,7 @@ abstract class AbstractArticlePageAdminListController extends AdminListControlle
      */
     public function addAction(Request $request)
     {
-        return parent::doAddAction($this->getAdminListConfigurator(), $request);
+        return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/SatelliteAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/SatelliteAdminListController.php
@@ -51,7 +51,7 @@ class SatelliteAdminListController extends AdminListController
      */
     public function addAction(Request $request)
     {
-        return parent::doAddAction($this->getAdminListConfigurator(), $request);
+        return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
     /**

--- a/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
+++ b/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
@@ -50,7 +50,7 @@ class RedirectAdminListController extends AdminListController
      */
     public function addAction(Request $request)
     {
-        return parent::doAddAction($this->getAdminListConfigurator(), $request);
+        return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
     /**


### PR DESCRIPTION
I noticed the 'Add Redirect' action was broken in the admin interface (_illegal offset error_), and it turns out the `RedirectAdminListController` makes a wrong call to `AdminListController::doAddAction` [[1]].

This was also the case in some other controllers, which I also fixed.

```php
// RedirectAdminListController.php
public function addAction(Request $request)
{
	return parent::doAddAction($this->getAdminListConfigurator(), $request);
}
```

But the method signature has `$type` as the second parameter:
```php
/**
 * Creates and processes the form to add a new Entity
 *
 * @param AbstractAdminListConfigurator $configurator The adminlist configurator
 * @param string                        $type         The type to add
 *
 * @return array
 */
protected function doAddAction(AbstractAdminListConfigurator $configurator, $type = null, Request $request = null)
{
    // ...
}
```
_the third `@param` is missing btw_

We could also add a check in the `doAddAction` method, but that seems very ugly and a bit unnecessary.
```php
if ($request === null && $type instanceof Request) {
    $request = $type;
    $type = null;
}
```

[1]: https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/bc779e3471541195373e5df89905a591e3a6a991/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php#L53