### PR TITLE
[NodeSearchBundle] move mapping to symfony config and allow custom data to be indexed

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/HasCustomSearchDataInterface.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/HasCustomSearchDataInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Configuration;
+
+interface HasCustomSearchDataInterface
+{
+    /**
+     * @param array $doc
+     *
+     * @return array
+     */
+    public function getCustomSearchData(array $doc);
+}

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\NodeSearchBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -21,12 +22,27 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode    = $treeBuilder->root('kunstmaan_node_search');
 
-        $rootNode
-            ->children()
-                ->booleanNode('enable_update_listener')
-                    ->defaultTrue()
-                ->end()
-            ->end();
+        $rootNode->children()->booleanNode('enable_update_listener')->defaultTrue();
+
+        /** @var ArrayNodeDefinition $properties */
+        $properties = $rootNode->children()->arrayNode('mapping')->prototype('array');
+        $properties->children()->scalarNode('type')->beforeNormalization()->ifNotInArray($types = [
+            'string', 'token_count',
+            'float', 'double', 'byte', 'short', 'integer', 'long',
+            'date',
+            'boolean',
+            'binary',
+        ])->thenInvalid('type must be one of: ' . implode(', ', $types));
+        $properties->children()->scalarNode('index')->beforeNormalization()->ifNotInArray(['analyzed', 'not_analyzed', 'no'])
+            ->thenInvalid("index must be one of: analyzed, not_analyzed, no");
+        $properties->children()->booleanNode('include_in_all')->defaultFalse();
+        $properties->children()->booleanNode('store')->defaultFalse();
+        $properties->children()->floatNode('boost');
+        $properties->children()->scalarNode('null_value');
+        $properties->children()->scalarNode('analyzer');
+        $properties->children()->scalarNode('index_analyzer');
+        $properties->children()->scalarNode('index_name');
+
 
         return $treeBuilder;
     }

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
@@ -25,7 +25,8 @@ class Configuration implements ConfigurationInterface
         $rootNode->children()->booleanNode('enable_update_listener')->defaultTrue();
 
         /** @var ArrayNodeDefinition $properties */
-        $properties = $rootNode->children()->arrayNode('mapping')->prototype('array');
+        $properties = $rootNode->children()->arrayNode('mapping')->useAttributeAsKey('name')->prototype('array');
+
         $properties->children()->scalarNode('type')->beforeNormalization()->ifNotInArray($types = [
             'string', 'token_count',
             'float', 'double', 'byte', 'short', 'integer', 'long',
@@ -35,8 +36,8 @@ class Configuration implements ConfigurationInterface
         ])->thenInvalid('type must be one of: ' . implode(', ', $types));
         $properties->children()->scalarNode('index')->beforeNormalization()->ifNotInArray(['analyzed', 'not_analyzed', 'no'])
             ->thenInvalid("index must be one of: analyzed, not_analyzed, no");
-        $properties->children()->booleanNode('include_in_all')->defaultFalse();
-        $properties->children()->booleanNode('store')->defaultFalse();
+        $properties->children()->booleanNode('include_in_all');
+        $properties->children()->booleanNode('store');
         $properties->children()->floatNode('boost');
         $properties->children()->scalarNode('null_value');
         $properties->children()->scalarNode('analyzer');

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeSearchBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -12,7 +13,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class KunstmaanNodeSearchExtension extends Extension
+class KunstmaanNodeSearchExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritDoc}
@@ -28,5 +29,89 @@ class KunstmaanNodeSearchExtension extends Extension
         if (!empty($config['enable_update_listener']) && $config['enable_update_listener']) {
             $loader->load('update_listener.yml');
         }
+
+        $container->getDefinition('kunstmaan_node_search.search_configuration.node')
+            ->addMethodCall('setDefaultProperties', [$config['mapping']]);
+    }
+
+    /**
+     * Allow an extension to prepend the extension configurations.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->prependExtensionConfig('kunstmaan_node_search', [
+            'mapping' => [
+                'node_id'            => [
+                    'type'           => 'integer',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'nodetranslation_id' => [
+                    'type'           => 'integer',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'nodeversion_id'     => [
+                    'type'           => 'integer',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'title'              => [
+                    'type'           => 'string',
+                    'include_in_all' => true
+                ],
+                'lang'               => [
+                    'type'           => 'string',
+                    'include_in_all' => true,
+                    'index'          => 'not_analyzed'
+                ],
+                'slug'               => [
+                    'type'           => 'string',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'type'               => [
+                    'type'           => 'string',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'page_class'         => [
+                    'type'           => 'string',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'contentanalyzer'    => [
+                    'type'           => 'string',
+                    'include_in_all' => true,
+                    'index'          => 'not_analyzed'
+                ],
+                'content'            => [
+                    'type'           => 'string',
+                    'include_in_all' => true
+                ],
+                'created'            => [
+                    'type'           => 'date',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'updated'            => [
+                    'type'           => 'date',
+                    'include_in_all' => false,
+                    'index'          => 'not_analyzed'
+                ],
+                'view_roles'         => [
+                    'type'           => 'string',
+                    'include_in_all' => true,
+                    'index'          => 'not_analyzed',
+                    'index_name'     => 'view_role'
+                ],
+                '_boost'             => [
+                    'type'           => 'float',
+                    'include_in_all' => false
+                ]
+            ]
+        ]);
     }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Event/IndexNodeEvent.php
+++ b/src/Kunstmaan/NodeSearchBundle/Event/IndexNodeEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Event;
+
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class IndexNodeEvent extends Event
+{
+    const EVENT_INDEX_NODE = 'kunstmaan_node_search.onIndexNode';
+
+    /**
+     * @var array
+     */
+    public $doc;
+    /**
+     * @var HasNodeInterface
+     */
+    private $page;
+
+    public function __construct(HasNodeInterface $page, array $doc)
+    {
+        $this->doc = $doc;
+        $this->page = $page;
+    }
+
+    /**
+     * @return HasNodeInterface
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+
+}

--- a/src/Kunstmaan/NodeSearchBundle/Helper/IndexablePagePartsService.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/IndexablePagePartsService.php
@@ -2,9 +2,8 @@
 
 namespace Kunstmaan\NodeSearchBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
-use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\SearchBundle\Helper\IndexableInterface;
 
 /**
@@ -26,12 +25,12 @@ class IndexablePagePartsService
     /**
      * Returns all indexable pageparts for the specified page and context
      *
-     * @param HasNodeInterface $page
-     * @param string           $context
+     * @param HasPagePartsInterface $page
+     * @param string                $context
      *
      * @return array
      */
-    public function getIndexablePageParts(HasNodeInterface $page, $context = 'main')
+    public function getIndexablePageParts(HasPagePartsInterface $page, $context = 'main')
     {
         $pageparts = $this->em
             ->getRepository('KunstmaanPagePartBundle:PagePartRef')

--- a/src/Kunstmaan/NodeSearchBundle/README.md
+++ b/src/Kunstmaan/NodeSearchBundle/README.md
@@ -56,9 +56,11 @@ You may configure the index mapping via Symfony config. For example:
 kunstmaan_node_search:
     mapping:
         average_score:
+            name: average_score
             type: float
             index: not_analyzed
         tags:
+            name: tags
             type: string
             index: analyzed
 ```

--- a/src/Kunstmaan/NodeSearchBundle/README.md
+++ b/src/Kunstmaan/NodeSearchBundle/README.md
@@ -47,6 +47,28 @@ Extend the AbstractSearchPage and add your new class as a possible child to a pa
     }
 ```
 
+### Custom mapping
+
+You may configure the index mapping via Symfony config. For example:
+
+```
+# config.yml
+kunstmaan_node_search:
+    mapping:
+        average_score:
+            type: float
+            index: not_analyzed
+        tags:
+            type: string
+            index: analyzed
+```
+
+Please notice that this *does not* index any data.
+
+## Adding data to index
+
+Pages can implement `HasCustomSearchDataInterface` to dynamically add more data to the document while indexing. For more complex scenarios a service can listen on the `kunstmaan_node_search.onIndexNode` event.
+
 ## Documentation
 
 Find more documentation on how it works [here](https://github.com/Kunstmaan/KunstmaanNodeSearchBundle/tree/master/Resources/doc/NodeSearchBundle.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #411

The index mapping configuration is now in bundle config and can be tweaked by the end user easily. 

In addition, I have restored the `onIndexNode` event as well as added an interface to extend the indexed document by adding custom data.

```yaml
kunstmaan_node_search:
    mapping:
        average_score:
            name: average_score
            type: float
            index: not_analyzed
        tags:
            name: tags
            type: string
            index: analyzed
```