### PR TITLE
Bugfix for render_pagetemplate()

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
@@ -72,7 +72,7 @@ class PageTemplateTwigExtension extends \Twig_Extension
 
         $template = $this->environment->loadTemplate($pageTemplate->getTemplate());
 
-        return $template->render($twigContext);
+        return $template->render(array_merge($twigContext, $parameters));
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
@@ -72,7 +72,7 @@ class PageTemplateTwigExtension extends \Twig_Extension
 
         $template = $this->environment->loadTemplate($pageTemplate->getTemplate());
 
-        return $template->render(array_merge($twigContext, $parameters));
+        return $template->render(array_merge($parameters, $twigContext));
     }
 
     /**


### PR DESCRIPTION
 - Merge passed parameters with the current twig context - allows passing of view variables when calling render_pagetemplate()
 - Argument was previously unused