### PR TITLE
Require at least PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.4.0",
 
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",

--- a/docs/01-00-introduction.md
+++ b/docs/01-00-introduction.md
@@ -30,7 +30,7 @@ Starting fresh has a lot of advantages and going further we defined the basic pr
 2. Added on top of the framework we included a lot of **community components** that provide our extended framework with functionality like Image resizing, pagination, user management, an advanced router, etc.
 3. And we wrap all this into a **user friendly admin interface with content management** functionalities.
 
-We are able to support PHP 5.3.9 and up, and all Symfony versions since 2.3. We constantly test and adapt to be able to run the latest and greatest from Symfony and the community.
+We are able to support PHP 5.4 and up, and all Symfony versions since 2.3. We constantly test and adapt to be able to run the latest and greatest from Symfony and the community.
 
 # Open Source
 

--- a/docs/03-01-system-requirements.md
+++ b/docs/03-01-system-requirements.md
@@ -1,7 +1,7 @@
 # System Requirements
 
 * PHP
-    * minimum version of PHP 5.3.9, but since 5.3 is out of support, we prefer 5.5 or 5.6.
+    * minimum version of PHP 5.4, but we prefer 5.5 or 5.6.
     * JSON needs to be enabled
     * ctype needs to be enabled
     * curl needs to be enabled

--- a/src/Kunstmaan/AdminBundle/.travis.yml
+++ b/src/Kunstmaan/AdminBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "friendsofsymfony/user-bundle": "2.0.*@dev",

--- a/src/Kunstmaan/AdminListBundle/.travis.yml
+++ b/src/Kunstmaan/AdminListBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/AdminListBundle/composer.json
+++ b/src/Kunstmaan/AdminListBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "sensio/framework-extra-bundle": ">=2.3.4,<4.0.0",
         "white-october/pagerfanta-bundle": "1.0.*",

--- a/src/Kunstmaan/ArticleBundle/.travis.yml
+++ b/src/Kunstmaan/ArticleBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "white-october/pagerfanta-bundle": "1.0.*",
         "kunstmaan/admin-bundle": "~3.0.0",

--- a/src/Kunstmaan/BehatBundle/.travis.yml
+++ b/src/Kunstmaan/BehatBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/BehatBundle/composer.json
+++ b/src/Kunstmaan/BehatBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "behat/behat": "~2.5.0",
         "behat/mink": "*",

--- a/src/Kunstmaan/DashboardBundle/.travis.yml
+++ b/src/Kunstmaan/DashboardBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/DashboardBundle/composer.json
+++ b/src/Kunstmaan/DashboardBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "alchemy/google-plus-api-client": "~0.6.5"

--- a/src/Kunstmaan/FormBundle/.travis.yml
+++ b/src/Kunstmaan/FormBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "ddeboer/data-import-bundle": "0.1.*",
         "gedmo/doctrine-extensions": "2.3.*",

--- a/src/Kunstmaan/GeneratorBundle/.travis.yml
+++ b/src/Kunstmaan/GeneratorBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "sensio/generator-bundle": ">=2.3.0, <2.5.0",

--- a/src/Kunstmaan/LanguageChooserBundle/.travis.yml
+++ b/src/Kunstmaan/LanguageChooserBundle/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 matrix:
   allow_failures:
-    - php: 5.5
+    - php: hhvm
 
 
 before_script:

--- a/src/Kunstmaan/LanguageChooserBundle/composer.json
+++ b/src/Kunstmaan/LanguageChooserBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "lunetics/locale-bundle": "*"
     },

--- a/src/Kunstmaan/LiveReloadBundle/.travis.yml
+++ b/src/Kunstmaan/LiveReloadBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/LiveReloadBundle/composer.json
+++ b/src/Kunstmaan/LiveReloadBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
 	"symfony/framework-bundle": "~2.3",
         "guzzle/guzzle": "3.8.*"
     },

--- a/src/Kunstmaan/MediaBundle/.travis.yml
+++ b/src/Kunstmaan/MediaBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",

--- a/src/Kunstmaan/MediaPagePartBundle/.travis.yml
+++ b/src/Kunstmaan/MediaPagePartBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/MediaPagePartBundle/composer.json
+++ b/src/Kunstmaan/MediaPagePartBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "kunstmaan/pagepart-bundle": "~3.0.0",
         "kunstmaan/media-bundle": "~3.0.0",

--- a/src/Kunstmaan/NodeBundle/.travis.yml
+++ b/src/Kunstmaan/NodeBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
         "symfony-cmf/routing-bundle": "~1.1.1",

--- a/src/Kunstmaan/NodeSearchBundle/.travis.yml
+++ b/src/Kunstmaan/NodeSearchBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/NodeSearchBundle/composer.json
+++ b/src/Kunstmaan/NodeSearchBundle/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "white-october/pagerfanta-bundle": "1.0.*",
         "ruflin/elastica": "~1.0",

--- a/src/Kunstmaan/PagePartBundle/.travis.yml
+++ b/src/Kunstmaan/PagePartBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/PagePartBundle/composer.json
+++ b/src/Kunstmaan/PagePartBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "kunstmaan/admin-bundle": "~3.0.0",
         "kunstmaan/utilities-bundle": "~3.0.0",

--- a/src/Kunstmaan/RedirectBundle/.travis.yml
+++ b/src/Kunstmaan/RedirectBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "symfony-cmf/routing-bundle": "~1.1.1",
         "kunstmaan/adminlist-bundle": "~3.0.0",

--- a/src/Kunstmaan/SearchBundle/.travis.yml
+++ b/src/Kunstmaan/SearchBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/SearchBundle/composer.json
+++ b/src/Kunstmaan/SearchBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "ruflin/elastica": "~1.0"
     },

--- a/src/Kunstmaan/SeoBundle/.travis.yml
+++ b/src/Kunstmaan/SeoBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/SeoBundle/composer.json
+++ b/src/Kunstmaan/SeoBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
         "kunstmaan/admin-bundle": "~3.0.0",

--- a/src/Kunstmaan/SitemapBundle/.travis.yml
+++ b/src/Kunstmaan/SitemapBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/SitemapBundle/composer.json
+++ b/src/Kunstmaan/SitemapBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "kunstmaan/admin-bundle": "~3.0.0",
         "kunstmaan/node-bundle": "~3.0.0",

--- a/src/Kunstmaan/TaggingBundle/.travis.yml
+++ b/src/Kunstmaan/TaggingBundle/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 matrix:
   allow_failures:
-    - php: 5.5
+    - php: hhvm
 
 
 before_script:

--- a/src/Kunstmaan/TaggingBundle/composer.json
+++ b/src/Kunstmaan/TaggingBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "fpn/doctrine-extensions-taggable": "0.9.0",
         "kunstmaan/admin-bundle": "~3.0.0",

--- a/src/Kunstmaan/TranslatorBundle/.travis.yml
+++ b/src/Kunstmaan/TranslatorBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",

--- a/src/Kunstmaan/UserManagementBundle/.travis.yml
+++ b/src/Kunstmaan/UserManagementBundle/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 matrix:

--- a/src/Kunstmaan/UserManagementBundle/composer.json
+++ b/src/Kunstmaan/UserManagementBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "kunstmaan/adminlist-bundle": "~3.0.0",
         "kunstmaan/admin-bundle": "~3.0.0",

--- a/src/Kunstmaan/UtilitiesBundle/.travis.yml
+++ b/src/Kunstmaan/UtilitiesBundle/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 matrix:
   allow_failures:
-    - php: 5.5
+    - php: hhvm
 
 
 before_script: composer install --dev --prefer-source

--- a/src/Kunstmaan/UtilitiesBundle/composer.json
+++ b/src/Kunstmaan/UtilitiesBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3"
     },

--- a/src/Kunstmaan/VotingBundle/.travis.yml
+++ b/src/Kunstmaan/VotingBundle/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 matrix:
   allow_failures:
-    - php: 5.5
+    - php: hhvm
 
 
 before_script: composer install --dev --prefer-source

--- a/src/Kunstmaan/VotingBundle/composer.json
+++ b/src/Kunstmaan/VotingBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Since PHP 5.3 is no longer maintained, we decided to drop PHP 5.3 support (if you're still using it : you *really* should upgrade!).