### PR TITLE
[AdminBundle] Added option to use a custom CKEditor config.js file

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
@@ -94,6 +94,7 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
         }
 
         elToolbar = (_ckEditorConfigs.hasOwnProperty($el.data('editor-mode'))) ? _ckEditorConfigs[$el.data('editor-mode')] : _ckEditorConfigs['kumaDefault'];
+        customConfigFile = customConfigFile || '';
 
         // Place CK
         CKEDITOR.replace(elId, {
@@ -115,6 +116,7 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
             shiftEnterMode: elShiftEnterMode,
 
             toolbar: elToolbar
+            customConfig: customConfigFile
         });
 
         $el.addClass('js-rich-editor--enabled');

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
@@ -55,4 +55,7 @@
             }
         ]
     };
+    
+    // Set path to custom CKEditor config.js file
+    customConfigFile = '';
 </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #402 

This pull request allows the developer to specify a custom config.js file for the CKEditor instance used in the AdminBundle.

To specify a custom config.js file, the developer should override `KunstmaanAdminBundle:Default:_ckeditor_configs.html.twig` and set the `customConfigFile` variable to the path to their custom config.js file.