### PR TITLE
Extending the admin User entity 3.2.*@dev

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -165,6 +165,19 @@ abstract class BaseUser extends AbstractUser
         )));
     }
 
-    abstract protected function getFormTypeClass();
-    abstract protected function getAdminListConfiguratorClass();
+    /**
+     * Return class name of form type used to add & edit users
+     *
+     * @return string
+     */
+    abstract public function getFormTypeClass();
+
+    /**
+     * Return class name of admin list configurator used for users
+     *
+     * @return string
+     *
+     * @deprecated Use the kunstmaan_user_management.user_admin_list_configurator.class parameter instead!
+     */
+    abstract public function getAdminListConfiguratorClass();
 }

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.5,<2.7",
         "doctrine/orm": "~2.2,>=2.2.3",
         "friendsofsymfony/user-bundle": "2.0.*@dev",
         "knplabs/knp-menu-bundle": "~2.0",


### PR DESCRIPTION
Hello,
I've updated kunstmaan bundles from 3.0 to 3.2.*@dev.
all works great but i have a problem with custom user entity.
i have extended the original entity by this article:

    http://bundles.kunstmaan.be/news/extending-the-admin-user-entity

but in new version i have some errors:
1 on user page it tries to show entities from original db table 
2 on add/edit i have this error 

     Error: Call to protected method Sandbox\WebsiteBundle\Entity\User::getFormTypeClass() from context 'Kunstmaan\UserManagementBundle\Controller\UsersController' 

and if i change the protected method to public i get 

     Attempted to load class "UserType" from namespace "SandBox\WebsiteBundle\Form".
Did you forget a "use" statement for "Kunstmaan\AdminBundle\Form\UserType"?

my method : 

        public function getFormTypeClass()
        {
            return 'SandBox\WebsiteBundle\Form\UserType';
        }

that file with that namespace exist(and it worked in prev version)


    Stack Trace
    in vendor/kunstmaan/bundles-cms/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php at line 89  -
            /* @var $em EntityManager */
            $em                = $this->getDoctrine()->getManager();
            $user              = $this->getUserClassInstance();
            $formTypeClassName = $user->getFormTypeClass();
            $formType          = new $formTypeClassName();
            $formType->setLangs($this->container->getParameter('kunstmaan_admin.admin_locales'));

how can i fix this?