### PR TITLE
[Dependencies] Lock on symfony lower then 2.7 (TEMPORARY)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
 
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.3,<2.7.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

The bundles are not yet compatible with Symfony 2.7. Until then we need to depend on symfony lower then 2.7.