### PR TITLE
Fix actions menu

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/public/js/script.js
+++ b/src/Kunstmaan/AdminBundle/Resources/public/js/script.js
@@ -440,8 +440,14 @@ function initCustomSelect() {
 
 //Custom Select
 function initDisableButtonsOnSubmit() {
+    var formSubmitting = false;
     $("#pageadminform").submit(function(){
-        $(".main_actions").find("button, a").attr('disabled','disabled').addClass("disabled");
+        if (formSubmitting) {
+            return false;
+        }
+
+        formSubmitting = true;
+        $(".main_actions").find("button, a").attr('data-toggle', null).addClass("disabled");
     });
 }
 

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -133,7 +133,7 @@ class ActionsMenuBuilder
                         $menu->addChild('action.publish', array('linkAttributes' => array('class' => 'btn', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#pub')));
                     }
                     if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node)) {
-                        $menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'btn' . ($isFirst ? ' btn-primary btn-save' : ''), 'value' => 'saveasdraft', 'name' => 'saveasdraft'), 'extras' => array('renderType' => 'button')));
+                        $menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'onClick' => 'isEdited=false', 'class' => 'btn' . ($isFirst ? ' btn-primary btn-save' : ''), 'value' => 'saveasdraft', 'name' => 'saveasdraft'), 'extras' => array('renderType' => 'button')));
                     }
                     $menu->addChild('action.preview', array('uri' => $this->router->generate('_slug_preview', array('url' => $activeNodeTranslation->getUrl())), 'linkAttributes' => array('target' => '_blank', 'class' => 'btn')));
                 }


### PR DESCRIPTION
Setting `disabled=disabled` on the "Save as draft" button prevents submitting the "saveasdraft" parameter.

This also unsets `data-toggle=modal` on "Publish/Unpublish" and "Add subpage" links, just in case.