### PR TITLE
[AdminBundle, AdminListBundle] Add an admin page title when the adminlist is not included in the menu + make it possible to override the admin page title + fix action button position when there is no admin page title

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -99,13 +99,15 @@
                     {% block header %}
                         <header class="app__content__header">
                             <div class="row">
-                                {% if adminmenu.current %}
+                                {% block admin_page_title %}
                                     <div class="col-sm-6 col-md-8">
-                                        <h1 class="app__content__header__title">
-                                            {{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}
-                                        </h1>
+                                        {% if adminmenu.current %}
+                                            <h1 class="app__content__header__title">
+                                                {{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}
+                                            </h1>
+                                        {% endif %}
                                     </div>
-                                {% endif %}
+                                {% endblock %}
 
                                 {% block extra_actions_header %}{% endblock %}
                             </div>

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
@@ -1,5 +1,17 @@
 {% extends 'KunstmaanAdminBundle:Default:layout.html.twig' %}
 
+{% block admin_page_title %}
+    <div class="col-sm-6 col-md-8">
+        <h1 class="app__content__header__title">
+            {% if adminmenu.current %}
+                {{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}
+            {% else %}
+                {{ adminlist.configurator.getEntityName() }}
+            {% endif %}
+        </h1>
+    </div>
+{% endblock %}
+
 {% block extra_actions_header %}
     {% if adminlist.canAdd() or adminlist.canExport() %}
         <div class="col-sm-6 col-md-4">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | []

This PR fixes these issues:
* When there was no admin page title, the action buttons (from the right top) where moved to the center of the page
* When an adminlist was not added to the `Modules` menu, no title was shown 
* Make it possible to overwrite the admin page title without duplicating the `extra_actions_header` block