### PR TITLE
[AdminBundle, UserManagmentBundle, AdminListBundle] Added seperate event to add tabs to admin forms and user forms

### DIFF
--- a/src/Kunstmaan/AdminBundle/Event/AdaptSimpleFormEvent.php
+++ b/src/Kunstmaan/AdminBundle/Event/AdaptSimpleFormEvent.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Event;
+
+use Kunstmaan\AdminBundle\Entity\User;
+use Kunstmaan\AdminBundle\Form\UserType;
+use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\TabPane;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class AdaptSimpleFormEvent
+ * @package Kunstmaan\AdminBundle\Event
+ */
+class AdaptSimpleFormEvent extends Event
+{
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var AbstractType
+     */
+    protected $formType;
+
+    /**
+     * @var TabPane
+     */
+    protected $tabPane;
+
+    /**
+     * @var
+     */
+    protected $data;
+
+    /**
+     * @param Request $request
+     * @param AbstractType $formType
+     * @param $data
+     */
+    public function __construct(Request $request , AbstractType $formType , $data)
+    {
+        $this->request = $request;
+        $this->formType = $formType;
+        $this->data = $data;
+    }
+
+    /**
+     * @return TabPane
+     */
+    public function getTabPane()
+    {
+        return $this->tabPane;
+    }
+
+    /**
+     * @param TabPane $tabPane
+     */
+    public function setTabPane(TabPane $tabPane)
+    {
+        $this->tabPane = $tabPane;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param Request $request
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return AbstractType
+     */
+    public function getFormType()
+    {
+        return $this->formType;
+    }
+
+    /**
+     * @param AbstractType $type
+     */
+    public function setFormType(AbstractType $type)
+    {
+        $this->formType = $type;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param $data
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Event/Events.php
+++ b/src/Kunstmaan/AdminBundle/Event/Events.php
@@ -22,4 +22,12 @@ class Events
      * @var string
      */
     const POST_DEEP_CLONE_AND_SAVE = 'kunstmaan_admin.postDeepCloneAndSave';
+
+    /**
+     * The adapt_simple_form event occurs after a simple form is created, here it's possible to add a tabPane to a form without
+     * the need for the form to be connected to a node
+     *
+     * @var string
+     */
+    const ADAPT_SIMPLE_FORM = 'kunstmaan_admin.adaptSimpleForm';
 }

--- a/src/Kunstmaan/AdminBundle/Form/UserType.php
+++ b/src/Kunstmaan/AdminBundle/Form/UserType.php
@@ -84,8 +84,7 @@ class UserType extends AbstractType implements RoleDependentUserFormInterface
                             'multiple' => true,
                             'expanded' => false,
                             'required' => false,
-                            'attr' => array(
-				'class' => 'js-advanced-select form-control advanced-select',
+                            'attr' => array('class' => 'js-advanced-select form-control advanced-select',
                                 'data-placeholder' => 'Choose the permission groups...'
                             )
                         )
@@ -106,8 +105,10 @@ class UserType extends AbstractType implements RoleDependentUserFormInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array('password_required' => false));
+        $resolver->setDefaults(
+        array('password_required' => false,
+            'data_class' => 'Kunstmaan\AdminBundle\Entity\User',
+        ));
         $resolver->addAllowedValues(array('password_required' => array(true, false)));
     }
-
 }

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -3,6 +3,8 @@
 namespace Kunstmaan\AdminListBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Event\AdaptSimpleFormEvent;
+use Kunstmaan\AdminBundle\Event\Events;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractAdminListConfigurator;
 use Symfony\Component\HttpFoundation\Request;
@@ -162,11 +164,22 @@ abstract class AdminListController extends Controller
         if (!$configurator->canEdit($helper)) {
             throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
         }
+        $formType = $configurator->getAdminType($helper);
 
-        $form = $this->createForm($configurator->getAdminType($helper), $helper);
+        $event = new AdaptSimpleFormEvent($request, $formType, $helper);
+        $event = $this->container->get('event_dispatcher')->dispatch(Events::ADAPT_SIMPLE_FORM , $event);
+        $tabPane = $event->getTabPane();
+
+        $form = $this->createForm($formType , $helper);
 
         if ($request->isMethod('POST')) {
-            $form->submit($request);
+            if($tabPane){
+                $tabPane->bindRequest($request);
+                $form = $tabPane->getForm();
+            } else {
+                $form->submit($request);
+            }
+
             if ($form->isValid()) {
                 $em->persist($helper);
                 $em->flush();
@@ -180,10 +193,15 @@ abstract class AdminListController extends Controller
 
         $configurator->buildItemActions();
 
+    $params =  array('form' => $form->createView(), 'entity' => $helper, 'adminlistconfigurator' => $configurator);
+
+    if($tabPane) {
+        $params = array_merge($params, array('tabPane' => $tabPane));
+    }
+
         return new Response(
             $this->renderView(
-                $configurator->getEditTemplate(),
-                array('form' => $form->createView(), 'entity' => $helper, 'adminlistconfigurator' => $configurator)
+            $configurator->getEditTemplate(), $params
             )
         );
     }

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
@@ -46,7 +46,11 @@
         <!-- Fields -->
         <fieldset class="form__fieldset--padded">
             {% block form_content %}
-                {{ form_widget(form) }}
+		{% if tabPane is defined %}
+		    {{ tabs_widget(tabPane) }}
+		{% else %}
+		    {{ form_rest(form) }}
+		{% endif %}
             {% endblock %}
         </fieldset>
     </form>

--- a/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
+++ b/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
@@ -45,8 +45,14 @@
         </div>
 
         <!-- Fields -->
+
+
         <fieldset class="form__fieldset--padded">
-            {{ form_rest(form) }}
+            {% if tabPane is defined %}
+                {{ tabs_widget(tabPane) }}
+            {% else %}
+                {{ form_rest(form) }}
+            {% endif %}
         </fieldset>
     </form>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #74 

In order to add tabs to admin and user forms, just write a listener that listens for the kunstmaan_admin.adaptSimpleForm Event and implements a method that creates a new TabPane and adds a FormWidget to the event.


    public function onAdaptSimpleFormEvent(AdaptSimpleFormEvent $event)
    {
        $tabPane = new TabPane('TabPane', $event->getRequest(), $this->formFactory);

        $widget = new FormWidget();
        $widget->addType('Tab',$event->getFormType(),$event->getData());
        
        $tabPane->addTab(new Tab('User', $widget));
        $tabPane->buildForm();

        $event->setTabPane($tabPane);
    }


