### PR TITLE
[WIP] Upgrade to LiipImagineBundle ~1.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "lunetics/locale-bundle": "*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",
-        "liip/imagine-bundle": "v0.20.2",
+        "liip/imagine-bundle": "~1.2.4",
         "knplabs/knp-gaufrette-bundle": "0.1.*",
         "symfony-cmf/routing-bundle": "~1.1.1",
         "ruflin/elastica": "~1.0",

--- a/src/Kunstmaan/MediaBundle/Resources/config/liip_imagine.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/liip_imagine.yml
@@ -1,5 +1,8 @@
 liip_imagine:
-    cache_prefix: uploads/cache
+    resolvers:
+        default:
+            web_path:
+                cache_prefix: uploads/cache
     driver: imagick
     data_loader: kunstmaan_media_thumbloader
     #cache: no_cache

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -11,14 +11,6 @@ parameters:
     kunstmaan_media.mimetype_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory'
 
 services:
-    liip_imagine.data.loader.stream.profile_photos:
-        class: "%liip_imagine.data.loader.stream.class%"
-        arguments:
-            - "@liip_imagine"
-            - ''
-        tags:
-            - { name: 'liip_imagine.data.loader', loader: 'kunstmaan_media_thumbloader' }
-
     kunstmaan_media.media_manager:
         class: "%kunstmaan_media.media_manager.class%"
         calls:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #228

- [ ] Add pull request in StandardEdition
- [ ] Document the changes in the UPGRADE file
- [ ] Solve the cache extension - content issue https://github.com/liip/LiipImagineBundle/issues/584

Default config in the StandardEdition should change to:
```
liip_imagine:
    driver: imagick
    cache:                default
    data_loader:          default
    loaders:
        default:
            filesystem: ~
    resolvers:
       web_path:
           web_path: ~
    filter_sets:
        optim:
            quality: 85
            format: jpg
            filters:
                strip: ~
        optimjpg:
            quality: 85
            format: jpg
            filters:
                strip: ~
        optimpng:
            quality: 85
            format: png
            filters:
                strip: ~
```