### PR TITLE
[NodeBundle] Fix online/offline indication in the menu tree for child pages of structure nodes

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
@@ -1,4 +1,5 @@
 {% set nodeId = menuitem.uniqueId %}
+
 <li id="{{ nodeId }}"{% if menuitem.offline %} data-jstree='{"type":"offline"}'{% endif %} class="{% if menuitem.active or nodeId == 'node-1' %}jstree-open{% endif %}{% if menuitem.offline %} jstree-node--offline{% endif %}"{% if menuitem.role %} rel="{{menuitem.role}}"{% endif %}>
     {% if menuitem.route %}
         <a href="{{ path(menuitem.route, menuitem.routeparams) }}" class="{% if currentMenuItem is not null and currentMenuItem.uniqueId == menuitem.uniqueId %}active{% endif %}">

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -12,6 +12,7 @@ use Kunstmaan\AdminBundle\Helper\Menu\MenuAdaptorInterface;
 use Kunstmaan\AdminBundle\Helper\Menu\TopMenuItem;
 use Kunstmaan\NodeBundle\Entity\HideFromNodeTreeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Kunstmaan\NodeBundle\Helper\NodeMenuItem;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -145,6 +146,25 @@ class PageMenuAdaptor implements MenuAdaptorInterface
     }
 
     /**
+     * Determine if current node is a structure node.
+     *
+     * @param string $refEntityName
+     *
+     * @return bool
+     */
+    private function isStructureNode($refEntityName)
+    {
+        $structureNode = false;
+        if (class_exists($refEntityName)) {
+            $page     = new $refEntityName();
+            $structureNode = ($page instanceof StructureNode);
+            unset($page);
+        }
+
+        return $structureNode;
+    }
+
+    /**
      * Get an array with the id's off all nodes in the tree that should be expanded.
      *
      * @param $request
@@ -191,7 +211,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
                 ->setUniqueId('node-' . $child['id'])
                 ->setLabel($child['title'])
                 ->setParent($parent)
-                ->setOffline(!$child['online'])
+                ->setOffline(!$child['online'] && !$this->isStructureNode($child['ref_entity_name']))
                 ->setRole('page')
                 ->setWeight($child['weight']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | []

All sub pages of a structured node are always marked as "offline" in the tree, even if they are published. This PR solves this issue.
