### PR TITLE
[NodeBundle, SeoBundle] Update labels at 'Edit pages' to be more clear

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/PageAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/PageAdminType.php
@@ -18,8 +18,12 @@ class PageAdminType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('id', 'hidden');
-        $builder->add('title', null, array('label' => 'Name'));
-        $builder->add('pageTitle');
+        $builder->add('title', null, array('label' => 'Navigation title'));
+        $builder->add('pageTitle', null, array(
+            'attr' => array(
+                'info_text' => 'Used as title inside the page.'
+            )
+        ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/src/Kunstmaan/SeoBundle/Form/SeoType.php
+++ b/src/Kunstmaan/SeoBundle/Form/SeoType.php
@@ -18,7 +18,12 @@ class SeoType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('id', 'hidden')
-                ->add('metaTitle', null, array('label' => 'Title', 'attr' => array('info_text' => 'Use %websitetitle% to dynamic fill in the main website title.')))
+                ->add('metaTitle', null, array(
+                    'label' => 'Meta title',
+                    'attr' => array(
+                        'info_text' => 'Sets the title in the head of your document. It should be short and descriptive. The content of the "Navigation title" field will be used if this field is left blank.'
+                    )
+                ))
                 ->add('metaAuthor', null, array('label' => 'Meta author'))
                 ->add('metaDescription', null, array('label' => 'Meta description'))
                 ->add('metaKeywords', null, array('label' => 'Meta keywords'))


### PR DESCRIPTION
All the title fields at the page - edit form are confusing. 
I updated the titles and info so that everything will be a bit more clear. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #248