### PR TITLE
[Nodebunde] Fix not slugified slug

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager,
     Doctrine\ORM\Event\OnFlushEventArgs,
     Doctrine\ORM\Event\PostFlushEventArgs;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Kunstmaan\NodeBundle\Entity\Node,
     Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
@@ -42,6 +43,48 @@ class NodeTranslationListener
         $this->logger = $logger;
         $this->slugifier = $slugifier;
     }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+
+        if ($entity instanceof NodeTranslation) {
+            $this->setSlugWhenEmpty($entity, $args->getEntityManager());
+        }
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+
+        if ($entity instanceof NodeTranslation) {
+            $this->setSlugWhenEmpty($entity, $args->getEntityManager());
+        }
+    }
+
+    private function setSlugWhenEmpty(NodeTranslation $nodeTranslation, EntityManager $em)
+    {
+        $publicNode = $nodeTranslation->getRef($em);
+
+        /** Do nothing for StructureNode objects, skip */
+        if ($publicNode instanceof HasNodeInterface && $publicNode->isStructureNode()) {
+            return;
+        }
+
+        /**
+         * If no slug is set and no structure node, apply title as slug
+         */
+        if ($nodeTranslation->getSlug() == null && $nodeTranslation->getNode()->getParent() != null) {
+            $nodeTranslation->setSlug($this->slugifier->slugify($nodeTranslation->getTitle()));
+        }
+    }
+
 
     /**
      * onFlush doctrine event - collect all nodetranslations in scheduled entity updates here

--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -10,7 +10,6 @@ use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
-use Kunstmaan\UtilitiesBundle\Helper\Slugifier;
 
 /**
  * NodeRepository
@@ -296,7 +295,6 @@ class NodeTranslationRepository extends EntityRepository
             ->setNode($node)
             ->setLang($lang)
             ->setTitle($hasNode->getTitle())
-            ->setSlug(!$hasNode->isStructureNode() ? $hasNode->getTitle(): null)
             ->setOnline(false)
             ->setWeight(0);
 

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -9,6 +9,8 @@ services:
         tags:
             - { name: 'doctrine.event_listener', event: 'onFlush', method: 'onFlush' }
             - { name: 'doctrine.event_listener', event: 'postFlush', method: 'postFlush' }
+            - { name: 'doctrine.event_listener', event: 'prePersist', method: 'prePersist' }
+            - { name: 'doctrine.event_listener', event: 'preUpdate', method: 'preUpdate' }
 
     kunstmaan_node.menu.adaptor.pages:
         class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When you copy a page or use the doctrine fixtures (without setting a slug) the non slugified page title is used as slug.
Because you can't add the slugifier service to the nodetranslation repo this will be handled in the nodetranslation listener on pre persist/update.