### PR TITLE
[SeoBundle] Remove the required option from the Open Graph Image field in the social tab

### DIFF
--- a/src/Kunstmaan/SeoBundle/Form/SocialType.php
+++ b/src/Kunstmaan/SeoBundle/Form/SocialType.php
@@ -22,9 +22,7 @@ class SocialType extends AbstractType
             ->add('ogType', null, array('label' => 'OG type'))
             ->add('ogTitle', null, array('label' => 'OG title'))
             ->add('ogDescription', null, array('label' => 'OG description'))
-            ->add('ogImage', 'media', array(
-                  'mediatype' => 'image',
-                  'label' => 'OG image'))
+            ->add('ogImage', 'media', array('mediatype' => 'image', 'label' => 'OG image', 'required' => false))
             ->add('ogUrl', null, array('label' => 'OG Url'))
             ->add('linkedInRecommendLink', "text", array("required" => false, 'label' => 'LinkedIn Recommend Link'))
             ->add('linkedInRecommendProductID', "text", array("required" => false, 'label' => 'LinkedIn Product ID'));


### PR DESCRIPTION
This fix will make the OG image not required.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #336