### PR TITLE
make it possible to have no item actions for some records

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
@@ -72,9 +72,12 @@
                         {% if itemAction.template is not null %}
                             {% include itemAction.template with {'row': item, 'item': item, 'action': itemAction} %}
                         {% else %}
-                            <a href="{{ path(itemAction.getUrlFor(item)["path"], itemAction.getUrlFor(item)[("params")] ) }}">
-                                {% if itemAction.getIconFor(item) is not null %}<i class="icon-{{ itemAction.getIconFor(item) }}"></i>{% endif %}{{ itemAction.getLabelFor(item) }}
-                            </a>
+                            {% set url = itemAction.getUrlFor(item) %}
+                            {% if url %}
+                                <a href="{{ path(url["path"], url[("params")]) }}">
+                                    {% if itemAction.getIconFor(item) is not null %}<i class="icon-{{ itemAction.getIconFor(item) }}"></i>{% endif %}{{ itemAction.getLabelFor(item) }}
+                                </a>
+                            {% endif %}
                         {% endif %}
                         {% endfor %}
                     {% endif %}
@@ -149,7 +152,7 @@
                     $('.js-bulk-button').addClass('disabled');
                 }
             };
-            
+
             var checkboxes = document.querySelectorAll('.js-bulk-checkbox');
             for (var key in checkboxes) {
                 checkboxes[key].onchange = validateBulkCheckboxes;


### PR DESCRIPTION
When some rows in the adminlist do not need to have a certain item action, you can just do this:

```php
        $create_route = function ($item) {
            if (!$item->foo()) {
                return null;
            } else {
                return array(
                    'path'   => 'mybundle_admin_projects',
                    'params' => array('id' => $item->getSlug())
                );
            }
        };
        $ia = new \Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction($create_route, "eye-open", "Preview");
        $this->addItemAction($ia);
```