### PR TITLE
[GeneratorBundle] Add missing entity namespace folder in the AudioPagePartAdminType

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/AudioPagePart/AudioPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/AudioPagePart/AudioPagePartAdminType.php
@@ -49,7 +49,7 @@ class {{ pagepart }}AdminType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
 	$resolver->setDefaults(array(
-	    'data_class' => '{{ namespace }}\Entity\{{ pagepart }}',
+	    'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
 	));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Missing one part of the namespace.