### PR TITLE
[TranslatorBundle] Fix error when importing translations where keyword lenght > 255 characters

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
@@ -47,6 +47,10 @@ class Importer
 
     private function importSingleTranslation($keyword, $text, $locale, $filename, $domain, $force = false)
     {
+        if (strlen($keyword) > 255) {
+            return false;
+        }
+
         $translationGroup = $this->translationGroupManager->getTranslationGroupByKeywordAndDomain($keyword, $domain);
 
         if (!($translationGroup instanceof TranslationGroup)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | []

We cannot convert the VARCHAR(255) keyword column to TEXT, because indexes will not work anymore. See http://www.doctrine-project.org/jira/browse/DDC-2802
