### PR TITLE
fixes infinite recursion problem in NodeTranslationListener

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
@@ -10,7 +10,7 @@ use Kunstmaan\NodeBundle\Entity\Node,
     Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
-use Kunstmaan\NodeBundle\Entity\StructureNode;
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -73,7 +73,7 @@ class NodeTranslationListener
                 $publicNode = $publicNodeVersion->getRef($em);
 
                 /** Do nothing for StructureNode objects, skip */
-                if ($publicNode instanceof StructureNode) {
+                if ($publicNode instanceof HasNodeInterface && $publicNode->isStructureNode()) {
                     continue;
                 }
 


### PR DESCRIPTION
This listener goes into infinite recursion when saving a Page, if that Page is a structure node, but does not extend `StructureNode` class for whatever reason.

I think it's better to check if it's a structure node by using `isStructureNode()` of `HasNodeInterface`, because one might not want to extend `StructureNode` and `AbstractPage` (which StructureNode extends from) just because of this listener. 