### PR TITLE
[NodeBundle] Refactor online template

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/Admin/online.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/Admin/online.html.twig
@@ -1,13 +1,13 @@
-{% set online = adminlist.getStringValue(row, columnName) %}
-{% if online=='true' %}
-    <i class="fa fa-check-square-o"></i>
-    <span class="text--muted">
-        {{ ' (Online)' | trans }}
-    </span>
-{% elseif online=='false' %}
+{% set online = adminlist.getValue(row, columnName) %}
+{% if online == false %}
     <i class="fa fa-square-o"></i>
     <span class="text--muted">
         {{ ' (Offline)' | trans }}
+    </span>
+{% elseif online == true %}
+    <i class="fa fa-check-square-o"></i>
+    <span class="text--muted">
+        {{ ' (Online)' | trans }}
     </span>
 {% else %}
     {{ online }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

If you wanted to use the 'online template' from the nodebundle, you had to convert the 0 or 1 boolean in database to "true" or "false" strings using.

    public function getValue($item, $columnName)
    {
        if ($columnName == 'online') {
            return $item['online'] ? 'true' : 'false';
        }

        return parent::getValue($item, $columnName);
    } 

This is not needed if you just check for the boolean type true or false in the template, and not the string type.