### PR TITLE
[GeneratorBundle] Use real bundle name if it’s not the same as the namespace

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -101,7 +101,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
 
         foreach ($finder as $file) {
             $bundles[$counter++] = array(
-                'name'      => str_replace(DIRECTORY_SEPARATOR, '', $file->getRelativePath()),
+                'name'      => basename($file->getFilename(), '.php'),
                 'namespace' => $file->getRelativePath(),
                 'dir'       => $file->getPath()
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A 

A bundle may have it’s own name, not composed of it’s namespace. 