### PR TITLE
[GeneratorBundle] Added missing check for AbstractPagePart during page part generation

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/PagePartGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/PagePartGenerator.php
@@ -76,13 +76,13 @@ class PagePartGenerator extends KunstmaanGenerator
      */
     private function generatePagePartEntity()
     {
-	if ($this->bundle->getPath().'/Entity/PageParts/AbstractPagePart.php') {
-	    $abstractClass = $this->bundle->getNamespace().'\Entity\PageParts\AbstractPagePart';
-	} else {
-	    $abstractClass = 'Kunstmaan\PagePartBundle\Entity\AbstractPagePart';
-	}
+        if (file_exists($this->bundle->getPath().'/Entity/PageParts/AbstractPagePart.php')) {
+            $abstractClass = $this->bundle->getNamespace().'\Entity\PageParts\AbstractPagePart';
+        } else {
+            $abstractClass = 'Kunstmaan\PagePartBundle\Entity\AbstractPagePart';
+        }
 
-	list($entityCode, $entityPath) = $this->generateEntity($this->bundle, $this->entity, $this->fields, 'PageParts', $this->prefix, $abstractClass);
+        list($entityCode, $entityPath) = $this->generateEntity($this->bundle, $this->entity, $this->fields, 'PageParts', $this->prefix, $abstractClass);
 
         // Add some extra functions in the generated entity :s
         $params = array(


### PR DESCRIPTION
Hi, in the correct repo now :) My bad, I was a bit too quick and did not read the contribution guide. Hope everything is allright now.

When generating a pagepart using Kunstmaan v3.1 the check for an AbstractPagePart only contained a string and did not check if the file existed which resulted in an error when trying to generate a pagepart. Added a file_exists to the condition.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /