### PR TITLE
don't create a session (and to set-cookie) when we only want to check if...

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
@@ -80,7 +80,7 @@ class SessionSecurityListener
         }
 
         $request = $event->getRequest();
-        if ($request->hasSession()) {
+        if ($request->hasSession() && $request->getSession()->isStarted()) {
             $session = $request->getSession();
 
             // Check that the ip matches


### PR DESCRIPTION
... there is something in the session.

Now the $session->has() does immediately Set-Cookie, so all pages now used sessions and varnish did ignored all requests.