### PR TITLE
Wysiwyg formtype added

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/WysiwygType.php
+++ b/src/Kunstmaan/AdminBundle/Form/WysiwygType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * This class represents the type for the TextFormWysiwygSubmissionField
+ */
+class WysiwygType extends AbstractType
+{
+    public function getParent()
+    {
+        return 'textarea';
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        // return 'kunstmaan_formbundle_Wysiwygformsubmissiontype';
+        return 'wysiwyg';
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -144,3 +144,8 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -1000 }
+
+    kunstmaan_form.type.wysiwyg:
+        class: Kunstmaan\AdminBundle\Form\WysiwygType
+        tags:
+            - { name: form.type, alias: wysiwyg }

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
@@ -48,7 +48,56 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
             elToolbar = [
                 {
                     name: 'basicstyles',
-                    items : ['Bold', 'Italic', 'Underline', 'RemoveFormat']
+                    items: ['Bold', 'Italic', 'Underline', 'RemoveFormat']
+                }
+            ]
+        } else if($el.data('full') === true) {
+            elToolbar = [
+                {
+                    name: 'basicstyles',
+                    items : ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'RemoveFormat']
+                },
+                {
+                    name: 'paragraph',
+                    groups: [ 'align' ],
+                    items: [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock']
+                },
+                {
+                    name: 'lists',
+                    items : ['NumberedList', 'BulletedList']
+                },
+                {
+                    name: 'dents',
+                    items : ['Outdent', 'Indent']
+                },
+                {
+                    name: 'links',
+                    items : ['Link','Unlink', 'Anchor']
+                },
+                {
+                    name: 'insert',
+                    items : ['Image', 'Table', 'SpecialChar']
+                },
+                {
+                    name: 'clipboard',
+                    items : ['SelectAll', 'Cut', 'Copy', 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo']
+                },
+                {
+                    name: 'editing',
+                    items : []
+                },
+                {
+                    name: 'styles',
+                    items: [ 'Styles', 'Format', 'Font', 'FontSize' ]
+
+                },
+                {
+                    name: 'colors',
+                    items: [ 'TextColor', 'BGColor' ]
+                },
+                {
+                    name: 'document',
+                    items : ['Source']
                 }
             ]
         } else {

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -57,6 +57,11 @@
     {% endspaceless %}
 {% endblock textarea_widget %}
 
+{% block wysiwyg_widget %}
+    {% spaceless %}
+        <textarea {{ block('widget_attributes') }} {% if attr['type'] is defined %} data-{{ attr['type'] }}=true {% endif %} class="js-rich-editor rich-editor form-control{% if attr['maxlength'] is defined %} js-max-length-input{% endif %}" rows="10" cols="600">{{ value|raw }}</textarea>
+    {% endspaceless %}
+{% endblock wysiwyg_widget %}
 
 {% block checkbox_widget %}
     {% spaceless %}

--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -500,7 +500,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
         $types             = array();
         $types[$counter++] = $niceNames ? 'Single line text' : 'single_line';
         $types[$counter++] = $niceNames ? 'Multi line text' : 'multi_line';
-        $types[$counter++] = $niceNames ? 'Rich text' : 'rich_text';
+        $types[$counter++] = $niceNames ? 'Wysiwyg' : 'wysiwyg';
         $types[$counter++] = $niceNames ? 'Link (url, text, new window)' : 'link';
         if ($this->isBundleAvailable('KunstmaanMediaPagePartBundle')) {
             $types[$counter++] = $niceNames ? 'Image (media, alt text)' : 'image';
@@ -568,11 +568,18 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                 );
                 break;
             case 'multi_line':
-            case 'rich_text':
                 $fields[$type][] = array(
                     'fieldName' => lcfirst(Container::camelize($name)),
                     'type'      => 'text',
                     'formType'  => 'textarea',
+                    'nullable'  => $allNullable
+                );
+                break;
+            case 'wysiwyg':
+                $fields[$type][] = array(
+                    'fieldName' => lcfirst(Container::camelize($name)),
+                    'type'      => 'text',
+                    'formType'  => 'wysiwyg',
                     'nullable'  => $allNullable
                 );
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #212

TODO
- [x] Submit changes to the documentation

WHAT
A new wysiwyg form type has been created in the Adminbundle. 
This makes it possible to use 'wysiwig' in the formbuilder as a type and results in a text area with a wysiwyg editor on top. There are two extra options you can pass as a data attribute:
- simple: will only render a basic wysiwyg editor
- full: will render a wysiwyg editor with extra buttons
The wysiwyg formtype also replaces the rich text type when generating a new pagepart using the kunstmaan generatorbundle.

WHY
Before this feature there was:
```php
        $builder->add('name', 'textarea',
                array(
                    'attr' => array(
                        'rows'  => 5,
                        'cols'  => 600,
                        'class' => 'js-rich-editor rich-editor'
                    )
                )
        );
```
now you just have to use:
```php
        $builder->add('name', 'wysiwyg');
```

