### PR TITLE
ConsoleExceptionListener

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('default_admin_locale')->cannotBeEmpty()->defaultValue('en')->end()
-                ->booleanNode('enable_console_listener')->defaultTrue()->end()
+                ->booleanNode('enable_console_exception_listener')->defaultTrue()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -38,6 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('default_admin_locale')->cannotBeEmpty()->defaultValue('en')->end()
+                ->booleanNode('enable_console_listener')->defaultFalse()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('default_admin_locale')->cannotBeEmpty()->defaultValue('en')->end()
-                ->booleanNode('enable_console_listener')->defaultFalse()->end()
+                ->booleanNode('enable_console_listener')->defaultTrue()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -48,7 +48,7 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        if (!empty($config['enable_console_listener']) && $config['enable_console_listener']) {
+        if (!empty($config['enable_console_exception_listener']) && $config['enable_console_exception_listener']) {
             $loader->load('console_listener.yml');
         }
     }

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -47,6 +47,10 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        if (!empty($config['enable_console_listener']) && $config['enable_console_listener']) {
+            $loader->load('console_listener.yml');
+        }
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionListener.php
@@ -1,0 +1,27 @@
+<?php
+namespace Kunstmaan\AdminBundle\EventListener;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Psr\Log\LoggerInterface;
+
+class ConsoleExceptionListener
+{
+    private $logger;
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+    public function onConsoleException(ConsoleExceptionEvent $event)
+    {
+        $command = $event->getCommand();
+        $exception = $event->getException();
+        $message = sprintf(
+            '%s: %s (uncaught exception) at %s line %s while running console command `%s`',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine(),
+            $command->getName()
+        );
+        $this->logger->error($message, array('exception' => $exception));
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -1,0 +1,7 @@
+services:
+    kernel.listener.command_dispatch:
+        class: Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener
+        arguments:
+            logger: "@logger"
+        tags:
+            - { name: kernel.event_listener, event: console.exception }

--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -1,5 +1,5 @@
 services:
-    kernel.listener.command_dispatch:
+    kunstmaan_admin.consolelogger.listener:
         class: Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener
         arguments:
             logger: "@logger"

--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -1,6 +1,10 @@
+parameters:
+    kunstmaan_admin.consoleexception.class: "Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener"
+
+
 services:
     kunstmaan_admin.consolelogger.listener:
-        class: Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener
+        class: %kunstmaan_admin.consoleexception.class%
         arguments:
             logger: "@logger"
         tags:

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -85,13 +85,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.onDeepCloneAndSave, method: onDeepCloneAndSave }
 
-    kunstmaan_admin.command_dispatch:
-        class: Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener
-        arguments:
-            logger: "@logger"
-        tags:
-            - { name: kernel.event_listener, event: console.exception }
-
     kunstmaan_admin.logger.processor.user:
         class: Kunstmaan\AdminBundle\Helper\UserProcessor
         arguments: [ "@service_container" ]

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -85,6 +85,13 @@ services:
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.onDeepCloneAndSave, method: onDeepCloneAndSave }
 
+    kunstmaan_admin.command_dispatch:
+        class: Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener
+        arguments:
+            logger: "@logger"
+        tags:
+            - { name: kernel.event_listener, event: console.exception }
+
     kunstmaan_admin.logger.processor.user:
         class: Kunstmaan\AdminBundle\Helper\UserProcessor
         arguments: [ "@service_container" ]


### PR DESCRIPTION
added a ConsoleExcetpionListener to the adminBundle, this service can be toggled on or off in the app/config.yml file by adding the line: enable_console_exception_listener: true 
to the kunstmaan_admin section.