### PR TITLE
Speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ php:
   - 5.6
 
 env:
-  - SYMFONY_VERSION="2.3.*"
-  - SYMFONY_VERSION="2.5.*"
   - SYMFONY_VERSION="2.6.*"
+
+matrix:
+  include:
+    - php: 5.6
+      SYMFONY_VERSION="2.5.*"
+    - php: 5.6
+      SYMFONY_VERSION="2.3.*"
 
 before_script:
     - composer selfupdate
@@ -19,7 +24,6 @@ before_script:
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
     - sudo locale-gen nl_BE.UTF-8 && sudo update-locale
-    - composer --prefer-source --dev install
     - composer require symfony/symfony:${SYMFONY_VERSION}
     - wget https://phar.phpunit.de/phpunit.phar
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
 matrix:
   include:
     - php: 5.6
-      SYMFONY_VERSION="2.5.*"
+      env: SYMFONY_VERSION="2.5.*"
     - php: 5.6
-      SYMFONY_VERSION="2.3.*"
+      env: SYMFONY_VERSION="2.3.*"
 
 before_script:
     - composer selfupdate


### PR DESCRIPTION
Previously, you had `count(php_versions) * count(symfony_versions)`. This PR does `count(php_versions) + count(symfony_versions) - 1`, which will reduce quite a lot of jobs. This means that the build is quicker and more builds can be run at the same time (Travis support up to 6 parallel jobs per organization).

Besides that, you ran require 2 times, which doesn't really speed up the job.

As soon as issue https://github.com/travis-ci/travis-ci/issues/3195 is fixed on Travis, the sudo call can be removed and the quicker docker env (including caching features) can be used.