### PR TITLE
[AdminBundle] fix admin locale listener on RememberMe token

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\AdminBundle\EventListener;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -78,7 +79,7 @@ class AdminLocaleListener implements EventSubscriberInterface
      */
     private function isAdminToken(TokenInterface $token, $providerKey)
     {
-        return $token instanceof UsernamePasswordToken && $token->getProviderKey() === $providerKey;
+        return ($token instanceof UsernamePasswordToken || $token instanceof RememberMeToken) && $token->getProviderKey() === $providerKey;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

The admin locale was lost when `UsernamePaswordToken` turned into `RememberMeToken`