### PR TITLE
SQL syntax error in admin pages

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
@@ -107,13 +107,13 @@ class AclNativeHelper
         }
 
         $joinTableQuery = <<<SELECTQUERY
-SELECT DISTINCT o.object_identifier as id FROM {$databasePrefix}.acl_object_identities as o
-INNER JOIN {$databasePrefix}.acl_classes c ON c.id = o.class_id
-LEFT JOIN {$databasePrefix}.acl_entries e ON (
+SELECT DISTINCT o.object_identifier as id FROM {$databasePrefix}acl_object_identities as o
+INNER JOIN {$databasePrefix}acl_classes c ON c.id = o.class_id
+LEFT JOIN {$databasePrefix}acl_entries e ON (
     e.class_id = o.class_id AND (e.object_identity_id = o.id
     OR {$aclConnection->getDatabasePlatform()->getIsNullExpression('e.object_identity_id')})
 )
-LEFT JOIN {$databasePrefix}.acl_security_identities s ON (
+LEFT JOIN {$databasePrefix}acl_security_identities s ON (
 s.id = e.security_identity_id
 )
 WHERE c.class_type = {$rootEntity}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace {{ namespace }}\Features\Context;
+namespace Sandbox\WebBundle\Features\Context;
 
 use Kunstmaan\BehatBundle\Features\Context\FeatureContext as AbstractContext;
 use Behat\Behat\Context\Step;
@@ -105,7 +105,7 @@ class FeatureContext extends AbstractContext
     public function iTryToLogInWith($username, $password)
     {
         return array(
-            new Step\Given("I am on \"".$this->lang."/login\""),
+            new Step\Given("I am on \"".$this->lang."/admin/login\""),
             new Step\Given("I wait 1 seconds"),
             new Step\Given("I press \"×\" if present"),
             new Step\Given("I fill in \"username\" with \"". $username . "\""),
@@ -198,7 +198,7 @@ class FeatureContext extends AbstractContext
     public function getPageUrlForPageName($pageName)
     {
         $pages = array(
-            "forgot password" => $this->lang."/resetting/request",
+            "forgot password" => $this->lang."/admin/resetting/request",
             "users" => $this->lang."/admin/settings/users",
             "create new user" => $this->lang."/admin/settings/users/add",
             "groups" => $this->lang."/admin/settings/groups",
@@ -206,7 +206,7 @@ class FeatureContext extends AbstractContext
             "roles" => $this->lang."/admin/settings/roles",
             "create new role" => $this->lang."/admin/settings/roles/add",
             "dashboard" => $this->lang."/admin",
-            "login" => $this->lang."/login",
+            "login" => $this->lang."/admin/login",
             "media" => $this->lang."/admin/media/folder/1",
             "add new image" => $this->lang."/admin/media/create/2/file",
             "image" => $this->lang."/admin/media/folder/2",

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sandbox\WebBundle\Features\Context;
+namespace {{ namespace }}\Features\Context;
 
 use Kunstmaan\BehatBundle\Features\Context\FeatureContext as AbstractContext;
 use Behat\Behat\Context\Step;


### PR DESCRIPTION
Fixes syntax error created by commit: https://github.com/Kunstmaan/KunstmaanBundlesCMS/commit/b72a8f982605ccd068b8957831693bc8eaf6675d (Do not prefix database when using SQLite).