### PR TITLE
[AdminListBundle] Fix pagination issue for DBAL adminlists

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineDBALAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineDBALAdminListConfigurator.php
@@ -97,8 +97,8 @@ abstract class AbstractDoctrineDBALAdminListConfigurator extends AbstractAdminLi
                 $this->getUseDistinctCount()
             );
             $this->pagerfanta = new Pagerfanta($adapter);
-            $this->pagerfanta->setCurrentPage($this->getPage());
             $this->pagerfanta->setMaxPerPage($this->getLimit());
+            $this->pagerfanta->setCurrentPage($this->getPage());
         }
 
         return $this->pagerfanta;


### PR DESCRIPTION
The `setCurrentPage ` also checks if the page exists based in the `max items per page`. So if you override it, it checks if the page exists based on the default `max items per page`, because the custom number is only set after the `setCurrentPage ` method call.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 