### PR TITLE
Bundle specific kunstmaan dependencies always require 3.0

### DIFF
--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -19,11 +19,11 @@
         "friendsofsymfony/user-bundle": "2.0.*@dev",
         "knplabs/knp-menu-bundle": "~2.0",
         "sensio/framework-extra-bundle": "*",
-        "kunstmaan/utilities-bundle": "~3.0.0",
+        "kunstmaan/utilities-bundle": "~3.2",
         "guzzle/guzzle": "3.8.*"
     },
     "suggests": {
-        "kunstmaan/user-management-bundle": "~3.0.0"
+        "kunstmaan/user-management-bundle": "~3.2"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",

--- a/src/Kunstmaan/AdminListBundle/composer.json
+++ b/src/Kunstmaan/AdminListBundle/composer.json
@@ -17,8 +17,8 @@
         "symfony/symfony": "~2.3",
         "sensio/framework-extra-bundle": ">=2.3.4,<4.0.0",
         "white-october/pagerfanta-bundle": "1.0.*",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/utilities-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/utilities-bundle": "~3.2",
         "phpoffice/phpexcel": "1.8.*",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -16,9 +16,9 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "white-october/pagerfanta-bundle": "1.0.*",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -20,10 +20,10 @@
         "gedmo/doctrine-extensions": "2.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "sensio/framework-extra-bundle": ">=2.3.0,<4.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/pagepart-bundle": "~3.0.0",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/pagepart-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -19,16 +19,16 @@
         "doctrine/orm": "~2.2,>=2.2.3",
         "sensio/generator-bundle": ">=2.3.0, <2.5.0",
         "fzaninotto/faker": "~1.4.0",
-        "kunstmaan/utilities-bundle": "~3.0.0"
+        "kunstmaan/utilities-bundle": "~3.2"
     },
     "suggest": {
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/form-bundle": "~3.0.0",
-        "kunstmaan/media-bundle": "~3.0.0",
-        "kunstmaan/media-pagepart-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0",
-        "kunstmaan/pagepart-bundle": "~3.0.0"
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/form-bundle": "~3.2",
+        "kunstmaan/media-bundle": "~3.2",
+        "kunstmaan/media-pagepart-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
+        "kunstmaan/pagepart-bundle": "~3.2"
     },
     "autoload": {
         "psr-0": { "Kunstmaan\\GeneratorBundle": "" }

--- a/src/Kunstmaan/LeadGenerationBundle/composer.json
+++ b/src/Kunstmaan/LeadGenerationBundle/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/symfony": "~2.3",
-    "kunstmaan/adminlist-bundle": "~3.0.0"
+    "kunstmaan/adminlist-bundle": "~3.2"
   },
   "autoload": {
     "psr-4": { "Kunstmaan\\KunstmaanLeadGenerationBundle\\": "" }

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -21,9 +21,9 @@
         "liip/imagine-bundle": "v0.20.2",
         "knplabs/knp-gaufrette-bundle": "0.1.*",
         "sensio/framework-extra-bundle": ">=2.3.0,<4.0.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/utilities-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/utilities-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "suggest": {

--- a/src/Kunstmaan/MediaPagePartBundle/composer.json
+++ b/src/Kunstmaan/MediaPagePartBundle/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "kunstmaan/pagepart-bundle": "~3.0.0",
-        "kunstmaan/media-bundle": "~3.0.0",
+        "kunstmaan/pagepart-bundle": "~3.2",
+        "kunstmaan/media-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {

--- a/src/Kunstmaan/MenuBundle/composer.json
+++ b/src/Kunstmaan/MenuBundle/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/symfony": "~2.3",
-    "kunstmaan/adminlist-bundle": "~3.0.0"
+    "kunstmaan/adminlist-bundle": "~3.2"
   },
   "autoload": {
     "psr-4": { "Kunstmaan\\MenuBundle\\": "" }

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -17,9 +17,9 @@
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
         "symfony-cmf/routing-bundle": "~1.1.1",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/utilities-bundle": "~3.0.0",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/utilities-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",

--- a/src/Kunstmaan/NodeSearchBundle/composer.json
+++ b/src/Kunstmaan/NodeSearchBundle/composer.json
@@ -23,9 +23,9 @@
         "symfony/symfony": "~2.3",
         "white-october/pagerfanta-bundle": "1.0.*",
         "ruflin/elastica": "~1.0",
-        "kunstmaan/node-bundle": "~3.0.0",
-        "kunstmaan/pagepart-bundle": "~3.0.0",
-        "kunstmaan/search-bundle": "~3.0.0",
+        "kunstmaan/node-bundle": "~3.2",
+        "kunstmaan/pagepart-bundle": "~3.2",
+        "kunstmaan/search-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {

--- a/src/Kunstmaan/PagePartBundle/composer.json
+++ b/src/Kunstmaan/PagePartBundle/composer.json
@@ -15,9 +15,9 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/utilities-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/utilities-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -16,8 +16,8 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "symfony-cmf/routing-bundle": "~1.1.1",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/admin-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",

--- a/src/Kunstmaan/SeoBundle/composer.json
+++ b/src/Kunstmaan/SeoBundle/composer.json
@@ -17,9 +17,9 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "gedmo/doctrine-extensions": "2.3.*",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/media-bundle": "~3.0.0",
-        "kunstmaan/utilities-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/media-bundle": "~3.2",
+        "kunstmaan/utilities-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {

--- a/src/Kunstmaan/SitemapBundle/composer.json
+++ b/src/Kunstmaan/SitemapBundle/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",

--- a/src/Kunstmaan/TaggingBundle/composer.json
+++ b/src/Kunstmaan/TaggingBundle/composer.json
@@ -16,10 +16,10 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "fpn/doctrine-extensions-taggable": "0.9.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/media-bundle": "~3.0.0",
-        "kunstmaan/node-bundle": "~3.0.0"
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/media-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2"
     },
     "autoload": {
         "psr-0": { "Kunstmaan\\TaggingBundle": "" }

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -26,8 +26,8 @@
         "sensio/framework-extra-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.0",
 
-        "kunstmaan/admin-bundle": "~3.0.0",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
+        "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/adminlist-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "require-dev": {

--- a/src/Kunstmaan/UserManagementBundle/composer.json
+++ b/src/Kunstmaan/UserManagementBundle/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "kunstmaan/adminlist-bundle": "~3.0.0",
-        "kunstmaan/admin-bundle": "~3.0.0",
+        "kunstmaan/adminlist-bundle": "~3.2",
+        "kunstmaan/admin-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
When you don't use "kunstmaan/bundles-cms" composer package but require each bundle independently you will get composer conflicts.
The reason of the conflict error is that the composer.json of each bundle has dependencies on kunstmaan bundles on version 3.0.*.

This pull request should fix this.