### PR TITLE
changed iconv transliteration setting

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -71,7 +71,7 @@ class Slugifier
 			$slugifier = new Slugifier();
 			$text = $slugifier->rus2translit($text);
 			
-            $text = iconv('utf-8', 'us-ascii//IGNORE//TRANSLIT', $text);
+            $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
             setlocale(LC_CTYPE, $previouslocale);
         }
 


### PR DESCRIPTION
Aren't //IGNORE and //TRANSLIT mutually exclusive?

I was getting a `iconv(): Detected an illegal character in input string` notice with some accented letters.