### PR TITLE
[AdminBundle] Fix the AclHelper test due to changes in Doctrine 2.5.0

### DIFF
--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclHelperTest.php
@@ -110,6 +110,14 @@ class AclHelperTest extends \PHPUnit_Framework_TestCase
             ->method('getQuoteStrategy')
             ->will($this->returnValue($strat));
 
+        $conf->expects($this->any())
+            ->method('getDefaultQueryHints')
+            ->willReturn(array());
+
+        $conf->expects($this->any())
+            ->method('isSecondLevelCacheEnabled')
+            ->willReturn(false);
+
         $this->em->expects($this->any())
             ->method('getConfiguration')
             ->will($this->returnValue($conf));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Due to changes in Doctrine, the ACLHelper test was broken. This PR should fix that.