### PR TITLE
[LiveReloadBundle] require framework-bundle only, not symfony/symfony

### DIFF
--- a/src/Kunstmaan/LiveReloadBundle/composer.json
+++ b/src/Kunstmaan/LiveReloadBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "~2.3",
+        "symfony/framework-bundle": "~2.3",
         "guzzle/guzzle": "3.8.*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This makes it easier to use in other projects that use symfony parts