### PR TITLE
fix issue slugify method

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -71,7 +71,7 @@ class Slugifier
 			$slugifier = new Slugifier();
 			$text = $slugifier->rus2translit($text);
 			
-            $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+            $text = @iconv('utf-8', 'us-ascii//TRANSLIT', $text);
             setlocale(LC_CTYPE, $previouslocale);
         }
 


### PR DESCRIPTION
In case a user insert a text with special characters in a page the method slugify would break without this change.
Specifically I get the error " iconv: Detected an illegal character in input string ".
Adding the @ silent this notice and all works fine.