### PR TITLE
[MediaBundle] Add add/delete new folders while inside the media-chooser popup

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -8,6 +8,7 @@ use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Helper\Media\AbstractMediaHandler;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
+use Kunstmaan\MediaBundle\Form\FolderType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -112,6 +113,10 @@ class ChooserController extends Controller
         $adminList             = $this->get('kunstmaan_adminlist.factory')->createList($adminListConfigurator);
         $adminList->bindRequest($request);
 
+        $sub = new Folder();
+        $sub->setParent($folder);
+        $subForm  = $this->createForm(new FolderType($sub), $sub);
+
         $linkChooserLink = null;
         if (!empty($linkChooser)) {
             $params = array();
@@ -124,7 +129,7 @@ class ChooserController extends Controller
             $linkChooserLink = $this->generateUrl($routeName, $params);
         }
 
-       $viewVariabels = array(
+        $viewVariabels = array(
             'cKEditorFuncNum' => $cKEditorFuncNum,
             'linkChooser'     => $linkChooser,
             'linkChooserLink' => $linkChooserLink,
@@ -134,7 +139,7 @@ class ChooserController extends Controller
             'type'            => $type,
             'folder'          => $folder,
             'adminlist'       => $adminList,
-
+            'subform'         => $subForm->createView()
         );
 
         /* generate all forms */

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -113,10 +113,12 @@ class FolderController extends Controller
             $this->get('session')->getFlashBag()->add('success', 'Folder \'' . $folderName . '\' has been deleted!');
             $folderId = $parentFolder->getId();
         }
+        if (strpos($_SERVER['HTTP_REFERER'],'chooser')) {
+            $redirect = 'KunstmaanMediaBundle_chooser_show_folder';
+        } else $redirect = 'KunstmaanMediaBundle_folder_show';
 
         return new RedirectResponse(
-            $this->generateUrl(
-                'KunstmaanMediaBundle_folder_show',
+            $this->generateUrl($redirect,
                 array(
                     'folderId' => $folderId
                 )
@@ -153,16 +155,16 @@ class FolderController extends Controller
                     'success',
                     'Folder \'' . $folder->getName() . '\' has been created!'
                 );
+                if (strpos($_SERVER['HTTP_REFERER'],'chooser') !== false) {
+                    $redirect = 'KunstmaanMediaBundle_chooser_show_folder';
+                } else $redirect = 'KunstmaanMediaBundle_folder_show';
 
-                return new Response(
-                    '<script>window.location="' .
-                    $this->generateUrl(
-                        'KunstmaanMediaBundle_folder_show',
+                return new RedirectResponse(
+                    $this->generateUrl( $redirect,
                         array(
                             'folderId' => $folder->getId()
                         )
-                    ) .
-                    '"</script>'
+                    )
                 );
             }
         }

--- a/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
@@ -129,18 +129,24 @@
                         Add media <i class="fa fa-caret-down"></i>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                    {% for addaction in mediamanager.getFolderAddActions() %}
-                        <li>
-                            <a href="javascript:void(0)" data-toggle="modal" data-target="#add{{ addaction.type }}-modal">
-                                {{ addaction.name |trans }}
-                            </a>
-                        </li>
-                    {% endfor %}
+                        {% for addaction in mediamanager.getFolderAddActions() %}
+                            <li>
+                                <a href="javascript:void(0)" data-toggle="modal" data-target="#add{{ addaction.type }}-modal">
+                                    {{ addaction.name |trans }}
+                                </a>
+                            </li>
+                        {% endfor %}
                     </ul>
                 </div>
+            <button class="btn btn-default btn--raise-on-hover" data-target="#addsub-modal" data-toggle="modal" type="button">
+                {{ 'media.folder.addsub.action' |trans }}
+            </button>
+            <button class="btn btn-default btn--raise-on-hover" data-target="#delete-modal" data-toggle="modal" type="button">
+                {{ 'media.folder.delete.action' |trans }}
+            </button>
             {% endblock %}
-            </div>
         </div>
+    </div>
 
 
     <!-- Scroll-actions -->
@@ -236,6 +242,8 @@
     <!-- Modals -->
     {% set urlParams = urlParams|merge({'folderId': folder.id}) %}
     {% include 'KunstmaanMediaBundle:Media:addType-modal.html.twig' %}
+    {% include 'KunstmaanMediaBundle:Folder:addsub-modal.html.twig' %}
+    {% include 'KunstmaanMediaBundle:Folder:delete-modal.html.twig' %}
 
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #251 

This feature makes it possible to add/delete new folders while inside the media-chooser. This way, you can re-arrange the folder structure without having to exit the media-chooser.