### PR TITLE
[PagepartBundle] Pagepart limits

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Helper/PagePartConfigurationReader.php
+++ b/src/Kunstmaan/PagePartBundle/Helper/PagePartConfigurationReader.php
@@ -63,6 +63,9 @@ class PagePartConfigurationReader
                 }
             } else {
                 $types[$type['name']] = array('name' => $type['name'], 'class' => $type['class']);
+                if (isset($type['pagelimit'])) {
+                    $types[$type['name']]['pagelimit'] = $type['pagelimit'];
+                }
             }
         }
 


### PR DESCRIPTION

If there is a page limit for the page part in the config, add this to the types array.
Kunstmaan already checks on this value in the form widgets. But the pagepart configuration reader didn't add this value to the types array.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  https://github.com/Kunstmaan/KunstmaanBundlesStandardEdition/issues/60

Small change to config if you want to use this function
```
name: PagepartCollection
context: PagepartContext
types:
    - { name: PagepartName, class: PagePart, pagelimit: 1 }
```