### PR TITLE
[AdminBundle] Fixed missing error messages due to overwriting the errors array

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/FormHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/FormHelper.php
@@ -56,17 +56,17 @@ class FormHelper
                 $this->getRecursiveErrorMessages($formView, $errors);
             }
         } else {
-            $errors = $formViews->vars['errors'];
+            $viewErrors = $formViews->vars['errors'];
 
-            if (is_object($errors) && $errors instanceof \Traversable) {
-                $errors = iterator_to_array($errors);
+            if (is_object($viewErrors) && $viewErrors instanceof \Traversable) {
+                $viewErrors = iterator_to_array($viewErrors);
             }
 
             /**
              * @var $formViews FormView
              * @var $error     FormError
              */
-            foreach ($errors as $error) {
+            foreach ($viewErrors as $error) {
 
                 $template   = $error->getMessageTemplate();
                 $parameters = $error->getMessageParameters();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When looping child forms the errors array is overwriting itself.