### PR TITLE
[DashboardBundle] unified the css output paths for assetic

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -5,6 +5,7 @@
 {% block extracss %}
     {% stylesheets
     "@KunstmaanDashboardBundle/Resources/ui/scss/_dashboard.scss"
+        output='KunstmaanDashboardBundleAssets/css/DashboardStyle.min.css'
         filter="scss"
     %}
         <link rel="stylesheet" href="{{ asset_url }}" type="text/css"/>

--- a/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/setupcontainer.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/setupcontainer.html.twig
@@ -9,7 +9,8 @@
 {% block extracss %}
     {% stylesheets
     "@KunstmaanDashboardBundle/Resources/ui/scss/_dashboard.scss"
-    filter="scss"
+        output='KunstmaanDashboardBundleAssets/css/DashboardStyle.min.css'
+        filter="scss"
     %}
         <link rel="stylesheet" href="{{ asset_url }}" type="text/css"/>
     {% endstylesheets %}


### PR DESCRIPTION
Q | A
--- | ---
Bug fix? | no
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | /

previously, dashboard bundle css files were dumped to `web/css`, now they behave like every other bundle and get generated to `web/KunstmaanDashboardBundleAssets/css`, where its JS files already reside