### PR TITLE
[SeoBundle] Robots in plain text with extra info and preview button

### DIFF
--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\SeoBundle\Controller\Admin;
+namespace Kunstmaan\SeoBundle\Controller;
 
 use Kunstmaan\SeoBundle\Entity\Robots;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -13,7 +13,7 @@ class RobotsController extends Controller
     /**
      * Generates the robots.txt content when available in the database and falls back to normal robots.txt if exists
      *
-     * @Route(path="/robots.txt", name="KunstmaanSeoBundle_robots")
+     * @Route(path="/robots.txt", name="KunstmaanSeoBundle_robots", defaults={"_format": "txt"})
      * @Template(template="@KunstmaanSeo/Admin/Robots/index.html.twig")
      * @param Request $request
      *

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,10 @@
+# Media
+seo:
+    robots:
+        tip: Tip:
+        moreinfo: Meer info over de Kunstmaan robots.txt is te vinden in ons
+
+    action:
+        save: Save
+        cancel: Cancel
+        preview: Preview

--- a/src/Kunstmaan/SeoBundle/Resources/views/Admin/Robots/index.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/Admin/Robots/index.html.twig
@@ -1,1 +1,1 @@
-{{ robots | nl2br }}
+{{ robots }}

--- a/src/Kunstmaan/SeoBundle/Resources/views/Admin/Settings/robotsSettings.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/Admin/Settings/robotsSettings.html.twig
@@ -22,10 +22,13 @@
                         <div class="btn-group">
                             {% block actions %}
                                 <button type="submit" class="btn btn-primary btn--raise-on-hover">
-                                    {{ 'form.save' | trans }}
+                                    {{ 'seo.action.save' | trans }}
                                 </button>
                                 <a href="{{ path('KunstmaanSeoBundle_settings_robots') }}" class="btn btn-default btn--raise-on-hover">
-                                    {{ 'form.cancel' | trans }}
+                                    {{ 'seo.action.cancel' | trans }}
+                                </a>
+                                <a class="btn btn-default btn--raise-on-hover" href="/robots.txt">
+                                    {{ 'seo.action.preview' | trans }}
                                 </a>
                             {% endblock %}
                         </div>
@@ -50,5 +53,7 @@
         </fieldset>
 
     </form>
+
+    <strong>{{ 'seo.robots.tip' |trans }}</strong> {{ 'seo.robots.moreinfo' |trans }} <a href="http://bundles.kunstmaan.be/documentation/cookbook" target="_blank">cookbook</a>
 
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

- Changed the header content type to plain/text for the robot.txt route.
- Added a preview button
- Added a link to the cookbook for additional information