### PR TITLE
[MediaBundle] Fix drag & drop file upload boolean conversion exception

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -268,7 +268,7 @@ class MediaController extends Controller
 
         if (array_key_exists('files', $_FILES) && $_FILES['files']['error'] == 0) {
             $drop = $request->files->get('files');
-	} else if (!$request->files->get('file')) {
+	} else if ($request->files->get('file')) {
 	    $drop = $request->files->get('file');
         } else {
             $drop = $request->get('text');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

When uploading a file using drag & drop there was an Exception:

```
Catchable Fatal Error: Object of class Symfony\Component\HttpFoundation\File\UploadedFile could not be converted to boolean
```