### PR TITLE
[GeneratorBundle] Replace DialogHelper with QuestionHelper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "symfony-cmf/routing-bundle": "~1.1.1",
         "ruflin/elastica": "~1.0",
         "fpn/doctrine-extensions-taggable": "0.9.0",
-        "sensio/generator-bundle": ">=2.3.0, <2.5.0"
+	"sensio/generator-bundle": ">=2.5.0"
     },
     "require-dev": {
         "behat/behat": "~2.5.0",

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
@@ -43,8 +43,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Admin Tests Generation');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Admin Tests Generation');
 
         GeneratorUtils::ensureOptionsProvided($input, array('namespace'));
 
@@ -65,10 +65,10 @@ EOT
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Welcome to the Kunstmaan default site generator');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Welcome to the Kunstmaan default site generator');
 
-        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $dialog, $this->getApplication()->getKernel(), $this->getContainer());
+        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $questionHelper, $this->getApplication()->getKernel(), $this->getContainer());
 
         $inputAssistant->askForNamespace(array(
             '',

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
@@ -11,7 +11,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Sensio\Bundle\GeneratorBundle\Command\Validators;
 use Sensio\Bundle\GeneratorBundle\Manipulator\KernelManipulator;
 use Sensio\Bundle\GeneratorBundle\Manipulator\RoutingManipulator;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Generates bundles.
@@ -65,10 +67,11 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
+        $questionHelper = $this->getQuestionHelper();
 
         if ($input->isInteractive()) {
-            if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
+            $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
+            if (!$questionHelper->ask($input, $output, $confirmationQuestion)) {
                 $output->writeln('<error>Command aborted</error>');
 
                 return 1;
@@ -85,7 +88,7 @@ EOT
         $dir = Validators::validateTargetDir($input->getOption('dir'), $bundle, $namespace);
         $format = 'yml';
 
-        $dialog->writeSection($output, 'Bundle generation');
+        $questionHelper->writeSection($output, 'Bundle generation');
 
         if (!$this
             ->getContainer()
@@ -101,18 +104,18 @@ EOT
         $output->writeln('Generating the bundle code: <info>OK</info>');
 
         $errors = array();
-        $runner = $dialog->getRunner($output, $errors);
+        $runner = $questionHelper->getRunner($output, $errors);
 
         // check that the namespace is already autoloaded
         $runner($this->checkAutoloader($output, $namespace, $bundle));
 
         // register the bundle in the Kernel class
-        $runner($this->updateKernel($dialog, $input, $output, $this->getContainer()->get('kernel'), $namespace, $bundle));
+        $runner($this->updateKernel($questionHelper, $input, $output, $this->getContainer()->get('kernel'), $namespace, $bundle));
 
         // routing
-        $runner($this->updateRouting($dialog, $input, $output, $bundle, $format));
+        $runner($this->updateRouting($questionHelper, $input, $output, $bundle, $format));
 
-        $dialog->writeGeneratorSummary($output, $errors);
+        $questionHelper->writeGeneratorSummary($output, $errors);
     }
 
     /**
@@ -125,8 +128,8 @@ EOT
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Welcome to the Kunstmaan bundle generator');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Welcome to the Kunstmaan bundle generator');
 
         // namespace
         $output
@@ -138,9 +141,9 @@ EOT
                 'See http://symfony.com/doc/current/cookbook/bundles/best_practices.html#index-1 for more', 'details on bundle naming conventions.', '',
                 'Use <comment>/</comment> instead of <comment>\\ </comment>for the namespace delimiter to avoid any problems.', '',));
 
-        $namespace = $dialog
-            ->askAndValidate($output, $dialog->getQuestion('Bundle namespace', $input->getOption('namespace')),
-                array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleNamespace'), false, $input->getOption('namespace'));
+        $question = new Question($questionHelper->getQuestion('Bundle namespace', $input->getOption('namespace')), $input->getOption('namespace'));
+        $question->setValidator( array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleNamespace'));
+        $namespace = $questionHelper->ask($input, $output, $question);
         $input->setOption('namespace', $namespace);
 
         // bundle name
@@ -149,7 +152,9 @@ EOT
             ->writeln(
                 array('', 'In your code, a bundle is often referenced by its name. It can be the', 'concatenation of all namespace parts but it\'s really up to you to come',
                 'up with a unique name (a good practice is to start with the vendor name).', 'Based on the namespace, we suggest <comment>' . $bundle . '</comment>.', '',));
-        $bundle = $dialog->askAndValidate($output, $dialog->getQuestion('Bundle name', $bundle), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleName'), false, $bundle);
+        $question = new Question($questionHelper->getQuestion('Bundle name', $bundle), $bundle);
+        $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleName'));
+        $bundle = $questionHelper->ask($input, $output, $question);
         $input->setOption('bundle-name', $bundle);
 
         // target dir
@@ -157,11 +162,9 @@ EOT
             ->getContainer()
             ->getParameter('kernel.root_dir')) . '/src';
         $output->writeln(array('', 'The bundle can be generated anywhere. The suggested default directory uses', 'the standard conventions.', '',));
-        $dir = $dialog
-            ->askAndValidate($output, $dialog->getQuestion('Target directory', $dir),
-                function ($dir) use ($bundle, $namespace) {
-                    return Validators::validateTargetDir($dir, $bundle, $namespace);
-                }, false, $dir);
+        $question = new Question($questionHelper->getQuestion('Target directory', $dir), $dir);
+        $question->setValidator(function ($dir) use ($bundle, $namespace) { return Validators::validateTargetDir($dir, $bundle, $namespace); });
+        $dir = $questionHelper->ask($input, $output, $question);
         $input->setOption('dir', $dir);
 
         // format
@@ -195,20 +198,21 @@ EOT
     }
 
     /**
-     * @param DialogHelper    $dialog    The dialog helper
-     * @param InputInterface  $input     The command input
-     * @param OutputInterface $output    The command output
-     * @param KernelInterface $kernel    The kernel
-     * @param string          $namespace The namespace
-     * @param string          $bundle    The bundle
+     * @param QuestionHelper  $questionHelper The question helper
+     * @param InputInterface  $input          The command input
+     * @param OutputInterface $output         The command output
+     * @param KernelInterface $kernel         The kernel
+     * @param string          $namespace      The namespace
+     * @param string          $bundle         The bundle
      *
      * @return array
      */
-    protected function updateKernel(DialogHelper $dialog, InputInterface $input, OutputInterface $output, KernelInterface $kernel, $namespace, $bundle)
+    protected function updateKernel(QuestionHelper $questionHelper, InputInterface $input, OutputInterface $output, KernelInterface $kernel, $namespace, $bundle)
     {
         $auto = true;
         if ($input->isInteractive()) {
-            $auto = $dialog->askConfirmation($output, $dialog->getQuestion('Confirm automatic update of your Kernel', 'yes', '?'), true);
+            $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Confirm automatic update of your Kernel', 'yes', '?'), true);
+            $auto = $questionHelper->ask($input, $output, $confirmationQuestion);
         }
 
         $output->write('Enabling the bundle inside the Kernel: ');
@@ -228,19 +232,20 @@ EOT
     }
 
     /**
-     * @param DialogHelper    $dialog The dialog helper
-     * @param InputInterface  $input  The command input
-     * @param OutputInterface $output The command output
-     * @param string          $bundle The bundle name
-     * @param string          $format the format
+     * @param QuestionHelper  $questionHelper The question helper
+     * @param InputInterface  $input          The command input
+     * @param OutputInterface $output         The command output
+     * @param string          $bundle         The bundle name
+     * @param string          $format         The format
      *
      * @return array
      */
-    protected function updateRouting(DialogHelper $dialog, InputInterface $input, OutputInterface $output, $bundle, $format)
+    protected function updateRouting(QuestionHelper $questionHelper, InputInterface $input, OutputInterface $output, $bundle, $format)
     {
         $auto = true;
         if ($input->isInteractive()) {
-            $auto = $dialog->askConfirmation($output, $dialog->getQuestion('Confirm automatic update of the Routing', 'yes', '?'), true);
+            $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Confirm automatic update of the Routing', 'yes', '?'), true);
+            $auto = $questionHelper->ask($input, $output, $confirmationQuestion);
         }
 
         $output->write('Importing the bundle routing resource: ');

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
@@ -35,17 +35,17 @@ class GenerateDefaultPagePartsCommand extends KunstmaanGenerateCommand
      */
     protected function configure()
     {
-	$this->setDescription('Generates default pageparts')
-	    ->setHelp(<<<EOT
+        $this->setDescription('Generates default pageparts')
+            ->setHelp(<<<EOT
 The <info>kuma:generate:default-pageparts</info> command generates the default pageparts and adds the pageparts configuration.
 
 <info>php app/console kuma:generate:default-pageparts</info>
 EOT
-	    )
-	    ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace to generate the default pageparts in')
-	    ->addOption('prefix', '', InputOption::VALUE_OPTIONAL, 'The prefix to be used in the table name of the generated entity')
-	    ->addOption('contexts', '', InputOption::VALUE_OPTIONAL, 'The contexts were we need to allow the pageparts (separated multiple sections with a comma)')
-	    ->setName('kuma:generate:default-pageparts');
+            )
+            ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace to generate the default pageparts in')
+            ->addOption('prefix', '', InputOption::VALUE_OPTIONAL, 'The prefix to be used in the table name of the generated entity')
+            ->addOption('contexts', '', InputOption::VALUE_OPTIONAL, 'The contexts were we need to allow the pageparts (separated multiple sections with a comma)')
+            ->setName('kuma:generate:default-pageparts');
     }
 
     /**
@@ -53,7 +53,7 @@ EOT
      */
     protected function getWelcomeText()
     {
-	return 'Welcome to the Kunstmaan default pageparts generator';
+        return 'Welcome to the Kunstmaan default pageparts generator';
     }
 
     /**
@@ -61,35 +61,35 @@ EOT
      */
     protected function doExecute()
     {
-	$this->assistant->writeSection('Default PageParts generation');
+        $this->assistant->writeSection('Default PageParts generation');
 
-	$pagepartNames = array(
-	    'AbstractPagePart',
-	    'AudioPagePart',
-	    'ButtonPagePart',
-	    'DownloadPagePart',
-	    'HeaderPagePart',
-	    'ImagePagePart',
-	    'IntroTextPagePart',
-	    'LinePagePart',
-	    'LinkPagePart',
-	    'RawHtmlPagePart',
-	    'TextPagePart',
-	    'TocPagePart',
-	    'ToTopPagePart',
-	    'VideoPagePart',
-	);
+        $pagepartNames = array(
+            'AbstractPagePart',
+            'AudioPagePart',
+            'ButtonPagePart',
+            'DownloadPagePart',
+            'HeaderPagePart',
+            'ImagePagePart',
+            'IntroTextPagePart',
+            'LinePagePart',
+            'LinkPagePart',
+            'RawHtmlPagePart',
+            'TextPagePart',
+            'TocPagePart',
+            'ToTopPagePart',
+            'VideoPagePart',
+        );
 
-	foreach ($pagepartNames as $pagepartName) {
-	    $this->createGenerator()->generate($this->bundle, $pagepartName, $this->prefix, $this->sections, $this->behatTest);
-	}
+        foreach ($pagepartNames as $pagepartName) {
+            $this->createGenerator()->generate($this->bundle, $pagepartName, $this->prefix, $this->sections, $this->behatTest);
+        }
 
-	$this->assistant->writeSection('PageParts successfully created', 'bg=green;fg=black');
-	$this->assistant->writeLine(array(
-	    'Make sure you update your database first before you test the pagepart:',
-	    '    Directly update your database:          <comment>app/console doctrine:schema:update --force</comment>',
-	    '    Create a Doctrine migration and run it: <comment>app/console doctrine:migrations:diff && app/console doctrine:migrations:migrate</comment>')
-	);
+        $this->assistant->writeSection('PageParts successfully created', 'bg=green;fg=black');
+        $this->assistant->writeLine(array(
+                'Make sure you update your database first before you test the pagepart:',
+                '    Directly update your database:          <comment>app/console doctrine:schema:update --force</comment>',
+                '    Create a Doctrine migration and run it: <comment>app/console doctrine:migrations:diff && app/console doctrine:migrations:migrate</comment>')
+        );
     }
 
     /**
@@ -97,47 +97,47 @@ EOT
      */
     protected function doInteract()
     {
-	if (!$this->isBundleAvailable('KunstmaanPagePartBundle')) {
-	    $this->assistant->writeError('KunstmaanPagePartBundle not found', true);
-	}
+        if (!$this->isBundleAvailable('KunstmaanPagePartBundle')) {
+            $this->assistant->writeError('KunstmaanPagePartBundle not found', true);
+        }
 
-	$this->assistant->writeLine(array("This command helps you to generate a new pagepart.\n"));
+        $this->assistant->writeLine(array("This command helps you to generate a new pagepart.\n"));
 
-	/**
-	 * Ask for which bundle we need to create the pagepart
-	 */
-	$bundleNamespace = $this->assistant->getOptionOrDefault('namespace', null);
-	$this->bundle = $this->askForBundleName('pagepart', $bundleNamespace);
+        /**
+         * Ask for which bundle we need to create the pagepart
+         */
+        $bundleNamespace = $this->assistant->getOptionOrDefault('namespace', null);
+        $this->bundle = $this->askForBundleName('pagepart', $bundleNamespace);
 
-	/**
-	 * Ask the database table prefix
-	 */
-	$this->prefix = $this->askForPrefix(null, $this->bundle->getNamespace());
+        /**
+         * Ask the database table prefix
+         */
+        $this->prefix = $this->askForPrefix(null, $this->bundle->getNamespace());
 
-	/**
-	 * Ask for which page sections we should enable this pagepart
-	 */
-	$contexts = $this->assistant->getOptionOrDefault('contexts', null);
-	if ($contexts) {
-	    $contexts = explode(',', $contexts);
-	    array_walk($contexts, 'trim');
+        /**
+         * Ask for which page sections we should enable this pagepart
+         */
+        $contexts = $this->assistant->getOptionOrDefault('contexts', null);
+        if ($contexts) {
+            $contexts = explode(',', $contexts);
+            array_walk($contexts, 'trim');
 
-	    $this->sections = array();
-	    $allSections = $this->getAvailableSections($this->bundle);
-	    foreach ($allSections as $section) {
-		if (in_array($section['context'], $contexts)) {
-		    $this->sections[] = $section['file'];
-		}
-	    }
-	} else {
-	    $question = 'In which page section configuration file(s) do you want to add the pageparts (multiple possible, separated by comma)';
-	    $this->sections = $this->askForSections($question, $this->bundle, true);
-	}
+            $this->sections = array();
+            $allSections = $this->getAvailableSections($this->bundle);
+            foreach ($allSections as $section) {
+                if (in_array($section['context'], $contexts)) {
+                    $this->sections[] = $section['file'];
+                }
+            }
+        } else {
+            $question = 'In which page section configuration file(s) do you want to add the pageparts (multiple possible, separated by comma)';
+            $this->sections = $this->askForSections($question, $this->bundle, true);
+        }
 
-	/**
-	 * Check that we can create behat tests for the default pagepart
-	 */
-	$this->behatTest = (count($this->sections) > 0 && $this->canGenerateBehatTests($this->bundle));
+        /**
+         * Check that we can create behat tests for the default pagepart
+         */
+        $this->behatTest = (count($this->sections) > 0 && $this->canGenerateBehatTests($this->bundle));
     }
 
     /**
@@ -147,9 +147,9 @@ EOT
      */
     protected function createGenerator()
     {
-	$filesystem = $this->getContainer()->get('filesystem');
-	$registry = $this->getContainer()->get('doctrine');
+        $filesystem = $this->getContainer()->get('filesystem');
+        $registry = $this->getContainer()->get('doctrine');
 
-	return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer());
+        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer());
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -83,48 +83,49 @@ EOT
         $this->demosite = $this->assistant->getOption('demosite');
 
         // First we generate the layout if it is not yet generated
-	$command = $this->getApplication()->find('kuma:generate:layout');
-	$arguments = array(
-	    'command'      => 'kuma:generate:layout',
-	    '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
-	    '--demosite'   => $this->demosite,
-	    '--subcommand' => true
-	);
-	$input = new ArrayInput($arguments);
-	$command->run($input, $this->assistant->getOutput());
+        $command = $this->getApplication()->find('kuma:generate:layout');
+        $arguments = array(
+            'command'      => 'kuma:generate:layout',
+            '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
+            '--demosite'   => $this->demosite,
+            '--subcommand' => true
+        );
+        $input = new ArrayInput($arguments);
+        $command->run($input, $this->assistant->getOutput());
 
-	$rootDir = $this->getApplication()->getKernel()->getRootDir().'/../';
-	$this->createGenerator()->generate($this->bundle, $this->prefix, $rootDir, $this->demosite);
+        $rootDir = $this->getApplication()->getKernel()->getRootDir().'/../';
+        $this->createGenerator()->generate($this->bundle, $this->prefix, $rootDir, $this->demosite);
 
-	// Generate the default pageparts
-	$command = $this->getApplication()->find('kuma:generate:default-pageparts');
-	$arguments = array(
-	    'command'      => 'kuma:generate:default-pageparts',
-	    '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
-	    '--prefix'     => $this->prefix,
-	    '--contexts'   => 'main',
-	    '--quiet'      => true
-	);
-	$output = new ConsoleOutput(ConsoleOutput::VERBOSITY_QUIET);
-	$input = new ArrayInput($arguments);
-	$command->run($input, $output);
-	$this->assistant->writeLine('Generating default pageparts : <info>OK</info>');
 
-	if ($this->demosite) {
-	    // Generate a blog
-	    $command = $this->getApplication()->find('kuma:generate:article');
+        // Generate the default pageparts
+        $command = $this->getApplication()->find('kuma:generate:default-pageparts');
+        $arguments = array(
+            'command'      => 'kuma:generate:default-pageparts',
+            '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
+            '--prefix'     => $this->prefix,
+            '--contexts'   => 'main',
+            '--quiet'      => true
+        );
+        $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_QUIET);
+        $input = new ArrayInput($arguments);
+        $command->run($input, $output);
+        $this->assistant->writeLine('Generating default pageparts : <info>OK</info>');
+
+        if ($this->demosite) {
+            // Generate a blog
+            $command = $this->getApplication()->find('kuma:generate:article');
             $arguments = array(
-		'command'      => 'kuma:generate:article',
+                'command'      => 'kuma:generate:article',
                 '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
-		'--prefix'     => $this->prefix,
-		'--entity'     => 'Blog',
-		'--dummydata'  => true,
-		'--quiet'      => true
+                '--prefix'     => $this->prefix,
+                '--entity'     => 'Blog',
+                '--dummydata'  => true,
+                '--quiet'      => true
             );
-	    $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_QUIET);
+            $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_QUIET);
             $input = new ArrayInput($arguments);
-	    $command->run($input, $output);
-	    $this->assistant->writeLine('Generating blog : <info>OK</info>');
+            $command->run($input, $output);
+            $this->assistant->writeLine('Generating blog : <info>OK</info>');
         }
 
         $this->assistant->writeSection('Site successfully created', 'bg=green;fg=black');

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
@@ -7,13 +7,15 @@ use Sensio\Bundle\GeneratorBundle\Command\Validators;
 use Symfony\Component\Console\Input\ArrayInput;
 use Kunstmaan\GeneratorBundle\Generator\DoctrineEntityGenerator;
 use Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineCommand;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Doctrine\DBAL\Types\Type;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * GenerateEntityCommand
@@ -75,10 +77,11 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
+    $questionHelper = $this->getQuestionHelper();
 
         if ($input->isInteractive()) {
-            if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
+            $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
+            if (!$questionHelper->ask($input, $output, $confirmationQuestion)) {
                 $output->writeln('<error>Command aborted</error>');
 
                 return 1;
@@ -94,7 +97,7 @@ EOT
 
         $prefix = $input->getOption('prefix');
 
-        $dialog->writeSection($output, 'Entity generation');
+        $questionHelper->writeSection($output, 'Entity generation');
 
         $bundle = $this->getContainer()->get('kernel')->getBundle($bundleName);
 
@@ -114,7 +117,7 @@ EOT
             $command->run($input, $output);
         }
 
-        $dialog->writeGeneratorSummary($output, array());
+        $questionHelper->writeGeneratorSummary($output, array());
 
         $output->writeln(array(
                 'Make sure you update your database first before you test the pagepart:',
@@ -129,8 +132,8 @@ EOT
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Welcome to the Doctrine2 entity generator');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Welcome to the Doctrine2 entity generator');
 
         // namespace
         $output->writeln(array(
@@ -147,7 +150,10 @@ EOT
         $foundBundle = $bundle = $entity = null;
 
         while (true) {
-            $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'), $bundleNames);
+            $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getOption('entity')));
+            $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'));
+            $question->setAutocompleterValues($bundleNames);
+            $entity = $questionHelper->ask($input, $output, $question);
 
             list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
@@ -177,20 +183,22 @@ EOT
         }
         $input->setOption('entity', $bundle.':'.$entity);
 
-        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $dialog, $this->getApplication()->getKernel(), $this->getContainer());
+        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $questionHelper, $this->getApplication()->getKernel(), $this->getContainer());
         $inputAssistant->askForPrefix(null, $foundBundle->getNamespace());
 
         // fields
-        $input->setOption('fields', $this->addFields($input, $output, $dialog));
+        $input->setOption('fields', $this->addFields($input, $output, $questionHelper));
 
         // repository?
         $output->writeln('');
-        $withRepository = $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate an empty repository class', $input->getOption('with-repository') ? 'yes' : 'no', '?'), $input->getOption('with-repository'));
+        $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Do you want to generate an empty repository class', $input->getOption('with-repository') ? 'yes' : 'no', '?'), $input->getOption('with-repository'));
+        $withRepository = $questionHelper->ask($input, $output, $confirmationQuestion);
         $input->setOption('with-repository', $withRepository);
 
         // repository?
         $output->writeln('');
-        $withAdminList = $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate an AdminList for your entity', $input->getOption('with-adminlist') ? 'yes' : 'no', '?'), $input->getOption('with-adminlist'));
+        $confirmationQuestion = new ConfirmationQuestion($questionHelper->getQuestion('Do you want to generate an AdminList for your entity', $input->getOption('with-adminlist') ? 'yes' : 'no', '?'), $input->getOption('with-adminlist'));
+        $withAdminList = $questionHelper->ask($input, $output, $confirmationQuestion);
         $input->setOption('with-adminlist', $withAdminList);
 
         // summary
@@ -232,15 +240,15 @@ EOT
     }
 
     /**
-     * @param InputInterface  $input  The input
-     * @param OutputInterface $output The output
-     * @param DialogHelper    $dialog The dialog helper
+     * @param InputInterface  $input          The input
+     * @param OutputInterface $output         The output
+     * @param QuestionHelper  $questionHelper The question helper
      *
      * @throws \InvalidArgumentException
      *
      * @return array
      */
-    private function addFields(InputInterface $input, OutputInterface $output, DialogHelper $dialog)
+    private function addFields(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
     {
         $fields = $this->parseFields($input->getOption('fields'));
         $output->writeln(array(
@@ -296,7 +304,8 @@ EOT
             $output->writeln('');
             $self = $this;
             $generator = $this->getGenerator();
-            $columnName = $dialog->askAndValidate($output, $dialog->getQuestion('New field name (enter empty name to stop adding fields)', null), function ($name) use ($fields, $self, $generator) {
+            $question = new Question($questionHelper->getQuestion('New field name (enter empty name to stop adding fields)', null));
+            $question->setValidator(function ($name) use ($fields, $self, $generator) {
                 if (isset($fields[$name]) || 'id' == $name) {
                     throw new \InvalidArgumentException(sprintf('Field "%s" is already defined.', $name));
                 }
@@ -308,6 +317,7 @@ EOT
 
                 return $name;
             });
+            $columnName = $questionHelper->ask($input, $output, $question);
             if (!$columnName) {
                 break;
             }
@@ -327,12 +337,17 @@ EOT
 
             $columnName = DoctrineEntityGenerator::convertCamelCaseToSnakeCase($columnName);
 
-            $type = $dialog->askAndValidate($output, $dialog->getQuestion('Field type', $defaultType), $fieldValidator, false, $defaultType, $types);
+            $question = new Question($questionHelper->getQuestion('Field type', $defaultType), $defaultType);
+            $question->setAutocompleterValues($types);
+            $question->setValidator($fieldValidator);
+            $type = $questionHelper->ask($input, $output, $question);
 
             $data = array('columnName' => $columnName, 'fieldName' => lcfirst(Container::camelize($columnName)), 'type' => $type);
 
             if ($type == 'string') {
-                $data['length'] = $dialog->askAndValidate($output, $dialog->getQuestion('Field length', 255), $lengthValidator, false, 255);
+                $question = new Question($questionHelper->getQuestion('Field length', 255), 255);
+                $question->setValidator($lengthValidator);
+                $data['length'] = $questionHelper->ask($input, $output, $question);
             }
 
             $fields[$columnName] = $data;

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
@@ -33,7 +33,7 @@ EOT
             )
             ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace of the bundle where we need to create the layout in')
             ->addOption('subcommand', '', InputOption::VALUE_OPTIONAL, 'Whether the command is called from an other command or not')
-	    ->addOption('demosite', '', InputOption::VALUE_NONE, 'Pass this parameter when the demosite styles/javascipt should be generated')
+            ->addOption('demosite', '', InputOption::VALUE_NONE, 'Pass this parameter when the demosite styles/javascipt should be generated')
             ->setName('kuma:generate:layout');
     }
 
@@ -59,7 +59,7 @@ EOT
         }
 
         $rootDir = $this->getApplication()->getKernel()->getRootDir().'/../';
-	$this->createGenerator()->generate($this->bundle, $rootDir, $this->assistant->getOption('demosite'));
+        $this->createGenerator()->generate($this->bundle, $rootDir, $this->assistant->getOption('demosite'));
 
         if (!$this->isSubCommand()) {
             $this->assistant->writeSection('Layout successfully created', 'bg=green;fg=black');

--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
@@ -39,7 +39,7 @@ class GeneratePageCommand extends KunstmaanGenerateCommand
     /**
      * @var array
      */
-    private $sections;
+    private $sections = array();
 
     /**
      * @var array

--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
@@ -33,7 +33,7 @@ class GeneratePagePartCommand extends KunstmaanGenerateCommand
     /**
      * @var array
      */
-    private $sections;
+    private $sections = array();
 
     /**
      * @var bool
@@ -151,11 +151,11 @@ EOT
         foreach ($fields as $fieldInfo) {
             if($fieldInfo['type'] == 'image') {
                 $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'],
-                                  $fieldInfo['extra'], $fieldInfo['minHeight'], $fieldInfo['maxHeight'], $fieldInfo['minWidth'], $fieldInfo['maxWidth'], $fieldInfo['mimeTypes'], true);
-            } 
+                    $fieldInfo['extra'], $fieldInfo['minHeight'], $fieldInfo['maxHeight'], $fieldInfo['minWidth'], $fieldInfo['maxWidth'], $fieldInfo['mimeTypes'], true);
+            }
             elseif($fieldInfo['type'] == 'media') {
                 $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'],
-                        $fieldInfo['extra'], null, null, null, null, $fieldInfo['mimeTypes'], true);
+                    $fieldInfo['extra'], null, null, null, null, $fieldInfo['mimeTypes'], true);
             }
             else $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'], $fieldInfo['extra'], null, null, null, null, null, true);
         }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
@@ -55,8 +55,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Search Page Generation');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Search Page Generation');
 
         GeneratorUtils::ensureOptionsProvided($input, array('namespace'));
 
@@ -90,10 +90,10 @@ EOT
 
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Welcome to the SearchPage generator');
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Welcome to the SearchPage generator');
 
-        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $dialog, $this->getApplication()->getKernel(), $this->getContainer());
+        $inputAssistant = GeneratorUtils::getInputAssistant($input, $output, $questionHelper, $this->getApplication()->getKernel(), $this->getContainer());
 
         $inputAssistant->askForNamespace(array(
             '',

--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -61,7 +61,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
     {
         if (is_null($this->assistant)) {
             $this->assistant = new CommandAssistant();
-            $this->assistant->setDialog($this->getDialogHelper());
+            $this->assistant->setQuestionHelper($this->getQuestionHelper());
             $this->assistant->setKernel($this->getApplication()->getKernel());
         }
         $this->assistant->setOutput($output);
@@ -536,6 +536,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
 
                 }
             } else $data = array('name' => $fieldName, 'type' => $typeStrings[$typeId], 'extra' => $extra);
+
             $fields[$fieldName] = $data;
         }
 
@@ -590,6 +591,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
         return $types;
     }
 
+
     /**
      * Get all the entity fields for a specific type.
      *
@@ -598,9 +600,13 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
      * @param                 $prefix
      * @param                 $name
      * @param                 $type
-     * @param string|null     $extra
+     * @param null            $extra
+     * @param null            $minHeight
+     * @param null            $maxHeight
+     * @param null            $minWidth
+     * @param null            $maxWidth
+     * @param null            $mimeTypes
      * @param bool            $allNullable
-     *
      * @return array
      */
     protected function getEntityFields(
@@ -636,14 +642,14 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                     'nullable'  => $allNullable
                 );
                 break;
-        case 'wysiwyg':
-        $fields[$type][] = array(
-            'fieldName' => lcfirst(Container::camelize($name)),
-            'type'      => 'text',
-            'formType'  => 'wysiwyg',
-            'nullable'  => $allNullable
-        );
-        break;
+            case 'wysiwyg':
+                $fields[$type][] = array(
+                'fieldName' => lcfirst(Container::camelize($name)),
+                'type'      => 'text',
+                'formType'  => 'wysiwyg',
+                'nullable'  => $allNullable
+                );
+                break;
             case 'link':
                 foreach (array('url', 'text') as $subField) {
                     $fields[$type][$subField] = array(
@@ -885,11 +891,11 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
      */
     protected function canGenerateBehatTests(BundleInterface $bundle)
     {
-    $behatFile = dirname($this->getContainer()->getParameter('kernel.root_dir').'/') . '/behat.yml';
-    $pagePartContext = $bundle->getPath() . '/Features/Context/PagePartContext.php';
-    $behatTestPage = $bundle->getPath() . '/Entity/Pages/BehatTestPage.php';
+        $behatFile = dirname($this->getContainer()->getParameter('kernel.root_dir').'/') . '/behat.yml';
+        $pagePartContext = $bundle->getPath() . '/Features/Context/PagePartContext.php';
+        $behatTestPage = $bundle->getPath() . '/Entity/Pages/BehatTestPage.php';
 
-    // Make sure behat is configured and the PagePartContext and BehatTestPage exits
-    return (file_exists($behatFile) && file_exists($pagePartContext) && file_exists($behatTestPage));
+        // Make sure behat is configured and the PagePartContext and BehatTestPage exits
+        return (file_exists($behatFile) && file_exists($pagePartContext) && file_exists($behatTestPage));
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
@@ -26,10 +26,10 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
      */
     private $skeletonDir;
 
-    private $dialog;
+    private $questionHelper;
 
-    public function setDialog($dialog) {
-        $this->dialog = $dialog;
+    public function setQuestion($questionHelper) {
+	$this->questionHelper = $questionHelper;
     }
 
     /**
@@ -63,7 +63,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
                 $this->generateAdminType($bundle, $entityName, $metadata);
                 $output->writeln('Generating the Type code: <info>OK</info>');
             } catch (\Exception $error) {
-                $output->writeln($this->dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+		$output->writeln($this->questionHelper->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
                 $output->writeln('Generating the Type code: <error>ERROR</error>');
             }
         }
@@ -72,7 +72,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
             $this->generateConfiguration($bundle, $entityName, $metadata, $generateAdminType);
             $output->writeln('Generating the Configuration code: <info>OK</info>');
         } catch (\Exception $error) {
-            $output->writeln($this->dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+	    $output->writeln($this->questionHelper->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
             $output->writeln('Generating the Configuration code: <error>ERROR</error>');
         }
 
@@ -81,7 +81,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
             $this->generateController($bundle, $entityName, $metadata);
             $output->writeln('Generating the Controller code: <info>OK</info>');
         } catch (\Exception $error) {
-            $output->writeln($this->dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+	    $output->writeln($this->questionHelper->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
             $output->writeln('Generating the Controller code: <error>ERROR</error>');
         }
     }

--- a/src/Kunstmaan/GeneratorBundle/Helper/GeneratorUtils.php
+++ b/src/Kunstmaan/GeneratorBundle/Helper/GeneratorUtils.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Helper;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -163,14 +163,14 @@ class GeneratorUtils
      *
      * @param InputInterface     $input
      * @param OutputInterface    $output
-     * @param DialogHelper       $dialog
+     * @param QuestionHelper     $questionHelper
      * @param Kernel             $kernel
      * @param ContainerInterface $container
      *
      * @return InputAssistant
      */
-    public static function getInputAssistant(InputInterface &$input, OutputInterface $output, DialogHelper $dialog, Kernel $kernel, ContainerInterface $container)
+    public static function getInputAssistant(InputInterface &$input, OutputInterface $output, QuestionHelper $questionHelper, Kernel $kernel, ContainerInterface $container)
     {
-        return new InputAssistant($input, $output, $dialog, $kernel, $container);
+	return new InputAssistant($input, $output, $questionHelper, $kernel, $container);
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Helper/InputAssistant.php
+++ b/src/Kunstmaan/GeneratorBundle/Helper/InputAssistant.php
@@ -2,12 +2,13 @@
 
 namespace Kunstmaan\GeneratorBundle\Helper;
 
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sensio\Bundle\GeneratorBundle\Command\Validators;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * @deprecated the functions in this class should be moved to the KunstmaanGenerateCommand class.
@@ -20,8 +21,8 @@ class InputAssistant
     /** @var OutputInterface */
     private $output;
 
-    /** @var DialogHelper */
-    private $dialog;
+    /** @var QuestionHelper */
+    private $questionHelper;
 
     /** @var Kernel */
     private $kernel;
@@ -32,15 +33,15 @@ class InputAssistant
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @param DialogHelper $dialog
+     * @param QuestionHelper $questionHelper
      * @param Kernel $kernel
      * @param ContainerInterface $container
      */
-    public function __construct(InputInterface &$input, OutputInterface $output, DialogHelper $dialog, Kernel $kernel, ContainerInterface $container)
+    public function __construct(InputInterface &$input, OutputInterface $output, QuestionHelper $questionHelper, Kernel $kernel, ContainerInterface $container)
     {
         $this->input = $input;
         $this->output = $output;
-        $this->dialog = $dialog;
+	$this->questionHelper = $questionHelper;
         $this->kernel = $kernel;
         $this->container = $container;
     }
@@ -86,7 +87,10 @@ class InputAssistant
             $this->output->writeln($text);
         }
 
-        $namespace = $this->dialog->askAndValidate($this->output, $this->dialog->getQuestion('Bundle Namespace', $namespace), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleNamespace'), false, $namespace, $namespaces);
+	$question = new Question($this->questionHelper->getQuestion('Bundle Namespace', $namespace), $namespace);
+	$question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleNamespace'));
+	$question->setAutocompleterValues($namespaces);
+	$namespace = $this->questionHelper->ask($this->input, $this->output, $question);
 
         if ($this->input->hasOption('namespace')) {
             $this->input->setOption('namespace', $namespace);
@@ -103,7 +107,7 @@ class InputAssistant
      */
     private function writeError($message, $exit = false)
     {
-        $this->output->writeln($this->dialog->getHelperSet()->get('formatter')->formatBlock($message, 'error'));
+    $this->output->writeln($this->questionHelper->getHelperSet()->get('formatter')->formatBlock($message, 'error'));
         if ($exit) {
             exit;
         }
@@ -200,7 +204,8 @@ class InputAssistant
                 $namespace = $this->fixNamespace($namespace);
             }
             $defaultPrefix = GeneratorUtils::cleanPrefix($this->convertNamespaceToSnakeCase($namespace));
-            $prefix = $this->dialog->ask($this->output, $this->dialog->getQuestion('Tablename prefix', $defaultPrefix), $defaultPrefix);
+	    $question = new Question($this->questionHelper->getQuestion('Tablename prefix', $defaultPrefix), $defaultPrefix);
+	    $prefix = $this->questionHelper->ask($this->input, $this->output, $question);
             $prefix = GeneratorUtils::cleanPrefix($prefix);
             if ($this->input->hasOption('prefix')) {
                 $this->input->setOption('prefix', $prefix);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #71, #88 

This feature replaces all calls to DialogHelper with QuestionHelper in the GeneratorBundle since the DialogHelper is deprecated since Symfony 2.5 .