### PR TITLE
[AdminBundle] fixed styling error labels in page-main-tabs

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/structures/_page-actions.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/structures/_page-actions.scss
@@ -6,6 +6,23 @@
    ========================================================================== */
 .page-main-tabs{
 
+    .error-label {
+        display: inline-block;
+        width: 1.75rem;
+        height: 1.75rem;
+        margin-left: .25rem;
+
+        background: $red;
+        color: $white;
+
+        font-size: 1.11rem;
+        line-height: 1.65;
+        text-align: center;
+        font-weight: bold;
+
+        border-radius: $default-border-radius;
+    }
+
     @media (min-width: $screen-xs-min) {
         margin: 2rem 0 0;
     }

--- a/src/Kunstmaan/AdminBundle/Resources/views/TabsTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/TabsTwigExtension/widget.html.twig
@@ -12,12 +12,8 @@
         <a href="#{{ tabIdentifier }}" data-toggle="tab">
             {{ tab.title }}
             {% if formErrors|length > 0 %}
-                <span class="label label-important">
-                    {% if formErrors|length >1 %}
-                        {{formErrors|length}} {{ "Errors" | trans }}
-                    {% else %}
-                        {{ "1 Error" | trans }}
-                    {% endif %}
+                <span class="error-label">
+                    {{formErrors|length}}
                 </span>
             {% endif %}
         </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

 fix error label in the main tabs. Changed from text to a number bullet.