### PR TITLE
[FormBundle] Fix for the Doctrine ORM BC break in v2.5.0 => base inheritance mapping classes must befined as abstract

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionField.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
  *     "email" = "Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\EmailFormSubmissionField"
  * })
  */
-class FormSubmissionField
+abstract class FormSubmissionField
 {
     /**
      * This id of this FormSubmissionField


### PR DESCRIPTION
Make the Kunstmaan CMS compatible with Doctrine ORM 2.5.x
http://doctrine-orm.readthedocs.org/en/latest/changelog/migration_2_5.html#minor-bc-break-all-non-transient-classes-in-an-inheritance-must-be-part-of-the-inheritance-map

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #256