### PR TITLE
Fix Scrutinizer integration with Travis by disabling fast_finish on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - SYMFONY_VERSION="2.6.*"
 
 matrix:
-  fast_finish: true
+  fast_finish: false
   allow_failures:
     - php: 7.0
   include:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

- [x] Check if the scrutinizer test works now