### PR TITLE
Only export formsubmissions of the same language (aka NodeTranslation)

### DIFF
--- a/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
@@ -66,7 +66,10 @@ class FormSubmissionExportListConfigurator implements ExportListConfiguratorInte
             ->from('KunstmaanFormBundle:FormSubmission', 'fs')
             ->innerJoin('fs.node', 'n', 'WITH', 'fs.node = n.id')
             ->andWhere('n.id = :node')
+            // only export the requested language, bc headers aren't translated correctly
+            ->andWhere('fs.lang = :lang')
             ->setParameter('node', $this->nodeTranslation->getNode()->getId())
+            ->setParameter('lang', $this->nodeTranslation->getLang())
             ->addOrderBy('fs.created', 'DESC');
         $iterableResult = $qb->getQuery()->iterate();
         $isHeaderWritten = false;


### PR DESCRIPTION
When exporting all FormSubmissions of a certain NodeTransation, the csv or excel file contains all submissions for all translations of the Node. This results in a file exported with only certain fields filled in (depending on the first language):

![image](https://cloud.githubusercontent.com/assets/693017/6687233/2923ec1a-cca9-11e4-86a7-20b3559dde4a.png)

This was an export on the Dutch NodeTranslation.

As the method states it should only export all the entries of the NodeTranslation and not the Node. I propose to filter on the NodeTranslation language as well.