### PR TITLE
[NodeBundle] Add classname to admin if user is a super admin

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
@@ -29,7 +29,12 @@
 {% block header %}
     <!-- PageClassName: {{ node.refEntityName }} -->
     <h1 class="app__content__header__title">
-        {{ page.title }}
+        {% if is_granted('ROLE_SUPER_ADMIN') %}
+            <abbr title="{{ node.refEntityName }}">{{ page.title }}</abbr>
+        {% else %}
+            {{ page.title }}
+        {% endif %}
+        
         {% if draft %}
 	    <small class="app__content__header__title__small">
                 Draft version (Go to <a href="{{ path('KunstmaanNodeBundle_nodes_edit', { 'id': node.id}) }}">public version</a>)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This adds the classname of the entity as an abbr to the admin is the user has the SUPER_ADMIN role.

![add-classname](https://cloud.githubusercontent.com/assets/493233/7023450/871d31c2-dd35-11e4-9128-71b5310ac121.png)
