### PR TITLE
Make AdminLocaleListener also update locale on subrequests

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -3,7 +3,6 @@
 namespace Kunstmaan\AdminBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -57,11 +56,6 @@ class AdminLocaleListener implements EventSubscriberInterface
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
-            // return immediately
-            return;
-        }
-
         $url = $event->getRequest()->getRequestUri();
         if ($this->isAdminToken($this->context->getToken(), $this->providerKey) && $this->isAdminRoute($url)) {
             $token = $this->context->getToken();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Since Symfony 2.6 it seems to be necessary to also update the locale on subrequests. This becomes apparent when viewing a backend pag with a subrequest while the request locale (by virtue of the default locale) is not equal to an admin locale of a backend user. In my case I had my default locale set to Dutch (nl) and the backend locale set to English (en). This resulted in the dashboard page using Dutch translations, while the rest of the backend uses English translations.

Apparently this is caused by a refactor of the TranslatorListener in Symfony 2.6, which also acts on subrequests. I'm not certain if checking for a subrequest is still needed in Symfony 2.5, if so we need to look for another solution.