### PR TITLE
[NodeBundle, GeneratorBundle] Deprecated the service method in Pages in favour of controller methods

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/OverviewPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/OverviewPage.php
@@ -36,16 +36,6 @@ class {{ entity_class }}OverviewPage extends AbstractArticleOverviewPage impleme
 	return array('{{ bundle.getName() }}:{{ entity_class|lower }}overviewpage');
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @param Request            $request
-     * @param RenderContext      $context
-     */
-    public function service(ContainerInterface $container, Request $request, RenderContext $context)
-    {
-        parent::service($container, $request, $context);
-    }
-
     public function getArticleRepository($em)
     {
 	return $em->getRepository('{{ bundle.getName() }}:Pages\{{ entity_class }}Page');

--- a/src/Kunstmaan/NodeBundle/Controller/SlugActionInterface.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugActionInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Controller;
+
+
+interface SlugActionInterface
+{
+
+    /**
+     * @return mixed
+     *
+     */
+    public function getControllerAction();
+
+}

--- a/src/Kunstmaan/NodeBundle/Event/Events.php
+++ b/src/Kunstmaan/NodeBundle/Event/Events.php
@@ -129,4 +129,10 @@ class Events
      */
     const CONFIGURE_ACTION_MENU = 'kunstmaan_node.configureActionMenu';
 
+    /**
+     * This event will be triggered when the sluglistener needs to do security checks
+     *
+     * @var string
+     */
+    const SLUG_SECURITY = 'kunstmaan_node.slug.security';
 }

--- a/src/Kunstmaan/NodeBundle/Event/SlugSecurityEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/SlugSecurityEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Event;
+
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class SlugSecurityEvent
+ * @package Kunstmaan\NodeBundle\Event
+ */
+final class SlugSecurityEvent extends Event
+{
+
+}

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\EventListener;
+
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * Class RenderContextListener
+ * @package Kunstmaan\NodeBundle\EventListener
+ */
+class RenderContextListener
+{
+
+
+
+
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @param EntityManager $em
+     * @param EngineInterface $templating
+     */
+    public function __construct(EngineInterface $templating)
+    {
+        $this->templating = $templating;
+    }
+
+    /**
+     * @param GetResponseForControllerResultEvent $event
+     */
+    public function onKernelView(GetResponseForControllerResultEvent $event)
+    {
+        $request    = $event->getRequest();
+        $nodeTranslation = $request->attributes->get('_nodeTranslation');
+
+        if($nodeTranslation) {
+        //fetch parameters;
+            $entity          = $request->attributes->get('_entity');
+            $url             = $request->attributes->get('url');
+            $nodeMenu        = $request->attributes->get('_nodeMenu');
+            $parameters      = $request->attributes->get('_renderContext');
+            $renderContext = array(
+                '_nodeTranslation' => $nodeTranslation,
+                'slug' => $url,
+                'page' => $entity,
+                'resource' => $entity,
+                'nodemenu' => $nodeMenu,
+                );
+
+            $parameters = array_merge($renderContext, $parameters);
+            //sent the response here, another option is to let the symfony kernel.view listener handle it
+            $event->setResponse($this->templating->renderResponse($entity->getDefaultView(), $parameters));
+        }
+    }
+}

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\EventListener;
+
+use Kunstmaan\NodeBundle\Controller\SlugActionInterface;
+use Kunstmaan\NodeBundle\Event\Events;
+use Kunstmaan\NodeBundle\Event\SlugSecurityEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+
+
+/**
+ * Class SlugListener
+ * @package Kunstmaan\NodeBundle\EventListener
+ */
+class SlugListener
+{
+
+    /**
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * @var ControllerResolver
+     */
+    protected $resolver;
+
+
+    /**
+     * @var EventDispatcher
+     */
+    protected $eventDispatcher;
+
+    /**
+     * @param EntityManager $entityManager
+     * @param ControllerResolver $resolver
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EntityManager $entityManager, ControllerResolver $resolver, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->em = $entityManager;
+        $this->resolver = $resolver;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @param FilterControllerEvent $event
+     */
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $request = $event->getRequest();
+
+        //check if the event has anything to do with nodeTranslations, if not this method can be skipped
+        if (!$request->attributes->has('_nodeTranslation')) {
+            return;
+        }
+
+        $nodeTranslation = $request->attributes->get('_nodeTranslation');
+        $entity = $nodeTranslation->getPublicNodeVersion()->getRef($this->em);
+
+        //if the entity is an instance of the SlugControllerActionInterface, change the controller
+        if ($entity instanceof SlugActionInterface) {
+
+            $entity = $nodeTranslation->getRef($this->em);
+            $request->attributes->set('_entity', $entity);
+
+            //do security check by firing an event that gets handled by the SlugSecurityListener
+            $securityEvent = new SlugSecurityEvent();
+            $this->eventDispatcher->dispatch(Events::SLUG_SECURITY, $securityEvent);
+
+           //set the right controller
+            $request->attributes->set('_controller', $entity->getControllerAction());
+            $event->setController($this->resolver->getController($request));
+        }
+    }
+}

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\EventListener;
+
+
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
+use Kunstmaan\NodeBundle\Helper\NodeMenu;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Security\Core\SecurityContext;
+/**
+ * Class SlugSecurityListener
+ * @package Kunstmaan\NodeBundle\EventListener
+ */
+class SlugSecurityListener
+{
+    /**
+     * @var SecurityContext
+     */
+    protected $securityContext;
+
+    /**
+     * @var null|\Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
+
+    /**
+     * @var EntityManager
+     */
+    protected $em;
+
+    /**
+     * @var
+     */
+    protected $acl;
+
+    /**
+     * @param RequestStack $requestStack
+     * @param EntityManager $entityManager
+     * @param $securityContext
+     * @param $acl
+     */
+    public function __construct(RequestStack $requestStack,EntityManager $entityManager, SecurityContext $securityContext, $acl)
+    {
+        $this->securityContext = $securityContext;
+        $this->request = $requestStack->getCurrentRequest();
+        $this->em = $entityManager;
+        $this->acl = $acl;
+    }
+
+    /**
+     *
+     */
+    public function onSlugSecurityEvent()
+    {
+        $node = $this->request->attributes->get('_nodeTranslation')->getNode();
+
+        /* @var SecurityContextInterface $securityContext */
+        if (false === $this->securityContext->isGranted(PermissionMap::PERMISSION_VIEW, $node)) {
+            throw new AccessDeniedException('You do not have sufficient rights to access this page.');
+        }
+
+        $locale = $this->request->attributes->get('_locale');
+        $preview = $this->request->attributes->get('preview');
+
+        $nodeMenu       = new NodeMenu($this->em, $this->securityContext, $this->acl, $locale , $node, PermissionMap::PERMISSION_VIEW, $preview);
+
+        $this->request->attributes->set('_nodeMenu', $nodeMenu);
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 parameters:
     kunstmaan_node.version_timeout: 3600
     kunstmaan_node.slugrouter.class: 'Kunstmaan\NodeBundle\Router\SlugRouter'
-
+    kunstmaan_node.sluglistener.class: 'Kunstmaan\NodeBundle\EventListener\SlugListener'
 services:
     kunstmaan_node.nodetranslation.listener:
         class: Kunstmaan\NodeBundle\EventListener\NodeTranslationListener
@@ -120,3 +120,21 @@ services:
         class: Kunstmaan\NodeBundle\Command\FixTimestampsCommand
         calls:
             - [setContainer, ["@service_container"] ]
+
+    kunstmaan_node.slug.listener:
+        class: "%kunstmaan_node.sluglistener.class%"
+        arguments: ["@doctrine.orm.entity_manager","@controller_resolver", "@event_dispatcher"]
+        tags:
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
+
+    kunstmaan_node.slug.security.listener:
+        class: Kunstmaan\NodeBundle\EventListener\SlugSecurityListener
+        arguments: ["@request_stack" , "@doctrine.orm.entity_manager", "@security.context" , "@kunstmaan_admin.acl.helper" ]
+        tags:
+            - { name: kernel.event_listener, event: kunstmaan_node.slug.security, method: onSlugSecurityEvent }
+
+    kunstmaan_node.render.context.listener:
+        class: Kunstmaan\NodeBundle\EventListener\RenderContextListener
+        arguments: ["@templating"]
+        tags:
+            - { name: kernel.event_listener, event: kernel.view, method: onKernelView }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #211

instead of putting logic in the entity pages (service method), it is now possible to just implement the SlugActionInterface and specify which controller method must be executed. 

- [x] Gather feedback for my changes
- [x] update relevant CHANGELOG and UPGRADE files;

## UPGRADE

## Deprecated the service method in Pages in favour of controller methods

You need to remove the service method in your entities and replace them by implementing the SlugActionInterface. Add the method getControllerAction and make it return a callable string.

```php
    public function getControllerAction()
    {
        return 'Bundle:Controller:service';
    }
```

In your controller just add the serviceAction method, let it handle the logic and set the renderContext in the request attributes. 

```php
    public function serviceAction(Request $request)
    {
        ..logic..
        $context['variable'] = $variable;

        $request->attributes->set('_renderContext',$context);
    }

```
