### PR TITLE
[GeneratorBundle] Refactor pagepart media validation

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
@@ -150,12 +150,12 @@ EOT
         $this->fields = array();
         foreach ($fields as $fieldInfo) {
             if($fieldInfo['type'] == 'image') {
-            	$this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'], 
-            			          $fieldInfo['extra'], $fieldInfo['minHeight'], $fieldInfo['maxHeight'], $fieldInfo['minWidth'], $fieldInfo['maxWidth'], $fieldInfo['mimeTypes'], true);
+                $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'],
+                                  $fieldInfo['extra'], $fieldInfo['minHeight'], $fieldInfo['maxHeight'], $fieldInfo['minWidth'], $fieldInfo['maxWidth'], $fieldInfo['mimeTypes'], true);
             } 
             elseif($fieldInfo['type'] == 'media') {
-            	$this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'],
-            			$fieldInfo['extra'], null, null, null, null, $fieldInfo['mimeTypes'], true);
+                $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'],
+                        $fieldInfo['extra'], null, null, null, null, $fieldInfo['mimeTypes'], true);
             }
             else $this->fields[] = $this->getEntityFields($this->bundle, $this->pagepartName, $this->prefix, $fieldInfo['name'], $fieldInfo['type'], $fieldInfo['extra'], null, null, null, null, null, true);
         }
@@ -169,10 +169,10 @@ EOT
         /**
          * Ask that you want to create behat tests for the new pagepart, if possible
          */
-	if (count($this->sections) > 0 && $this->canGenerateBehatTests($this->bundle)) {
-	    $this->behatTest = $this->assistant->askConfirmation('Do you want to generate behat tests for this pagepart? (y/n)', 'y');
-	} else {
-	    $this->behatTest = false;
+        if (count($this->sections) > 0 && $this->canGenerateBehatTests($this->bundle)) {
+            $this->behatTest = $this->assistant->askConfirmation('Do you want to generate behat tests for this pagepart? (y/n)', 'y');
+        } else {
+            $this->behatTest = false;
         }
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -490,7 +490,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                 $mediaTypeId = $this->assistant->askSelect('Media filter', $mediaTypeSelect);
                 $extra       = strtolower($mediaTypeSelect[$mediaTypeId]);
             }
-           
+
             if ($typeStrings[$typeId] == 'image' || $typeStrings[$typeId] == 'media') {
 
                 // Ask the allowed mimetypes for the media ojbect
@@ -507,31 +507,35 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
 
                 if ($extra == 'image') {
 
-                    // Ask the minimum height allowed for the image
-                    $lengthValidation = function ($length) {
-                        if (empty ( $length ) || ! is_numeric ( $length ) || $length < 0) {
-                            throw new \InvalidArgumentException ( sprintf ( '"%s" is not a valid length', $length ) );
-                        } else {
-                            return $length;
-                        }
-                    };
-                    $minHeight = $this->assistant->askAndValidate ( 'What is the minimum height for the media object? (in pixels)', $lengthValidation);
+                    $minHeight = $maxHeight = $minWidth = $maxWidth = null;
+                    if ($this->assistant->askConfirmation('Do you want to add validation of the dimensions of the media object? (y/n)', 'n', '?', false)) {
 
-                    // Ask the maximum height allowed for the image
-                    $maxHeight = $this->assistant->askAndValidate ( 'What is the maximum height for the media object? (in pixels)', $lengthValidation);
+                        // Ask the minimum height allowed for the image
+                        $lengthValidation = function ($length) {
+                            if ((is_numeric($length) && $length < 0) || (!is_numeric($length) && !empty($length))) {
+                                throw new \InvalidArgumentException(sprintf('"%s" is not a valid length', $length));
+                            } else {
+                                return $length;
+                            }
+                        };
 
-                    // Ask the minimum width allowed for the image
-                    $minWidth = $this->assistant->askAndValidate ( 'What is the minimum width for the media object? (in pixels)', $lengthValidation);
+                        $minHeight = $this->assistant->askAndValidate('What is the minimum height for the media object? (in pixels)', $lengthValidation);
 
-                    //Ask the maximum width allowed for the image
-                    $maxWidth = $this->assistant->askAndValidate('What is the maximum width for the media object? (in pixels)', $lengthValidation);
+                        // Ask the maximum height allowed for the image
+                        $maxHeight = $this->assistant->askAndValidate('What is the maximum height for the media object? (in pixels)', $lengthValidation);
 
-                    $data = array('name' => $fieldName, 'type' => 'image', 'extra' => $extra,
-                            'minHeight' => $minHeight, 'maxHeight' => $maxHeight, 'minWidth' => $minWidth, 'maxWidth' => $maxWidth, 'mimeTypes' => $mimeTypes);
+                        // Ask the minimum width allowed for the image
+                        $minWidth = $this->assistant->askAndValidate('What is the minimum width for the media object? (in pixels)', $lengthValidation);
+
+                        //Ask the maximum width allowed for the image
+                        $maxWidth = $this->assistant->askAndValidate('What is the maximum width for the media object? (in pixels)', $lengthValidation);
+
                     }
+                    $data = array('name' => $fieldName, 'type' => 'image', 'extra' => $extra,
+                        'minHeight' => $minHeight, 'maxHeight' => $maxHeight, 'minWidth' => $minWidth, 'maxWidth' => $maxWidth, 'mimeTypes' => $mimeTypes);
 
+                }
             } else $data = array('name' => $fieldName, 'type' => $typeStrings[$typeId], 'extra' => $extra);
-
             $fields[$fieldName] = $data;
         }
 
@@ -552,7 +556,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
         $types             = array();
         $types[$counter++] = $niceNames ? 'Single line text' : 'single_line';
         $types[$counter++] = $niceNames ? 'Multi line text' : 'multi_line';
-    $types[$counter++] = $niceNames ? 'Wysiwyg' : 'wysiwyg';
+        $types[$counter++] = $niceNames ? 'Wysiwyg' : 'wysiwyg';
         $types[$counter++] = $niceNames ? 'Link (url, text, new window)' : 'link';
         if ($this->isBundleAvailable('KunstmaanMediaPagePartBundle')) {
             $types[$counter++] = $niceNames ? 'Image (media, alt text)' : 'image';
@@ -781,7 +785,7 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                 );
                 break;
         }
-        
+
         return $fields;
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/common/Form/EntityAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/common/Form/EntityAdminType.php
@@ -29,18 +29,30 @@ class {{ className }} extends {{ extend_class }}
         $builder->add('{{ field.fieldName }}', '{{ field.formType }}', array(
 {% if field.formType == 'media' %}            'pattern' => 'KunstmaanMediaBundle_chooser',
 {% endif %}
-{% if field.mediaType is defined and field.mediaType != 'none' %}            'mediatype' => '{{ field.mediaType }}', 
+{% if field.mediaType is defined and field.mediaType != 'none' %}            'mediatype' => '{{ field.mediaType }}',
+{% if field.mimeTypes != null or (field.mediaType == 'image' and (field.minHeight != null or field.maxHeight != null or field.minWidth != null or field.maxWidth or null)) %}
             'constraints' => array(new Assert\Media(array(
-		        'mimeTypes' => array({% for type in field.mimeTypes %}'{{ type }}',{% endfor %}),
+{% if field.mimeTypes != null %}
+                'mimeTypes' => array({% for type in field.mimeTypes %}'{{ type }}',{% endfor %}),
+{% endif %}
 {% endif %}
 {% if field.mediaType is defined and field.mediaType == 'image' %}
-		        'minHeight' => '{{ field.minHeight }}', 
-		        'maxHeight' => '{{ field.maxHeight }}', 
-		        'minWidth' => '{{ field.minWidth }}', 
-		        'maxWidth' => '{{ field.maxWidth }}',
+{% if field.minHeight != null %}
+                'minHeight' => '{{ field.minHeight }}',
 {% endif %}
-{% if field.mediaType is defined and field.mediaType != 'none' %}
-        ))),
+{% if field.maxHeight != null %}
+                'maxHeight' => '{{ field.maxHeight }}',
+{% endif %}
+{% if field.minWidth != null %}
+                'minWidth' => '{{ field.minWidth }}',
+{% endif %}
+{% if field.maxWidth != null %}
+                'maxWidth' => '{{ field.maxWidth }}',
+{% endif %}
+{% endif %}
+{% if field.mimeTypes != null or (field.mediaType == 'image' and (field.minHeight != null or field.maxHeight != null or field.minWidth != null or field.maxWidth or null)) %}
+            ))),
+{% endif %}
 {% endif %}
 {% if key == 'rich_text' %}            'attr' => array('rows' => 10, 'cols' => 600, 'class' => 'js-rich-editor rich-editor', 'height' => 140),
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Adding validation for media objects in pageparts is no longer obligated. You no longer have to set minimum/maximum dimension values for images if you don't want to. Instead you can skip the validation part and add it later directly into the form files if you want to. This makes for a more userfriendly experience when generating pageparts.

![screen shot 2015-05-13 at 11 09 06](https://cloud.githubusercontent.com/assets/11404474/7607294/6eb40dbc-f960-11e4-8dd5-51695ff14e17.png)


