### PR TITLE
Add check for presence of security token in AdminLocaleListener

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -57,8 +57,9 @@ class AdminLocaleListener implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $url = $event->getRequest()->getRequestUri();
-        if ($this->isAdminToken($this->context->getToken(), $this->providerKey) && $this->isAdminRoute($url)) {
-            $token = $this->context->getToken();
+        $token = $this->context->getToken();
+
+        if ($token && $this->isAdminToken($token, $this->providerKey) && $this->isAdminRoute($url)) {
             $locale = $token->getUser()->getAdminLocale();
 
             if (!$locale) {


### PR DESCRIPTION
Whoops, this is a fix for my previous pull request: https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/499

I will now yell at myself for breaking it :(

Apparently the previous check for subrequests protected against executing the code in AdminLocaleListener in case an exception needs to be handled, most notably a 404. Removing this check results in 404s no longer being handled correctly, as can be seen on your own demosite: http://demo.bundles.kunstmaan.be/en/doesnotexist

I've added an explicit check for the security context to handle this situation. Apologies for breaking this in the first place.