### PR TITLE
[MediaBundle] Fix missing type variable when accessing FolderController

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -82,7 +82,8 @@ class FolderController extends Controller
             'subform'       => $subForm->createView(),
             'editform'      => $editForm->createView(),
             'folder'        => $folder,
-            'adminlist'     => $adminList
+            'adminlist'     => $adminList,
+            'type'          => null,
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed this error when accessing FolderController:

![screen shot 2015-04-24 at 14 55 18 copy](https://cloud.githubusercontent.com/assets/11404474/7319111/1bfbce60-ea93-11e4-9b52-625a0e5ef8d8.png)
