### PR TITLE
[AdminBundle] reinit advancedSelect when editing a PagePart

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
@@ -1,11 +1,9 @@
 var kunstmaanbundles = kunstmaanbundles || {};
 
-kunstmaanbundles.pagepartEditor = (function(window, undefined) {
+kunstmaanbundles.pagepartEditor = (function(window) {
 
     var init,
         addPagePart, editPagePart, deletePagePart;
-
-    var $body = $('body');
 
     init = function() {
         var $body = $('body');
@@ -105,7 +103,10 @@ kunstmaanbundles.pagepartEditor = (function(window, undefined) {
         // Add edit active class
         $('#pp-' + targetId).addClass('pp--edit-active');
 
-        // Set Active Edit
+	    // Reinit custom selects
+	    kunstmaanbundles.advancedSelect.init();
+
+	    // Set Active Edit
         window.activeEdit = targetId;
     };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The `$.select2` widget gets confused when the input is hidden while initializing and uses a wrong width. 

![messed up widget](http://note.io/1BPp82P).

This patch reinitializes the widget on edit the same way as it’s done when adding a PagePart.