### PR TITLE
Use PHP Intl Transliterator to fix slugifier issues

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -7,47 +7,6 @@ namespace Kunstmaan\UtilitiesBundle\Helper;
  */
 class Slugifier
 {
-	/**
-	 * Convert russian to translit
-	 * @param $string
-	 * @return string
-	 */
-	public function rus2translit($string) {
-		$converter = array(
-			'а' => 'a',   'б' => 'b',   'в' => 'v',
-			'г' => 'g',   'д' => 'd',   'е' => 'e',
-			'ё' => 'e',   'ж' => 'zh',  'з' => 'z',
-			'и' => 'i',   'й' => 'y',   'к' => 'k',
-			'л' => 'l',   'м' => 'm',   'н' => 'n',
-			'о' => 'o',   'п' => 'p',   'р' => 'r',
-			'с' => 's',   'т' => 't',   'у' => 'u',
-			'ф' => 'f',   'х' => 'h',   'ц' => 'c',
-			'ч' => 'ch',  'ш' => 'sh',  'щ' => 'sch',
-			'ь' => '',    'ы' => 'y',   'ъ' => '',
-			'э' => 'e',   'ю' => 'yu',  'я' => 'ya',
-
-			'А' => 'A',   'Б' => 'B',   'В' => 'V',
-			'Г' => 'G',   'Д' => 'D',   'Е' => 'E',
-			'Ё' => 'E',   'Ж' => 'Zh',  'З' => 'Z',
-			'И' => 'I',   'Й' => 'Y',   'К' => 'K',
-			'Л' => 'L',   'М' => 'M',   'Н' => 'N',
-			'О' => 'O',   'П' => 'P',   'Р' => 'R',
-			'С' => 'S',   'Т' => 'T',   'У' => 'U',
-			'Ф' => 'F',   'Х' => 'H',   'Ц' => 'C',
-			'Ч' => 'Ch',  'Ш' => 'Sh',  'Щ' => 'Sch',
-			'Ь' => '',    'Ы' => 'Y',   'Ъ' => '',
-			'Э' => 'E',   'Ю' => 'Yu',  'Я' => 'Ya',
-			'ä' => 'a',   'á' => 'a',   'à' => 'a',
-			'å' => 'a',   'é' => 'e',   'è' => 'e',
-			'ë' => 'e',   'í' => 'i',   'ì' => 'i',
-			'ï' => 'i',   'ó' => 'o',   'ò' => 'o',
-			'ö' => 'o',   'ú' => 'u',   'ù' => 'u',
-			'ü' => 'u',   'ñ' => 'n',   'ß' => 'ss',
-			'æ' => 'ae',  'õ' => 'o',
-		);
-		return strtr(strtolower($string), $converter);
-	}
-
     /**
      * Slugify a string
      *
@@ -63,16 +22,11 @@ class Slugifier
         }
 
         // transliterate
-        if (function_exists('iconv')) {
-            $previouslocale = setlocale(LC_CTYPE, 0);
-            setlocale(LC_CTYPE, 'en_US.UTF8');
-			
-			//convert russian letters to translit
-			$slugifier = new Slugifier();
-			$text = $slugifier->rus2translit($text);
-			
-            $text = @iconv('utf-8', 'us-ascii//TRANSLIT', $text);
-            setlocale(LC_CTYPE, $previouslocale);
+        if (class_exists('Transliterator')) {
+            $text = mb_convert_encoding((string)$text, 'UTF-8', mb_list_encodings());
+
+            $transliterator = \Transliterator::create('Accents-Any');
+            $text = $transliterator->transliterate($text);
         }
 
         $text = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $text);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Slugifier tests were broken, this Transliterator seemed to work ok (and since Intl is required for Symfony it should not break anything).