### PR TITLE
Fix issue #173 moving pageparts gives error when saving

### DIFF
--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -191,6 +191,7 @@ class PagePartAdmin
         // Create the objects for the new pageparts
         $this->newPageParts = array();
         $newRefIds          = $request->get($this->context . '_new');
+
         if (is_array($newRefIds)) {
             foreach ($newRefIds as $newId) {
                 $type                       = $request->get($this->context . '_type_' . $newId);
@@ -200,7 +201,6 @@ class PagePartAdmin
 
         // Sort pageparts again
         $sequences = $request->get($this->context . '_sequence');
-
         if (!is_null($sequences)) {
             $tempPageparts = $this->pageParts;
             $this->pageParts = array();

--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -191,7 +191,6 @@ class PagePartAdmin
         // Create the objects for the new pageparts
         $this->newPageParts = array();
         $newRefIds          = $request->get($this->context . '_new');
-
         if (is_array($newRefIds)) {
             foreach ($newRefIds as $newId) {
                 $type                       = $request->get($this->context . '_type_' . $newId);
@@ -201,16 +200,19 @@ class PagePartAdmin
 
         // Sort pageparts again
         $sequences = $request->get($this->context . '_sequence');
+
         if (!is_null($sequences)) {
             $tempPageparts = $this->pageParts;
             $this->pageParts = array();
             foreach ($sequences as $sequence) {
                 if (array_key_exists($sequence, $this->newPageParts)) {
                     $this->pageParts[$sequence] = $this->newPageParts[$sequence];
-                } else {
+                } elseif (array_key_exists($sequence, $tempPageparts)) {
                     $this->pageParts[$sequence] = $tempPageparts[$sequence];
-                }
+                } else
+                    $this->pageParts[$sequence] = $this->getPagePart($sequence, array_search($sequence, $sequences)+1);
             }
+
             unset($tempPageparts);
         }
     }
@@ -356,6 +358,18 @@ class PagePartAdmin
         }
 
         return "no name";
+    }
+
+    /**
+     * @param bigint $id
+     * @param int    $sequenceNumber
+     *
+     * @return PagePart
+     */
+    public function getPagePart($id, $sequenceNumber)
+    {
+        $ppRefRepo = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        return $ppRefRepo->getPagePart($id, $this->context, $sequenceNumber);
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
+++ b/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php
@@ -181,4 +181,23 @@ class PagePartRefRepository extends EntityRepository
                 ->setParameter('pageId', $page->getId())
                 ->setParameter('context', $context)->getSingleScalarResult() != 0;
     }
+
+    /**
+     * @param bigint   $id             The id
+     * @param string   $context        The context
+     * @param int      $sequenceNumber The sequence number
+     *
+     * @return PagePart
+     */
+    public function getPagePart($id, $context = 'main', $sequenceNumber)
+    {
+        $ppRef = $this->find($id);
+        $ppRef->setContext($context);
+        $ppRef->setSequenceNumber($sequenceNumber);
+        $this->getEntityManager()->persist($ppRef);
+        $this->getEntityManager()->flush();
+
+        return $this->getEntityManager()->getRepository($ppRef->getPagePartEntityName())->find($ppRef->getPagePartId());
+
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #173

Moving pageparts to another region in the back-end caused an internal error. This fix makes it possible to save after transferring pageparts without causing an error.