### PR TITLE
[MediaBundle] refactored `MediaValidator`, fixed missing `TOO_NARROW_ERROR` constant

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Tests\Validator\Constraints;
+
+use Kunstmaan\MediaBundle\Entity\Media as MediaObject;
+use Kunstmaan\MediaBundle\Validator\Constraints\Media;
+use Kunstmaan\MediaBundle\Validator\Constraints\MediaValidator;
+use Symfony\Component\Validator\ExecutionContextInterface;
+
+class MediaValidatorTest extends \PHPUnit_Framework_TestCase
+{
+
+
+    public function testMimeTypeIsIgnoredWhenNotSpecified()
+    {
+        $constraint = new Media();
+        $media = new MediaObject;
+
+        $validator = $this->getValidator($this->noViolation());
+
+        $validator->validate($media, $constraint);
+        // no exception
+    }
+
+    /**
+     * @param $contentType
+     * @param $allowed
+     * @param $message
+     * @param $code
+     *
+     * @dataProvider dataMimeTypes
+     */
+    public function testMimeTypeMatches($contentType, $allowed, $message = null, $code = null)
+    {
+        $constraint = new Media(['mimeTypes' => $allowed]);
+        $media = (new MediaObject)->setContentType($contentType);
+
+        $validator = $this->getValidator(($message && $code) ? $this->thisViolation($message, $code) : $this->noViolation());
+
+        $validator->validate($media, $constraint);
+
+        // expect
+    }
+
+    public function testSvgIsNotTestedForDimensions()
+    {
+        $constraint = new Media(['minHeight' => 100]);
+        $media = (new MediaObject)->setContentType('image/svg+xml');
+
+        $validator = $this->getValidator($this->noViolation());
+        $validator->validate($media, $constraint);
+
+        // no violation
+    }
+
+    /**
+     * @param string $dimension
+     * @param int    $value
+     * @param string $message
+     * @param int    $code
+     *
+     * @dataProvider dataDimensions
+     */
+    public function testDimensionsAreChecked($dimension, $value, $message = null, $code = null)
+    {
+        $constraint = new Media([$dimension => $value]);
+        $media = (new MediaObject)
+            ->setMetadataValue('original_width', 100)
+            ->setMetadataValue('original_height', 100)
+            ->setContentType('image/png');
+
+        $validator = $this->getValidator(($message && $code) ? $this->thisViolation($message, $code) : $this->noViolation());
+
+        $validator->validate($media, $constraint);
+
+        // expect
+    }
+
+    public function dataMimeTypes()
+    {
+        $errors = new Media;
+
+        return [
+            ['image/png', ['image/png']],
+            ['image/png', ['image/jpg', 'image/png']],
+            ['image/png', ['image/*']],
+            ['image/PNG', ['image/png']],
+            ['image/png', ['image/PNG']],
+            ['image/png', ['image/jpg'], $errors->mimeTypesMessage, $errors::INVALID_MIME_TYPE_ERROR],
+            ['image/png', ['application/*'], $errors->mimeTypesMessage, $errors::INVALID_MIME_TYPE_ERROR],
+        ];
+    }
+
+    public function dataDimensions()
+    {
+        $errors = new Media;
+
+
+        // image size is 100x100
+        return [
+            ['minHeight', 100],
+            ['maxHeight', 100],
+            ['minWidth', 100],
+            ['maxWidth', 100],
+            ['minWidth', 200, $errors->minWidthMessage, $errors::TOO_NARROW_ERROR],
+            ['maxWidth', 50, $errors->maxWidthMessage, $errors::TOO_WIDE_ERROR],
+            ['minHeight', 200, $errors->minHeightMessage, $errors::TOO_LOW_ERROR],
+            ['maxHeight', 50, $errors->maxHeightMessage, $errors::TOO_HIGH_ERROR],
+        ];
+    }
+
+    private function getValidator(callable $mockCallback = null)
+    {
+        $builder = $this->getMockBuilder('\Symfony\Component\Validator\ExecutionContextInterface');
+
+        /** @var ExecutionContextInterface $mock */
+        $mock = $builder->getMock();
+        $mockCallback && $mockCallback($mock);
+
+        $validator = new MediaValidator();
+        $validator->initialize($mock);
+
+        return $validator;
+    }
+
+    private function thisViolation($message, $code)
+    {
+        return function (\PHPUnit_Framework_MockObject_MockObject $mock) use ($message, $code) {
+            $mock->expects($this->once())->method('addViolation')->with(
+                $this->equalTo($message), $this->anything(), $this->anything(), $this->anything(), $this->equalTo($code)
+            );
+        };
+    }
+
+    private function noViolation()
+    {
+        return function (\PHPUnit_Framework_MockObject_MockObject $mock) {
+            $mock->expects($this->never())->method('addViolation');
+        };
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/Media.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/Media.php
@@ -15,6 +15,7 @@ class Media extends Constraint
     const EMPTY_ERROR = 3;
     const INVALID_MIME_TYPE_ERROR = 5;
     const TOO_WIDE_ERROR = 11;
+    const TOO_NARROW_ERROR = 12;
     const TOO_HIGH_ERROR = 13;
     const TOO_LOW_ERROR = 14;
 
@@ -26,6 +27,7 @@ class Media extends Constraint
     	self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
     	self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
     	self::TOO_WIDE_ERROR => 'TOO_WIDE_ERROR',
+    	self::TOO_NARROW_ERROR => 'TOO_NARROW_ERROR',
     );
 
     public $minHeight;

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
@@ -8,108 +8,157 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-
 class MediaValidator extends ConstraintValidator
 {
+
     /**
+     * @param MediaObject $value
+     * @param Constraint  $constraint
      *
-     * @param mixed $value
-     * @param Constraint $constraint
      * @throws ConstraintDefinitionException
      */
-	public function validate($value, Constraint $constraint) {
-		
-		if (! $constraint instanceof Media) {
-			throw new UnexpectedTypeException ( $constraint, __NAMESPACE__ . '\Media' );
-		}
-		if ($value) {
-			
-			$mimeType = $value->getContentType();
-			
-			if ($constraint->mimeTypes) {
-				if (!$value instanceof MediaObject) {
-					$value = new MediaObject($value);
-				}
-			
-				$mimeTypes = (array) $constraint->mimeTypes;
-			
-				foreach ($mimeTypes as $type) {
-					if ($type === $mimeType) {
-						return;
-					}
-			
-					if ($discrete = strstr($type, '/*', true)) {
-						if (strstr($mimeType, '/', true) === $discrete) {
-							return;
-						}
-					}
-				}
-			
-				$this->buildViolation($constraint->mimeTypesMessage)
-				->setParameter('{{ media }}', $this->formatValue($value->getUrl()))
-				->setParameter('{{ type }}', $this->formatValue($mimeType))
-				->setParameter('{{ types }}', $this->formatValues ( $mimeTypes ) )->setCode ( Media::INVALID_MIME_TYPE_ERROR )->addViolation ();
-				
-				return;
-			}
-			
-			if (preg_match ( '^image\/*^', $mimeType ) && $mimeType != 'image/svg+xml') {
-				
-				$height = $value->getMetadataValue ( 'original_height' );
-				$width = $value->getMetadataValue ( 'original_width' );
-				
-				if ($constraint->minHeight) {
-					if (! ctype_digit ( ( string ) $constraint->minHeight )) {
-						throw new ConstraintDefinitionException ( sprintf ( '"%s" is not a valid minimum height', $constraint->minHeight ) );
-					}
-					
-					if ($height < $constraint->minHeight) {
-						$this->buildViolation ( $constraint->minHeightMessage )->setParameter ( '{{ height }}', $height )->setParameter ( '{{ min_height }}', $constraint->minHeight )->setCode ( Media::TOO_LOW_ERROR )->addViolation ();
-						
-						return;
-					}
-				}
-				
-				if ($constraint->maxHeight) {
-					if (! ctype_digit ( ( string ) $constraint->maxHeight )) {
-						throw new ConstraintDefinitionException ( sprintf ( '"%s" is not a valid maximum height', $constraint->maxHeight ) );
-					}
-					
-					if ($height > $constraint->maxHeight) {
-						$this->buildViolation ( $constraint->maxHeightMessage )->setParameter ( '{{ height }}', $height )->setParameter ( '{{ max_height }}', $constraint->maxHeight )->setCode ( Media::TOO_HIGH_ERROR )->addViolation ();
-						
-						return;
-					}
-				}
-				
-				if ($constraint->minWidth) {
-					if (! ctype_digit ( ( string ) $constraint->minWidth )) {
-						throw new ConstraintDefinitionException ( sprintf ( '"%s" is not a valid minimum width', $constraint->minWidth ) );
-					}
-					
-					if ($width < $constraint->minWidth) {
-						$this->buildViolation ( $constraint->minWidthMessage )->setParameter ( '{{ width }}', $width )->setParameter ( '{{ min_width }}', $constraint->minWidth )->setCode ( Media::TOO_NARROW_ERROR )->addViolation ();
-						
-						return;
-					}
-				}
-				
-				if ($constraint->maxWidth) {
-					if (! ctype_digit ( ( string ) $constraint->maxWidth )) {
-						throw new ConstraintDefinitionException ( sprintf ( '"%s" is not a valid maximum width', $constraint->maxWidth ) );
-					}
-					
-					if ($width > $constraint->maxWidth) {
-						$this->buildViolation ( $constraint->maxWidthMessage)
-							->setParameter('{{ width }}', $width)
-							->setParameter('{{ max_width }}', $constraint->maxWidth)
-							->setCode(Media::TOO_WIDE_ERROR)
-							->addViolation();
-							 
-							return;
-					}
-				}
-			}			 
-    		}
-    	}
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Media) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\Media');
+        }
+
+        if (!$value instanceof MediaObject) {
+            return;
+        }
+
+        $mimeType = $value->getContentType();
+
+        if ($constraint->mimeTypes) {
+            $mimeTypes = (array)$constraint->mimeTypes;
+
+            if (false === $this->validateMimeType($value, $mimeTypes)) {
+
+                $this->buildViolation($constraint->mimeTypesMessage)
+                    ->setParameter('{{ type }}', $this->formatValue($mimeType))
+                    ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
+                    ->setCode(Media::INVALID_MIME_TYPE_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+        if (!preg_match('^image\/*^', $mimeType) || $mimeType === 'image/svg+xml') {
+            return;
+        }
+
+        $this->validateDimensions($value, $constraint);
+
+    }
+
+    private function validateMimeType(MediaObject $value, $allowedMimeTypes)
+    {
+        $mimeType = strtolower($value->getContentType());
+
+        foreach ($allowedMimeTypes as $type) {
+            $type = strtolower($type);
+            if ($type === $mimeType) {
+                return true;
+            }
+
+            if ($discrete = strstr($type, '/*', true)) {
+                if (strstr($mimeType, '/', true) === $discrete) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function validateDimensions(MediaObject $value, Media $constraint)
+    {
+        $height = $value->getMetadataValue('original_height');
+        $width = $value->getMetadataValue('original_width');
+
+        if ($constraint->minHeight) {
+            if (!ctype_digit((string)$constraint->minHeight)) {
+                throw new ConstraintDefinitionException (
+                    sprintf(
+                        '"%s" is not a valid minimum height',
+                        $constraint->minHeight
+                    )
+                );
+            }
+
+            if ($height < $constraint->minHeight) {
+                $this->buildViolation($constraint->minHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ min_height }}', $constraint->minHeight)
+                    ->setCode(Media::TOO_LOW_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+        if ($constraint->maxHeight) {
+            if (!ctype_digit((string)$constraint->maxHeight)) {
+                throw new ConstraintDefinitionException (
+                    sprintf(
+                        '"%s" is not a valid maximum height',
+                        $constraint->maxHeight
+                    )
+                );
+            }
+
+            if ($height > $constraint->maxHeight) {
+                $this->buildViolation($constraint->maxHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ max_height }}', $constraint->maxHeight)
+                    ->setCode(Media::TOO_HIGH_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+        if ($constraint->minWidth) {
+            if (!ctype_digit(( string )$constraint->minWidth)) {
+                throw new ConstraintDefinitionException (
+                    sprintf(
+                        '"%s" is not a valid minimum width',
+                        $constraint->minWidth
+                    )
+                );
+            }
+
+            if ($width < $constraint->minWidth) {
+                $this->buildViolation($constraint->minWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ min_width }}', $constraint->minWidth)
+                    ->setCode(Media::TOO_NARROW_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+
+        if ($constraint->maxWidth) {
+            if (!ctype_digit(( string )$constraint->maxWidth)) {
+                throw new ConstraintDefinitionException (
+                    sprintf(
+                        '"%s" is not a valid maximum width',
+                        $constraint->maxWidth
+                    )
+                );
+            }
+
+            if ($width > $constraint->maxWidth) {
+                $this->buildViolation($constraint->maxWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ max_width }}', $constraint->maxWidth)
+                    ->setCode(Media::TOO_WIDE_ERROR)
+                    ->addViolation();
+
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #500

 - [x] Added missing constant `Media::TOO_NARROW_ERROR`
 - [x] Refactored `MediaValidator` in the process
 - [x] Added tests for `MediaValidator`