### PR TITLE
[NodeBundle] Fix admin preview when controller as a service is used

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\NodeBundle\EventListener;
 
+use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\Templating\EngineInterface;
 
@@ -12,12 +13,15 @@ class RenderContextListener
      */
     protected $templating;
 
+    protected $em;
+
     /**
      * @param EngineInterface $templating
      */
-    public function __construct(EngineInterface $templating)
+    public function __construct(EngineInterface $templating, EntityManager $em)
     {
         $this->templating = $templating;
+        $this->em = $em;
     }
 
     /**
@@ -33,6 +37,16 @@ class RenderContextListener
             $url             = $request->attributes->get('url');
             $nodeMenu        = $request->attributes->get('_nodeMenu');
             $parameters      = $request->attributes->get('_renderContext');
+
+            if ($request->get('preview') == true) {
+                $version = $request->get('version');
+                if (!empty($version) && is_numeric($version)) {
+                    $nodeVersion = $this->em->getRepository('KunstmaanNodeBundle:NodeVersion')->find($version);
+                    if (!is_null($nodeVersion)) {
+                        $entity = $nodeVersion->getRef($this->em);
+                    }
+                }
+            }
 
             $renderContext = array(
                 'nodetranslation'   => $nodeTranslation,

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -137,6 +137,6 @@ services:
 
     kunstmaan_node.render.context.listener:
         class: Kunstmaan\NodeBundle\EventListener\RenderContextListener
-        arguments: ["@templating"]
+        arguments: ["@templating", @doctrine.orm.entity_manager]
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This fixes the admin preview on pages where you bypass the SlugController with the controller as a service method.