### PR TITLE
[SitemapBundle] Make use of a sitemapindex and sub sitemaps

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -1,0 +1,16 @@
+# UPGRADE FROM 3.1 to 3.2
+
+## Manual upgrade needed in app/routes to refactor sitemaps
+
+### WHAT
+This feature generates one central sitemap.xml file at your document root to define a sub sitemap for each language available.
+You can now have up to 50000 urls for each language you define.
+As a bonus, you only have to register the sitemap index (/sitemap.xml) at the search engines to register all available languages.
+
+### HOW
+In order to upgrade, you need a new route in your app/config/routes.yml.
+```yml
+KunstmaanSitemapBundle_sitemapIndex:
+    resource: "@KunstmaanSitemapBundle/Controller/SitemapController.php"
+    type:     annotation
+```

--- a/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
+++ b/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
@@ -7,28 +7,54 @@ use Kunstmaan\NodeBundle\Helper\NodeMenu;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 class SitemapController extends Controller
 {
     /**
-     * Use the mode parameter to select in which mode the sitemap should be generated. At this moment only XML is supported
+     * This will generate a sitemap for the specified locale.
+     * Use the mode parameter to select in which mode the sitemap should be generated.
+     * At this moment only XML is supported
      *
-     * @Route("/sitemap.{_format}", name="KunstmaanSitemapBundle_sitemap", requirements={"_format" = "xml"})
+     * @Route("/sitemap-{locale}.{_format}", name="KunstmaanSitemapBundle_sitemap", requirements={"_format" = "xml"})
      * @Template("KunstmaanSitemapBundle:Sitemap:view.xml.twig")
      *
+     * @param $locale
      * @return array
      */
-    public function sitemapAction()
+    public function sitemapAction($locale)
     {
         $em = $this->getDoctrine()->getManager();
-        $locale = $this->getRequest()->getLocale();
-        $securityContext = $this->container->get('security.context');
-        $aclHelper = $this->container->get('kunstmaan_admin.acl.helper');
+	$securityContext = $this->get('security.context');
+	$aclHelper = $this->get('kunstmaan_admin.acl.helper');
         $nodeMenu = new NodeMenu($em, $securityContext, $aclHelper, $locale, null, PermissionMap::PERMISSION_VIEW, false, true);
 
         return array(
             'nodemenu' => $nodeMenu,
         );
+    }
+
+    /**
+     * This will generate a sitemap index file to define a sub sitemap for each language.
+     * Info at: https://support.google.com/webmasters/answer/75712?rd=1
+     * Use the mode parameter to select in which mode the sitemap should be generated.
+     * At this moment only XML is supported
+     *
+     * @Route("/sitemap.{_format}", name="KunstmaanSitemapBundle_sitemapindex", requirements={"_format" = "xml"})
+     * @Template("KunstmaanSitemapBundle:SitemapIndex:view.xml.twig")
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function sitemapIndexAction(Request $request)
+    {
+	$requiredLocales = $this->container->getParameter('requiredlocales');
+	$locales = explode("|", $requiredLocales);
+
+	return array(
+	    'locales' => $locales,
+	    'host' => $request->getSchemeAndHttpHost()
+	);
     }
 
 }

--- a/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
+++ b/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for locale in locales %}
+	<sitemap>
+	    <loc>{{ host }}/sitemap-{{ locale }}.xml</loc>
+	</sitemap>
+    {% endfor %}
+</sitemapindex>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #4

WHAT
This feature generates one central sitemap.xml file at your document root to define a sub sitemap for each language available.
You can now have up to 50000 urls for each language you define.
As a bonus, you only have to register the sitemap index (/sitemap.xml) at the search engines to register all available languages.

HOW
In order to upgrade, you need a new route in your app/config/routes.yml.
```yml
KunstmaanSitemapBundle_sitemapIndex:
    resource: "@KunstmaanSitemapBundle/Controller/SitemapController.php"
    type:     annotation
```

TODO
- [ ] add a note in UPGRADE-3.2.md file