### PR TITLE
[MediaBundle] Change MediaController createAndRedirect() from private to protected

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -311,7 +311,7 @@ class MediaController extends Controller
      *
      * @return array
      */
-    private function createAndRedirect(Request $request, $folderId, $type, $redirectUrl, $extraParams = array())
+    protected function createAndRedirect(Request $request, $folderId, $type, $redirectUrl, $extraParams = array())
     {
         $em = $this->getDoctrine()->getManager();
 


### PR DESCRIPTION
In the interest of extensibility, this method should be protected, not private.  If you want to extend this bundle and make changes to either this method, or methods that call it, you have to copy large swaths of code because a child class can't access private methods from the parent.  And if you do that, you now can't get updates to the class because you've redefined almost all the methods.