### PR TITLE
[SeoBundle] Suggest a default value in the robots.txt field when empty

### DIFF
--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -15,6 +15,23 @@ use Symfony\Component\HttpFoundation\Request;
 class SettingsController extends BaseSettingsController
 {
     /**
+     * @var string the default value of the robots.txt file
+     */
+    private $default;
+
+    /**
+     * Get the defaults value and show a warning
+     */
+    private function getDefaults()
+    {
+        $this->default = $this->container->getParameter('robots_default');
+        $warning = $this->get('translator')->trans('seo.robots.warning');
+        $this->get('session')->getFlashBag()->add('warning', $warning);
+    }
+
+    /**
+     * Generates the robots administration form and fills it with a default value if needed.
+     *
      * @Route(path="/", name="KunstmaanSeoBundle_settings_robots")
      * @Template(template="@KunstmaanSeo/Admin/Settings/robotsSettings.html.twig")
      * @param Request $request
@@ -24,44 +41,35 @@ class SettingsController extends BaseSettingsController
     {
         $this->checkPermission();
 
-        $em     = $this->getDoctrine()->getManager();
-        $repo   = $this->getDoctrine()->getRepository("KunstmaanSeoBundle:Robots");
-        $default = $repo->findOneBy(array())->getRobotsTxt();
+        $em = $this->getDoctrine()->getManager();
+        $repo = $this->getDoctrine()->getRepository("KunstmaanSeoBundle:Robots");
+        $robot = $repo->findOneBy(array());
 
-        $settings = $repo->findOneBy(array());
-        if (is_null($settings)) {
-            $settings = new Robots();
+        if (!$robot) {
+            $robot = new Robots();
+            $this->getDefaults();
+        } else {
+            if($robot->getRobotsTxt() == NULL) {
+                $this->getDefaults();
+            } else {
+                $this->default = $robot->getRobotsTxt();
+            }
         }
 
-
-        if (!$default)
-        {
-            $default = "
-# Warning: This is a default value and example.
-# No custom robots.txt has been defined.
-# Adjust and save these values
-# or place a robots.txt file in your document root.
-
-User-agent: *
-            ";
-        }
-
-        $form = $this->createForm(new RobotsType($default), $settings);
+        $form = $this->createForm(new RobotsType($this->default), $robot);
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
             if ($form->isValid()) {
 
-                $em->persist($settings);
+                $em->persist($robot);
                 $em->flush();
-
-                $this->get('session')->getFlashBag()->add('success', 'Robots.txt has been saved');
 
                 return new RedirectResponse($this->generateUrl('KunstmaanSeoBundle_settings_robots'));
             }
         }
 
         return array(
-            'form'  => $form->createView(),
+            'form' => $form->createView(),
         );
     }
 }

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -26,13 +26,27 @@ class SettingsController extends BaseSettingsController
 
         $em     = $this->getDoctrine()->getManager();
         $repo   = $this->getDoctrine()->getRepository("KunstmaanSeoBundle:Robots");
+        $default = $repo->findOneBy(array())->getRobotsTxt();
 
         $settings = $repo->findOneBy(array());
         if (is_null($settings)) {
             $settings = new Robots();
         }
 
-        $form = $this->createForm(new RobotsType(), $settings);
+
+        if (!$default)
+        {
+            $default = "
+# Warning: This is a default value and example.
+# No custom robots.txt has been defined.
+# Adjust and save these values
+# or place a robots.txt file in your document root.
+
+User-agent: *
+            ";
+        }
+
+        $form = $this->createForm(new RobotsType($default), $settings);
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
             if ($form->isValid()) {

--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -22,7 +22,14 @@ class RobotsController extends Controller
     public function indexAction(Request $request)
     {
         $entity = $this->get('doctrine')->getRepository('KunstmaanSeoBundle:Robots')->findOneBy(array());
-        $robots = "# Warning: No real robots.txt file has been found.\n# Create a robots.txt file in your document root to modify this content\nUser-agent: *";
+        $robots = "
+# Warning: This is a default value and example.
+# No custom robots.txt has been defined.
+# Adjust this file in the admin panel
+# or place a robots.txt file in your document root.
+
+User-agent: *
+            ";
 
         if ($entity and $entity->getRobotsTxt()) {
             $robots = $entity->getRobotsTxt();

--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -22,14 +22,7 @@ class RobotsController extends Controller
     public function indexAction(Request $request)
     {
         $entity = $this->get('doctrine')->getRepository('KunstmaanSeoBundle:Robots')->findOneBy(array());
-        $robots = "
-# Warning: This is a default value and example.
-# No custom robots.txt has been defined.
-# Adjust this file in the admin panel
-# or place a robots.txt file in your document root.
-
-User-agent: *
-            ";
+        $robots = $this->container->getParameter('robots_default');
 
         if ($entity and $entity->getRobotsTxt()) {
             $robots = $entity->getRobotsTxt();

--- a/src/Kunstmaan/SeoBundle/Form/RobotsType.php
+++ b/src/Kunstmaan/SeoBundle/Form/RobotsType.php
@@ -11,6 +11,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class RobotsType extends AbstractType
 {
+
+    private $default;
+
+    function __construct($default = null) {
+        $this->default = $default;
+    }
+
     /**
      * @param FormBuilderInterface $builder
      * @param array                $options
@@ -19,6 +26,7 @@ class RobotsType extends AbstractType
     {
         $builder->add('robotsTxt', 'textarea', array(
             'label' => 'robots.txt',
+            'data' => $this->default,
             'attr' => array(
                 'rows' => 15
             )

--- a/src/Kunstmaan/SeoBundle/Resources/config/parameters.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/parameters.yml
@@ -1,2 +1,3 @@
 parameters:
   google.analytics.account_id: ''
+  robots_default: User-agent: *

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
@@ -2,7 +2,7 @@
 seo:
     robots:
         tip: Tip:
-        moreinfo: Meer info over de Kunstmaan robots.txt is te vinden in ons
+        moreinfo: You can find more information about the Kunstmaan robots.txt at our
 
     action:
         save: Save

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
@@ -2,6 +2,7 @@
 seo:
     robots:
         tip: Tip:
+        warning: This is a default value and example, no custom robots.txt has been defined.
         moreinfo: You can find more information about the Kunstmaan robots.txt at our
 
     action:


### PR DESCRIPTION
This is a upgrade for the robots.txt. It warns you that no robots.txt has been defined and makes a default suggestion.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /