### PR TITLE
[GeneratorBundle] Validate entity names and database prefixes in the generators

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
@@ -118,6 +118,8 @@ EOT
             $entityValidation = function ($entity) {
                 if (empty($entity)) {
                     throw new \RuntimeException('You have to provide a entity name!');
+		        } elseif (!preg_match('/^[a-zA-Z][a-zA-Z_0-9]+$/', $entity)) {
+		            throw new \InvalidArgumentException(sprintf("%s".' contains invalid characters', $entity));
                 } else {
                     return $entity;
                 }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
@@ -151,6 +151,12 @@ EOT
 
             list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
+            // check entity name
+            if(!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $entity)) {
+                $output->writeln(sprintf('<bg=red> "%s" is not a valid entity name.</>', $entity));
+                continue;
+            }
+
             // check reserved words
             if ($this->getGenerator()->isReservedKeyword($entity)) {
                 $output->writeln(sprintf('<bg=red> "%s" is a reserved word</>.', $entity));

--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -147,7 +147,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
             );
         }
 
-        if (is_null($prefix)) {
+        while (is_null($prefix)) {
             if (count($text) > 0) {
                 $this->assistant->writeLine($text);
             }
@@ -159,6 +159,18 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
             }
             $defaultPrefix = GeneratorUtils::cleanPrefix($this->convertNamespaceToSnakeCase($namespace));
             $prefix        = GeneratorUtils::cleanPrefix($this->assistant->ask('Tablename prefix', $defaultPrefix));
+
+            if($prefix == '') {
+                break;
+            }
+
+            $output = $this->assistant->getOutput();
+            if(!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $prefix)) {
+                $output->writeln(sprintf('<bg=red> "%s" contains invalid characters</>', $prefix));
+                $prefix = $text = null;
+                continue;
+            }
+
             $this->assistant->setOption('prefix', $prefix);
         }
 
@@ -480,46 +492,46 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
             }
            
             if ($typeStrings[$typeId] == 'image' || $typeStrings[$typeId] == 'media') {
-            	
-            	// Ask the allowed mimetypes for the media ojbect
-				$mimeTypes = $this->assistant->ask ('Do you want to limit the possible file types? Then specify a comma-seperated list of types (example: image/png,image/svg+xml), otherwise press ENTER', null);
-				if(isset($mimeTypes)) {
-					$mimeTypes = explode(',', $mimeTypes);
-				}
-				$data = array (
-						'name' => $fieldName,
-						'type' => $typeStrings [$typeId],
-						'extra' => $extra,
-						'mimeTypes' => $mimeTypes,
-				);
-				
-				if ($typeStrings [$typeId] == 'image') {
-	
-					// Ask the minimum height allowed for the image
-					$lengthValidation = function ($length) {
-						if (empty ( $length ) || ! is_numeric ( $length ) || $length < 0) {
-							throw new \InvalidArgumentException ( sprintf ( '"%s" is not a valid length', $length ) );
-						} else {
-							return $length;
-						}
-					};
-					$minHeight = $this->assistant->askAndValidate ( 'What is the minimum height for the media object? (in pixels)', $lengthValidation);
-					
-					// Ask the maximum height allowed for the image
-					$maxHeight = $this->assistant->askAndValidate ( 'What is the maximum height for the media object? (in pixels)', $lengthValidation);
-					
-					// Ask the minimum width allowed for the image
-					$minWidth = $this->assistant->askAndValidate ( 'What is the minimum width for the media object? (in pixels)', $lengthValidation);
-            			 
-            		//Ask the maximum width allowed for the image
-            		$maxWidth = $this->assistant->askAndValidate('What is the maximum width for the media object? (in pixels)', $lengthValidation);
-            		
-            		$data = array('name' => $fieldName, 'type' => $typeStrings[$typeId], 'extra' => $extra, 
-            				'minHeight' => $minHeight, 'maxHeight' => $maxHeight, 'minWidth' => $minWidth, 'maxWidth' => $maxWidth, 'mimeTypes' => $mimeTypes);
-            		}
-            		
+
+                // Ask the allowed mimetypes for the media ojbect
+                $mimeTypes = $this->assistant->ask ('Do you want to limit the possible file types? Then specify a comma-seperated list of types (example: image/png,image/svg+xml), otherwise press ENTER', null);
+                if(isset($mimeTypes)) {
+                    $mimeTypes = explode(',', $mimeTypes);
+                }
+                $data = array (
+                        'name' => $fieldName,
+                        'type' => $typeStrings [$typeId],
+                        'extra' => $extra,
+                        'mimeTypes' => $mimeTypes,
+                );
+
+                if ($typeStrings [$typeId] == 'image') {
+
+                    // Ask the minimum height allowed for the image
+                    $lengthValidation = function ($length) {
+                        if (empty ( $length ) || ! is_numeric ( $length ) || $length < 0) {
+                            throw new \InvalidArgumentException ( sprintf ( '"%s" is not a valid length', $length ) );
+                        } else {
+                            return $length;
+                        }
+                    };
+                    $minHeight = $this->assistant->askAndValidate ( 'What is the minimum height for the media object? (in pixels)', $lengthValidation);
+
+                    // Ask the maximum height allowed for the image
+                    $maxHeight = $this->assistant->askAndValidate ( 'What is the maximum height for the media object? (in pixels)', $lengthValidation);
+
+                    // Ask the minimum width allowed for the image
+                    $minWidth = $this->assistant->askAndValidate ( 'What is the minimum width for the media object? (in pixels)', $lengthValidation);
+
+                    //Ask the maximum width allowed for the image
+                    $maxWidth = $this->assistant->askAndValidate('What is the maximum width for the media object? (in pixels)', $lengthValidation);
+
+                    $data = array('name' => $fieldName, 'type' => $typeStrings[$typeId], 'extra' => $extra,
+                            'minHeight' => $minHeight, 'maxHeight' => $maxHeight, 'minWidth' => $minWidth, 'maxWidth' => $maxWidth, 'mimeTypes' => $mimeTypes);
+                    }
+
             } else $data = array('name' => $fieldName, 'type' => $typeStrings[$typeId], 'extra' => $extra);
-			
+
             $fields[$fieldName] = $data;
         }
 
@@ -540,7 +552,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
         $types             = array();
         $types[$counter++] = $niceNames ? 'Single line text' : 'single_line';
         $types[$counter++] = $niceNames ? 'Multi line text' : 'multi_line';
-	$types[$counter++] = $niceNames ? 'Wysiwyg' : 'wysiwyg';
+    $types[$counter++] = $niceNames ? 'Wysiwyg' : 'wysiwyg';
         $types[$counter++] = $niceNames ? 'Link (url, text, new window)' : 'link';
         if ($this->isBundleAvailable('KunstmaanMediaPagePartBundle')) {
             $types[$counter++] = $niceNames ? 'Image (media, alt text)' : 'image';
@@ -594,11 +606,11 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
         $name,
         $type,
         $extra = null,
-    	$minHeight = null,
-    	$maxHeight = null,
-    	$minWidth = null,
-    	$maxWidth = null,
-    	$mimeTypes = null,
+        $minHeight = null,
+        $maxHeight = null,
+        $minWidth = null,
+        $maxWidth = null,
+        $mimeTypes = null,
         $allNullable = false
     ) {
         $fields = array();
@@ -620,14 +632,14 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                     'nullable'  => $allNullable
                 );
                 break;
-	    case 'wysiwyg':
-		$fields[$type][] = array(
-		    'fieldName' => lcfirst(Container::camelize($name)),
-		    'type'      => 'text',
-		    'formType'  => 'wysiwyg',
-		    'nullable'  => $allNullable
-		);
-		break;
+        case 'wysiwyg':
+        $fields[$type][] = array(
+            'fieldName' => lcfirst(Container::camelize($name)),
+            'type'      => 'text',
+            'formType'  => 'wysiwyg',
+            'nullable'  => $allNullable
+        );
+        break;
             case 'link':
                 foreach (array('url', 'text') as $subField) {
                     $fields[$type][$subField] = array(
@@ -869,11 +881,11 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
      */
     protected function canGenerateBehatTests(BundleInterface $bundle)
     {
-	$behatFile = dirname($this->getContainer()->getParameter('kernel.root_dir').'/') . '/behat.yml';
-	$pagePartContext = $bundle->getPath() . '/Features/Context/PagePartContext.php';
-	$behatTestPage = $bundle->getPath() . '/Entity/Pages/BehatTestPage.php';
+    $behatFile = dirname($this->getContainer()->getParameter('kernel.root_dir').'/') . '/behat.yml';
+    $pagePartContext = $bundle->getPath() . '/Features/Context/PagePartContext.php';
+    $behatTestPage = $bundle->getPath() . '/Entity/Pages/BehatTestPage.php';
 
-	// Make sure behat is configured and the PagePartContext and BehatTestPage exits
-	return (file_exists($behatFile) && file_exists($pagePartContext) && file_exists($behatTestPage));
+    // Make sure behat is configured and the PagePartContext and BehatTestPage exits
+    return (file_exists($behatFile) && file_exists($pagePartContext) && file_exists($behatTestPage));
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Helper/InputAssistant.php
+++ b/src/Kunstmaan/GeneratorBundle/Helper/InputAssistant.php
@@ -189,7 +189,7 @@ class InputAssistant
             );
         }
 
-        if (is_null($prefix)) {
+        while (is_null($prefix)) {
             if (count($text) > 0) {
                 $this->output->writeln($text);
             }
@@ -204,6 +204,16 @@ class InputAssistant
             $prefix = GeneratorUtils::cleanPrefix($prefix);
             if ($this->input->hasOption('prefix')) {
                 $this->input->setOption('prefix', $prefix);
+            }
+
+            if($prefix == '') {
+                break;
+            }
+
+            if(!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $prefix)) {
+                $this->output->writeln(sprintf('<bg=red> "%s" contains invalid characters</>', $prefix));
+                $prefix = $text = null;
+                continue;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #184 

You no longer can create entities with names that cause errors and database prefixes are now validated on creation. 