### PR TITLE
make Imagick dependency optional (only when pdf previews are enabled) - fixes issue #24

### DIFF
--- a/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
@@ -30,6 +30,19 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
         $output->writeln('<info>PDF preview images have been created.</info>');
     }
 
+    /**
+     * Checks whether the command is enabled or not in the current environment.
+     *
+     * Override this to check for x or y and return false if the command can not
+     * run properly under the current conditions.
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->getContainer()->getParameter('kunstmaan_media.enable_pdf_preview');
+    }
+
     protected function configure()
     {
         parent::configure();

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
@@ -33,8 +33,8 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('dailymotion')->defaultTrue()->end()
                     ->end()
                 ->end()
+                ->booleanNode('enable_pdf_preview')->defaultFalse()->end()
             ->end();
-
 
         return $treeBuilder;
     }

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -38,9 +38,14 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         );
         $container->setParameter('kunstmaan_media.soundcloud_api_key', $config['soundcloud_api_key']);
         $container->setParameter('kunstmaan_media.remote_video', $config['remote_video']);
+        $container->setParameter('kunstmaan_media.enable_pdf_preview', $config['enable_pdf_preview']);
 
         $loader->load('services.yml');
         $loader->load('handlers.yml');
+
+        if ($config['enable_pdf_preview'] === true) {
+            $loader->load('pdf_preview.yml');
+        }
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Kunstmaan/MediaBundle/README.md
+++ b/src/Kunstmaan/MediaBundle/README.md
@@ -20,7 +20,7 @@ If you want to use this bundle for a Symfony 2.2 release, use the 2.2 branch.
 
 ## Audio
 
-If you want to use your own api key for SoundCloud, you can define this in the config.yml of your application but it works fine without it aswell.
+If you want to use your own api key for SoundCloud, you can define this in the config.yml of your application but it works fine without it as well.
 
 ```yml
 kunstmaan_media:
@@ -44,7 +44,7 @@ $builder
     );
 ```
 
-## Generating PDF thumbnails
+## Generating PDF preview thumbnails
 
 For this functionality to work, you need to install the ImageMagick extension with PDF support (using
 Ghostscript). You will also have to make sure that the Ghostscript executable (gs) can be found
@@ -65,3 +65,10 @@ On OS X with apache you will probably have to add that path to the apache enviro
 ```
 
 Where ```/path/to/gs``` is just the actual path where the gs binary is stored.
+
+*NOTE:* This functionality has to be enabled by setting the ```enable_pdf_preview``` configuration option to true, ie. :
+
+```yml
+kunstmaan_media:
+    enable_pdf_preview: true
+```

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -4,7 +4,6 @@ parameters:
     kunstmaan_media.media_handler.remote_audio.class: 'Kunstmaan\MediaBundle\Helper\RemoteAudio\RemoteAudioHandler'
     kunstmaan_media.media_handler.image.class: 'Kunstmaan\MediaBundle\Helper\Image\ImageHandler'
     kunstmaan_media.media_handler.file.class: 'Kunstmaan\MediaBundle\Helper\File\FileHandler'
-    kunstmaan_media.media_handler.pdf.class: 'Kunstmaan\MediaBundle\Helper\File\PdfHandler'
     aviary_api_key: null
 
 services:
@@ -38,14 +37,5 @@ services:
         arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
-        tags:
-            -  { name: 'kunstmaan_media.media_handler' }
-
-    kunstmaan_media.media_handlers.pdf:
-        class: "%kunstmaan_media.media_handler.pdf.class%"
-        arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
-        calls:
-            - [ setMediaPath, [ "%kernel.root_dir%" ] ]
-            - [ setPdfTransformer, [ "@kunstmaan_media.pdf_transformer" ]]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }

--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -1,0 +1,25 @@
+parameters:
+    kunstmaan_media.pdf_transformer.class: 'Kunstmaan\MediaBundle\Helper\Transformer\PdfTransformer'
+    kunstmaan_media.media_handler.pdf.class: 'Kunstmaan\MediaBundle\Helper\File\PdfHandler'
+
+services:
+    kunstmaan_media.imagick:
+        class: "Imagick"
+
+    kunstmaan_media.pdf_transformer:
+        class: "%kunstmaan_media.pdf_transformer.class%"
+        arguments: ["@kunstmaan_media.imagick"]
+
+    kunstmaan_media.command.createpdfpreview:
+        class: Kunstmaan\MediaBundle\Command\CreatePdfPreviewCommand
+        calls:
+            - [setContainer, ["@service_container"] ]
+
+    kunstmaan_media.media_handlers.pdf:
+        class: "%kunstmaan_media.media_handler.pdf.class%"
+        arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
+        calls:
+            - [ setMediaPath, [ "%kernel.root_dir%" ] ]
+            - [ setPdfTransformer, [ "@kunstmaan_media.pdf_transformer" ]]
+        tags:
+            -  { name: 'kunstmaan_media.media_handler' }

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -8,7 +8,6 @@ parameters:
     kunstmaan_media.icon_font_manager.class: 'Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager'
     kunstmaan_media.icon_font.default_loader.class: 'Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader'
     kunstmaan_media.media_creator_service.class: 'Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService'
-    kunstmaan_media.pdf_transformer.class: 'Kunstmaan\MediaBundle\Helper\Transformer\PdfTransformer'
     kunstmaan_media.mimetype_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory'
 
 services:
@@ -80,13 +79,6 @@ services:
         class: "%kunstmaan_media.folder_manager.class%"
         arguments: ["@kunstmaan_media.repository.folder"]
 
-    kunstmaan_media.imagick:
-        class: "Imagick"
-
-    kunstmaan_media.pdf_transformer:
-        class: "%kunstmaan_media.pdf_transformer.class%"
-        arguments: ["@kunstmaan_media.imagick"]
-
     kunstmaan_media.mimetype_guesser.factory:
         class: "%kunstmaan_media.mimetype_guesser.factory.class%"
 
@@ -97,10 +89,5 @@ services:
 
     kunstmaan_media.command.rebuildfoldertree:
         class: Kunstmaan\MediaBundle\Command\RebuildFolderTreeCommand
-        calls:
-            - [setContainer, ["@service_container"] ]
-
-    kunstmaan_media.command.createpdfpreview:
-        class: Kunstmaan\MediaBundle\Command\CreatePdfPreviewCommand
         calls:
             - [setContainer, ["@service_container"] ]


### PR DESCRIPTION
Imagick is now no longer required to use the media bundle, you have to enable it (if you want the auto generation of PDF preview thumbnails) by adding the following to your configuration :

```yml
kunstmaan_media:
    enable_pdf_preview: true
```
