### PR TITLE
[SeoBundle] Avoid using "and" operator, using &&

### DIFF
--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -23,7 +23,7 @@ class RobotsController extends Controller
         $entity = $this->get('doctrine')->getRepository('KunstmaanSeoBundle:Robots')->findOneBy(array());
         $robots = $this->container->getParameter('robots_default');
 
-        if ($entity and $entity->getRobotsTxt()) {
+        if ($entity && $entity->getRobotsTxt()) {
             $robots = $entity->getRobotsTxt();
         } else {
             $file = $request->getBasePath() . "robots.txt";


### PR DESCRIPTION
The and operator does not have the same precedence as &&.
This could lead to unexpected behavior, use && instead.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #467
