### PR TITLE
[SitemapBundle] refactored SitemapInterface

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -1,19 +1,25 @@
 # UPGRADE FROM 3.1 to 3.2
 
-## Manual upgrade needed in app/routes to refactor sitemaps
+## Manual upgrades needed to refactor Sitemaps bundle
 
-### WHAT
+### Sitemaps split into languages
 This feature generates one central sitemap.xml file at your document root to define a sub sitemap for each language available.
 You can now have up to 50000 urls for each language you define.
 As a bonus, you only have to register the sitemap index (/sitemap.xml) at the search engines to register all available languages.
 
-### HOW
+#### HOW
 In order to upgrade, you need a new route in your app/config/routes.yml.
 ```yml
 KunstmaanSitemapBundle_sitemapIndex:
     resource: "@KunstmaanSitemapBundle/Controller/SitemapController.php"
     type:     annotation
 ```
+
+### Renamed HiddenFromSitemap
+Renamed HiddenFromSitemap to HiddenFromSitemapInterface to comply to the Symfony coding standards.
+
+#### HOW
+Make sure you update the interface names and namespaces if you used them in your project.
 
 ## Form submission field order support
 
@@ -73,3 +79,4 @@ The FormHandler will pass the sequence to the adaptForm method of the FormSubmis
         }
         ...
     }
+

--- a/src/Kunstmaan/SitemapBundle/Entity/SitemapPage.php
+++ b/src/Kunstmaan/SitemapBundle/Entity/SitemapPage.php
@@ -4,7 +4,7 @@ namespace Kunstmaan\SitemapBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
-use Kunstmaan\SitemapBundle\Helper\HiddenFromSitemap;
+use Kunstmaan\SitemapBundle\Helper\HiddenFromSitemapInterface;
 
 /**
  * ContentPage
@@ -12,7 +12,7 @@ use Kunstmaan\SitemapBundle\Helper\HiddenFromSitemap;
  * @ORM\Entity()
  * @ORM\Table(name="kuma_sitemap_pages")
  */
-class SitemapPage extends AbstractPage implements HiddenFromSitemap
+class SitemapPage extends AbstractPage implements HiddenFromSitemapInterface
 {
     /**
      * @return array

--- a/src/Kunstmaan/SitemapBundle/Helper/HiddenFromSitemapInterface.php
+++ b/src/Kunstmaan/SitemapBundle/Helper/HiddenFromSitemapInterface.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\SitemapBundle\Helper;
 /**
  * Implement this interface to give you control over the Sitemap behavior of this page
  */
-interface HiddenFromSitemap
+interface HiddenFromSitemapInterface
 {
     /**
      * Returns true when the page is to be hidden from the generated sitemap

--- a/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
+++ b/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
@@ -28,7 +28,7 @@ class SitemapTwigExtension extends \Twig_Extension
      */
     public function isHiddenFromSitemap(NodeMenuItem $item)
     {
-        if (is_subclass_of($item->getNode()->getRefEntityName(), 'Kunstmaan\\SitemapBundle\\Helper\\HiddenFromSitemap')) {
+	if (is_subclass_of($item->getNode()->getRefEntityName(), 'Kunstmaan\\SitemapBundle\\Helper\\HiddenFromSitemapInterface')) {
             $page = $item->getPage();
 
             return $page->isHiddenFromSitemap();
@@ -46,7 +46,7 @@ class SitemapTwigExtension extends \Twig_Extension
      */
     public function isHiddenChildrenFromSitemap(NodeMenuItem $item)
     {
-        if (is_subclass_of($item->getNode()->getRefEntityName(), 'Kunstmaan\\SitemapBundle\\Helper\\HiddenFromSitemap')) {
+	if (is_subclass_of($item->getNode()->getRefEntityName(), 'Kunstmaan\\SitemapBundle\\Helper\\HiddenFromSitemapInterface')) {
             $page = $item->getPage();
 
             return $page->isChildrenHiddenFromSitemap();


### PR DESCRIPTION
Interfaces names should end with "Interface":
Interface HiddenFromSitemap should be named HiddenFromSitemapInterface for better clarity.

**THIS IS A BC BREAK!**

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | /