### PR TITLE
Can't add new user group from the admin interface

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/Group.php
+++ b/src/Kunstmaan/AdminBundle/Entity/Group.php
@@ -5,8 +5,7 @@ namespace Kunstmaan\AdminBundle\Entity;
 use InvalidArgumentException;
 
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContext;
-use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use FOS\UserBundle\Model\GroupInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -230,12 +229,15 @@ class Group implements RoleInterface, GroupInterface
     }
 
     /**
-     * @param ExecutionContext $context
+     * @param ExecutionContextInterface $context
      */
-    public function isGroupValid(ExecutionContext $context)
+    public function isGroupValid(ExecutionContextInterface $context)
     {
         if (!(count($this->getRoles()) > 0)) {
-            $context->addViolationAt('rolesCollection', 'errors.group.selectone', array(), null);
+            $context
+                ->buildViolation('errors.group.selectone', array())
+                ->atPath('rolesCollection')
+                ->addViolation();
         }
     }
 }

--- a/src/Kunstmaan/AdminBundle/Form/GroupType.php
+++ b/src/Kunstmaan/AdminBundle/Form/GroupType.php
@@ -12,29 +12,39 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class GroupType extends AbstractType
 {
-
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', array('required' => true, 'label' => 'settings.group.name'))
-                ->add('rolesCollection', 'entity', array(
-                        'label' => 'settings.group.roles',
-                        'class' => 'KunstmaanAdminBundle:Role',
-                        'query_builder' => function(EntityRepository $er) {
-                            return $er->createQueryBuilder('r')
-                                ->orderBy('r.role', 'ASC');
-                        },
-                        'multiple' => true,
-                        'expanded' => false,
-                        'required' => true,
-                        'attr' => array(
-                            'class' => 'chzn-select',
-                            'data-placeholder' => 'Choose the roles...'
-                        )
-                    )
-                );
+        $builder
+            ->add(
+                'name',
+                'text',
+                array(
+                    'required' => true,
+                    'label'    => 'settings.group.name'
+                )
+            )
+            ->add(
+                'rolesCollection',
+                'entity',
+                array(
+                    'label'         => 'settings.group.roles',
+                    'class'         => 'KunstmaanAdminBundle:Role',
+                    'query_builder' => function (EntityRepository $er) {
+                        return $er->createQueryBuilder('r')
+                            ->orderBy('r.role', 'ASC');
+                    },
+                    'multiple'      => true,
+                    'expanded'      => false,
+                    'required'      => true,
+                    'attr'          => array(
+                        'class'            => 'chzn-select',
+                        'data-placeholder' => 'Choose the roles...'
+                    ),
+                )
+            );
     }
 
     /**


### PR DESCRIPTION
Hello,

I have to add a new user group from admin and upon the save I get the following error

Catchable Fatal Error: Argument 1 passed to Kunstmaan\AdminBundle\Entity\Group::isGroupValid() must be an instance of Symfony\Component\Validator\ExecutionContext, instance of Symfony\Component\Validator\Context\LegacyExecutionContext given in .../vendor/kunstmaan/admin-bundle/Kunstmaan/AdminBundle/Entity/Group.php line 236

I tracked down the problem and I replaced the line 8

`use Symfony\Component\Validator\ExecutionContext;`

with

`use Symfony\Component\Validator\Context\LegacyExecutionContext as ExecutionContext;`

and the group was saved. 
By the way, both ExecutionContext and LegacyExecutionConext are deprecated in symfony 2.4.

Keep up the good work!
Iulian