### PR TITLE
[NodeBundle] add button to menu so pages are saved when published

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -592,6 +592,12 @@ class NodeAdminController extends Controller
             $page = $nodeVersion->getRef($this->em);
         }
 
+        $saveandpublish =$request->get('saveandpublish');
+
+        if($saveandpublish){
+            $this->get('kunstmaan_node.admin_node.publisher')->publish($nodeTranslation);
+        }
+
         $isStructureNode = $page->isStructureNode();
 
         $menubuilder = $this->get('kunstmaan_node.actions_menu_builder');

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -133,6 +133,9 @@ class ActionsMenuBuilder
 			$menu->addChild('action.unpublish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#unpub')));
                     } elseif (empty($queuedNodeTranslationAction) && !$activeNodeTranslation->isOnline() &&  $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node)) {
 			$menu->addChild('action.publish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#pub')));
+                        if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node) && $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node)) {
+                            $menu->addChild('action.save_and_publish', array('linkAttributes' => array('type' => 'submit', 'class' => 'js-save-btn btn btn--raise-on-hover' . ($isFirst ? ' btn-primary' : ' btn-default'), 'value' => 'saveandpublish', 'name' => 'saveandpublish'), 'extras' => array('renderType' => 'button')));
+                        }
                     }
                     if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node)) {
 			$menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'btn btn--raise-on-hover' . ($isFirst ? ' btn-primary btn-save' : ' btn-default'), 'value' => 'saveasdraft', 'name' => 'saveasdraft'), 'extras' => array('renderType' => 'button')));

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
@@ -10,6 +10,7 @@ action:
     delete: "Delete"
     addsubpage: "Add subpage"
     duplicate: "Duplicate"
+    save_and_publish: "Save and publish"
 
 pages:
     copynotavailable: "Please translate the parent page first"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  #293 

I've added a "save on publish" button to the menu.

 Another option would be to show a popup when publishing a page that tells the user that the page has not yet been saved.

- [ ] feedback