### PR TITLE
[KunstmaanBundlesCMS] [MediaBundle] Fix single slash in media path

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -219,7 +219,7 @@ class FileHandler extends AbstractMediaHandler
         }
 
         return sprintf(
-            '/%s/%s',
+            '%s/%s',
             $media->getUuid(),
             $filename
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #309 

Media url path does not contain double slashes anymore.