### PR TITLE
Fixed generated datafixtures to use correct textcase

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
@@ -34,7 +34,7 @@ class DefaultSiteFixtures extends AbstractFixture implements OrderedFixtureInter
     /**
      * Username that is used for creating pages
      */
-    const ADMIN_USERNAME = 'Admin';
+    const ADMIN_USERNAME = 'admin';
 
     /**
      * @var ContainerInterface

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/SitemapFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/SitemapFixtures.php
@@ -56,7 +56,7 @@ class SitemapFixtures extends AbstractFixture implements OrderedFixtureInterface
             'page_internal_name' => 'sitemap',
             'set_online' => true,
             'hidden_from_nav' => true,
-            'creator' => 'Admin'
+            'creator' => 'admin'
         );
 
         $pageCreator->createPage($sitemapPage, $translations, $options);


### PR DESCRIPTION
The username of the admin is not capitialized, but just lowercase (as you can see in the user datafixture: https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/master/src/Kunstmaan/AdminBundle/DataFixtures/ORM/UserFixtures.php#L41 ).