### PR TITLE
[NodeSearchBundle] changed NodePagesConfiguration methods/properties from private to protected to improve extendability

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -32,37 +32,37 @@ use Symfony\Component\Security\Acl\Model\AuditableEntryInterface;
 class NodePagesConfiguration implements SearchConfigurationInterface
 {
     /** @var string */
-    private $indexName;
+    protected $indexName;
 
     /** @var string */
-    private $indexType;
+    protected $indexType;
 
     /** @var SearchProviderInterface */
-    private $searchProvider;
+    protected $searchProvider;
 
     /** @var array */
-    private $locales = array();
+    protected $locales = array();
 
     /** @var array */
-    private $analyzerLanguages;
+    protected $analyzerLanguages;
 
     /** @var EntityManager */
-    private $em;
+    protected $em;
 
     /** @var array */
-    private $documents = array();
+    protected $documents = array();
 
     /** @var ContainerInterface */
-    private $container;
+    protected $container;
 
     /** @var AclProviderInterface */
-    private $aclProvider = null;
+    protected $aclProvider = null;
 
     /** @var LoggerInterface */
-    private $logger = null;
+    protected $logger = null;
 
     /** @var IndexablePagePartsService */
-    private $indexablePagePartsService;
+    protected $indexablePagePartsService;
 
     /**
      * @param ContainerInterface      $container
@@ -678,7 +678,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      *
      * @return \DateTime
      */
-    private function getUTCDateTime(\DateTime $dateTime)
+    protected function getUTCDateTime(\DateTime $dateTime)
     {
         $result = clone $dateTime;
         $result->setTimezone(new \DateTimeZone('UTC'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Changed all private properties/methods to protected so it's possible to extends and overwrite the NodePagesConfiguration easily.