### PR TITLE
Fix layout of labels in form by adding default classes

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
@@ -50,9 +50,11 @@
         {% if not compound %}
             {% set label_attr = label_attr|merge({'for': id}) %}
         {% endif %}
+        {% set class = 'col-md-2 control-label' %}
         {% if required %}
-            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' col-md-2 control-label required')|trim}) %}
-        {% endif %}
+            {%  set class = class ~ ' required' %}
+        {%  endif %}
+        {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' ' ~ class)|trim}) %}
         {% if label is empty %}
             {% set label = name|humanize %}
         {% endif %}


### PR DESCRIPTION
Currently labels of required fields get the col-md-2 and control-label classes, and other field don't get these classes. As a result, the labels of required fields are on the left side of a field, and other labels appear on the right side of fields. 
This fix gives all labels the col-md-2 and control-label class.