### PR TITLE
[MediaBundle] Uploaded files and images should retain their original name and extension

### DIFF
--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,10 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->booleanNode('enable_pdf_preview')->defaultFalse()->end()
+                ->arrayNode('blacklisted_extensions')
+                    ->defaultValue(array('php', 'htaccess'))
+                    ->prototype('scalar')->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -39,6 +39,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_media.soundcloud_api_key', $config['soundcloud_api_key']);
         $container->setParameter('kunstmaan_media.remote_video', $config['remote_video']);
         $container->setParameter('kunstmaan_media.enable_pdf_preview', $config['enable_pdf_preview']);
+        $container->setParameter('kunstmaan_media.blacklisted_extensions', $config['blacklisted_extensions']);
 
         $loader->load('services.yml');
         $loader->load('handlers.yml');

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -33,6 +33,8 @@ class FileHandler extends AbstractMediaHandler
      */
     public $mimeTypeGuesser = null;
 
+    CONST MEDIA_PATH = '/uploads/media/';
+
     /**
      * Constructor
      */
@@ -48,7 +50,7 @@ class FileHandler extends AbstractMediaHandler
      */
     public function setMediaPath($kernelRootDir)
     {
-        $this->fileSystem = new Filesystem(new Local($kernelRootDir . '/../web/uploads/media/', true));
+        $this->fileSystem = new Filesystem(new Local($kernelRootDir . '/../web' . self::MEDIA_PATH, true));
     }
 
     /**
@@ -139,12 +141,7 @@ class FileHandler extends AbstractMediaHandler
 
         $contentType = $this->mimeTypeGuesser->guess($media->getContent()->getPathname());
         $media->setContentType($contentType);
-        $relativePath = sprintf(
-            '/%s.%s',
-            $media->getUuid(),
-            ExtensionGuesser::getInstance()->guess($media->getContentType())
-        );
-        $media->setUrl('/uploads/media' . $relativePath);
+        $media->setUrl(self::MEDIA_PATH . $this->getFilePath($media));
         $media->setLocation('local');
     }
 
@@ -183,13 +180,22 @@ class FileHandler extends AbstractMediaHandler
      */
     public function getOriginalFile(Media $media)
     {
-        $relativePath = sprintf(
-            '/%s.%s',
-            $media->getUuid(),
-            ExtensionGuesser::getInstance()->guess($media->getContentType())
-        );
+        return $this->fileSystem->get($this->getFilePath($media), true);
+    }
 
-        return $this->fileSystem->get($relativePath, true);
+    /**
+     *
+     *
+     * @param Media $media
+     * @return string
+     */
+    private function getFilePath(Media $media)
+    {
+        return sprintf(
+            '/%s/%s',
+            $media->getUuid(),
+            $media->getOriginalFilename()
+        );
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -24,6 +24,11 @@ class FileHandler extends AbstractMediaHandler
     const TYPE = 'file';
 
     /**
+     * @var string
+     */
+    const MEDIA_PATH = '/uploads/media/';
+
+    /**
      * @var Filesystem
      */
     public $fileSystem = null;
@@ -33,7 +38,12 @@ class FileHandler extends AbstractMediaHandler
      */
     public $mimeTypeGuesser = null;
 
-    CONST MEDIA_PATH = '/uploads/media/';
+    /**
+     * Files with a blacklisted extension will be converted to txt
+     *
+     * @var array
+     */
+    private $blacklistedExtensions = array();
 
     /**
      * Constructor
@@ -41,6 +51,16 @@ class FileHandler extends AbstractMediaHandler
     public function __construct(MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory)
     {
         $this->mimeTypeGuesser = $mimeTypeGuesserFactory->get();
+    }
+
+    /**
+     * Inject the blacklisted
+     *
+     * @param array $blacklistedExtensions
+     */
+    public function setBlacklistedExtensions(array $blacklistedExtensions)
+    {
+        $this->blacklistedExtensions = $blacklistedExtensions;
     }
 
     /**
@@ -191,10 +211,16 @@ class FileHandler extends AbstractMediaHandler
      */
     private function getFilePath(Media $media)
     {
+        $filename = $media->getOriginalFilename();
+
+        if (!empty($this->blacklistedExtensions)) {
+            $filename = preg_replace('/\.('.join('|', $this->blacklistedExtensions).')$/', '.txt', $filename);
+        }
+
         return sprintf(
             '/%s/%s',
             $media->getUuid(),
-            $media->getOriginalFilename()
+            $filename
         );
     }
 

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -212,6 +212,7 @@ class FileHandler extends AbstractMediaHandler
     private function getFilePath(Media $media)
     {
         $filename = $media->getOriginalFilename();
+        $filename = str_replace(array('/', '\\'), '', $filename);
 
         if (!empty($this->blacklistedExtensions)) {
             $filename = preg_replace('/\.('.join('|', $this->blacklistedExtensions).')$/', '.txt', $filename);

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -29,6 +29,7 @@ services:
         arguments: ["@kunstmaan_media.mimetype_guesser.factory", "%aviary_api_key%"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
+            - [ setBlacklistedExtensions, [ "%kunstmaan_media.blacklisted_extensions%" ] ]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }
 
@@ -37,5 +38,6 @@ services:
         arguments: ["@kunstmaan_media.mimetype_guesser.factory"]
         calls:
             - [ setMediaPath, [ "%kernel.root_dir%" ] ]
+            - [ setBlacklistedExtensions, [ "%kunstmaan_media.blacklisted_extensions%" ] ]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #200

With this fix we can keep the original file name without conflicts in case of duplicate filenames. Also via a basic blacklist system we can limit the extensions on disk for security purposes. This blacklist can be extended through the config.yml.