### PR TITLE
[AdminBundle, NodeBundle] allow changing nodes parent in sidebar tree

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
@@ -6,6 +6,7 @@ pages:
   pagenottranslated: This page is not translated
   copyfrom: Copy from language
   createemptypage: Create as an empty page
+  movingconfirmation: You are moving "%title%" to "%target%", are you sure?
 
 # Modules
 modules:

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
@@ -1,6 +1,13 @@
 {% set nodeId = menuitem.uniqueId %}
 
-<li id="{{ nodeId }}"{% if menuitem.offline %} data-jstree='{"type":"offline"}'{% endif %} class="{% if menuitem.active or nodeId == 'node-1' %}jstree-open{% endif %}{% if menuitem.offline %} jstree-node--offline{% endif %}"{% if menuitem.role %} rel="{{menuitem.role}}"{% endif %}>
+<li id="{{ nodeId }}"{% if menuitem.offline %} data-jstree='{"type":"offline"}'{% endif %}
+        {% if menuitem.attributes.page is defined %}
+            {% if menuitem.attributes.page.icon is defined %}
+                data-jstree='{{ {"icon": menuitem.attributes.page.icon}|json_encode }}'
+            {% endif %}
+            data-page="{{ menuitem.attributes.page|json_encode }}"
+        {% endif %}
+    class="{% if menuitem.active or nodeId == 'node-1' %}jstree-open{% endif %}{% if menuitem.offline %} jstree-node--offline{% endif %}"{% if menuitem.role %} rel="{{menuitem.role}}"{% endif %}>
     {% if menuitem.route %}
         <a href="{{ path(menuitem.route, menuitem.routeparams) }}" class="{% if currentMenuItem is not null and currentMenuItem.uniqueId == menuitem.uniqueId %}active{% endif %}">
             {{ menuitem.label }}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/sidebar.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/sidebar.html.twig
@@ -13,7 +13,9 @@
 
 <!-- Tree -->
 {% set currentMenuItem = adminmenu.current %}
-<nav role="navigation" id="app__sidebar__navigation" class="app__sidebar__module app__sidebar__navigation" data-reorder-url="{{ path('KunstmaanNodeBundle_nodes_reorder') }}">
+<nav role="navigation" id="app__sidebar__navigation" class="app__sidebar__module app__sidebar__navigation"
+    data-reorder-url="{{ path('KunstmaanNodeBundle_nodes_reorder') }}"
+    data-moving-confirmation="{{ "pages.movingconfirmation"|trans }}">
     {% set currentMenuItem = adminmenu.current %}
     <ul>
     {% if lowestTopChild.appearInSidebar %}

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -482,6 +482,7 @@ class NodeAdminController extends Controller
         $this->init();
         $nodes = array();
         $nodeIds = $request->get('nodes');
+        $changeParents = $request->get('parent');
 
         foreach($nodeIds as $id){
             /* @var Node $node */
@@ -492,6 +493,16 @@ class NodeAdminController extends Controller
 
         $weight = 0;
         foreach($nodes as $node){
+
+            $newParentId = isset($changeParents[$node->getId()]) ? $changeParents[$node->getId()] : null;
+            if ($newParentId) {
+                $parent = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($newParentId);
+                $this->checkPermission($parent, PermissionMap::PERMISSION_EDIT);
+                $node->setParent($parent);
+                $this->em->persist($node);
+                $this->em->flush($node);
+            }
+
 
             /* @var NodeTranslation $nodeTranslation */
             $nodeTranslation = $node->getNodeTranslation($this->locale, true);

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\NodeBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -18,11 +19,23 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('kunstmaan_node');
+        $root = $treeBuilder->root('kunstmaan_node');
 
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
+        /** @var ArrayNodeDefinition $pages */
+        $pages = $root->children()->arrayNode('pages')->prototype('array');
+        $pages->children()->scalarNode('name')->isRequired();
+        $pages->children()->scalarNode('search_type');
+        $pages->children()->booleanNode('structure_node');
+        $pages->children()->booleanNode('indexable');
+        $pages->children()->scalarNode('icon')->defaultNull();
+        $pages->children()->scalarNode('hidden_from_tree');
+
+        /** @var ArrayNodeDefinition $children */
+        $children = $pages->children()->arrayNode('allowed_children')->prototype('array');
+        $children->beforeNormalization()->ifString()->then(function ($v) { return ["class" => $v]; });
+        $children->children()->scalarNode('class')->isRequired();
+        $children->children()->scalarNode('name');
+
         return $treeBuilder;
     }
 }

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -21,13 +22,17 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $container->setParameter('twig.form.resources', array_merge(
             $container->getParameter('twig.form.resources'),
             array('KunstmaanNodeBundle:Form:formWidgets.html.twig')
+        ));
+
+        $container->setDefinition('kunstmaan_node.pages_configuration', new Definition(
+            'Kunstmaan\NodeBundle\Helper\PagesConfiguration', [$config['pages']]
         ));
 
         $loader->load('services.yml');
@@ -44,7 +49,7 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
         $container->prependExtensionConfig('cmf_routing', $cmfRoutingExtraConfig);
 
         $configs = $container->getExtensionConfig($this->getAlias());
-        $config = $this->processConfiguration(new Configuration(), $configs);
+        $this->processConfiguration(new Configuration(), $configs);
 
     }
 }

--- a/src/Kunstmaan/NodeBundle/Entity/HasNodeInterface.php
+++ b/src/Kunstmaan/NodeBundle/Entity/HasNodeInterface.php
@@ -41,6 +41,7 @@ interface HasNodeInterface extends EntityInterface
 
     /**
      * @return array
+     * @deprecated — use PagesConfiguration
      */
     public function getPossibleChildTypes();
 

--- a/src/Kunstmaan/NodeBundle/Entity/HideFromNodeTreeInterface.php
+++ b/src/Kunstmaan/NodeBundle/Entity/HideFromNodeTreeInterface.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\NodeBundle\Entity;
 
+/**
+ * @deprecated — use PagesConfiguration class
+ */
 interface HideFromNodeTreeInterface
 {
 }

--- a/src/Kunstmaan/NodeBundle/Entity/NodeVersion.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeVersion.php
@@ -125,6 +125,17 @@ class NodeVersion extends AbstractEntity
         return $this->type;
     }
 
+    public function isDraft()
+    {
+        return self::DRAFT_VERSION === $this->type;
+    }
+
+    public function isPublic()
+    {
+        return self::PUBLIC_VERSION === $this->type;
+    }
+
+
     /**
      * Set type
      *

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -3,16 +3,15 @@
 namespace Kunstmaan\NodeBundle\Helper\Menu;
 
 use Doctrine\ORM\EntityManager;
-use Kunstmaan\NodeBundle\Entity\PageInterface;
 
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\NodeBundle\Event\ConfigureActionMenuEvent;
 use Kunstmaan\NodeBundle\Event\Events;
 
+use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 use Knp\Menu\ItemInterface;
@@ -54,6 +53,11 @@ class ActionsMenuBuilder
      */
     private $context;
 
+    /**
+     * @var PagesConfiguration
+     */
+    private $pagesConfiguration;
+
     private $isEditableNode = true;
 
 
@@ -63,31 +67,35 @@ class ActionsMenuBuilder
      * @param RouterInterface          $router     The router
      * @param EventDispatcherInterface $dispatcher The event dispatcher
      * @param SecurityContextInterface $context    The security context
+     * @param PagesConfiguration       $pagesConfiguration
      */
-    public function __construct(FactoryInterface $factory, EntityManager $em, RouterInterface $router, EventDispatcherInterface $dispatcher, SecurityContextInterface $context)
+    public function __construct(
+        FactoryInterface $factory,
+        EntityManager $em,
+        RouterInterface $router,
+        EventDispatcherInterface $dispatcher,
+        SecurityContextInterface $context,
+        PagesConfiguration $pagesConfiguration)
     {
         $this->factory = $factory;
         $this->em      = $em;
         $this->router  = $router;
         $this->dispatcher = $dispatcher;
         $this->context = $context;
+        $this->pagesConfiguration = $pagesConfiguration;
     }
 
     /**
-     * @param Request $request
-     *
      * @return ItemInterface
      */
-    public function createSubActionsMenu(/** @noinspection PhpUnusedParameterInspection */Request $request = null)
+    public function createSubActionsMenu()
     {
         $activeNodeVersion = $this->getActiveNodeVersion();
         $menu              = $this->factory->createItem('root');
-	$menu->setChildrenAttribute('class', 'page-sub-actions');
+        $menu->setChildrenAttribute('class', 'page-sub-actions');
 
-        if (!is_null($activeNodeVersion)) {
-            if ($this->isEditableNode) {
-                $menu->addChild('subaction.versions', array('linkAttributes' => array('data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#versions')));
-            }
+        if (null !== $activeNodeVersion && $this->isEditableNode) {
+            $menu->addChild('subaction.versions', array('linkAttributes' => array('data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#versions')));
         }
 
         $this->dispatcher->dispatch(Events::CONFIGURE_SUB_ACTION_MENU, new ConfigureActionMenuEvent($this->factory, $menu, $activeNodeVersion));
@@ -96,63 +104,72 @@ class ActionsMenuBuilder
     }
 
     /**
-     * @param Request $request
-     *
      * @return ItemInterface
      */
-    public function createActionsMenu(Request $request = null)
+    public function createActionsMenu()
     {
         $activeNodeVersion = $this->getActiveNodeVersion();
         $menu              = $this->factory->createItem('root');
-	$menu->setChildrenAttribute('class', 'page-main-actions js-auto-collapse-buttons');
+        $menu->setChildrenAttribute('class', 'page-main-actions js-auto-collapse-buttons');
 
 
-        if (!is_null($activeNodeVersion)) {
-            $activeNodeTranslation = $activeNodeVersion->getNodeTranslation();
-            $node = $activeNodeTranslation->getNode();
-            $queuedNodeTranslationAction = $this->em->getRepository('KunstmaanNodeBundle:QueuedNodeTranslationAction')->findOneBy(array('nodeTranslation' => $activeNodeTranslation));
+        if (null === $activeNodeVersion) {
+            $this->dispatcher->dispatch(Events::CONFIGURE_ACTION_MENU, new ConfigureActionMenuEvent($this->factory, $menu, $activeNodeVersion));
 
-            $isFirst = true;
-            if (('draft' == $activeNodeVersion->getType()) && $this->isEditableNode) {
-                if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node)) {
-		    $menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'js-save-btn btn btn--raise-on-hover' . ($isFirst ? ' btn-primary' : ' btn-default'), 'value' => 'save', 'name' => 'save'), 'extras' => array('renderType' => 'button')));
-                    $isFirst = false;
-                }
-		$menu->addChild('action.preview', array('uri' => $this->router->generate('_slug_preview', array('url' => $activeNodeTranslation->getUrl(), 'version' => $activeNodeVersion->getId())), 'linkAttributes' => array('target' => '_blank', 'class' => 'btn btn-default btn--raise-on-hover')));
-                if (empty($queuedNodeTranslationAction) && $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node)) {
-		    $menu->addChild('action.publish', array('linkAttributes' => array('data-toggle' => 'modal', 'data-target' => '#pub', 'class' => 'btn btn--raise-on-hover' . ($isFirst ? ' btn-primary btn-save' : ' btn-default'))));
-                }
-            } else {
-                if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node) && $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node)) {
-		    $menu->addChild('action.save', array('linkAttributes' => array('type' => 'submit', 'class' => 'js-save-btn btn btn--raise-on-hover' . ($isFirst ? ' btn-primary' : ' btn-default'), 'value' => 'save', 'name' => 'save'), 'extras' => array('renderType' => 'button')));
-                    $isFirst = false;
-                }
-                if ($this->isEditableNode) {
-		    $menu->addChild('action.preview', array('uri' => $this->router->generate('_slug_preview', array('url' => $activeNodeTranslation->getUrl())), 'linkAttributes' => array('target' => '_blank', 'class' => 'btn btn-default btn--raise-on-hover')));
-                    if (empty($queuedNodeTranslationAction) && $activeNodeTranslation->isOnline() &&  $this->context->isGranted(PermissionMap::PERMISSION_UNPUBLISH, $node)) {
-			$menu->addChild('action.unpublish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#unpub')));
-                    } elseif (empty($queuedNodeTranslationAction) && !$activeNodeTranslation->isOnline() &&  $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node)) {
-			$menu->addChild('action.publish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#pub')));
-                    }
-                    if ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node)) {
-			$menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'btn btn--raise-on-hover' . ($isFirst ? ' btn-primary btn-save' : ' btn-default'), 'value' => 'saveasdraft', 'name' => 'saveasdraft'), 'extras' => array('renderType' => 'button')));
-                    }
-                }
+            return $menu;
+        }
+
+        $activeNodeTranslation = $activeNodeVersion->getNodeTranslation();
+        $node = $activeNodeTranslation->getNode();
+        $queuedNodeTranslationAction = $this->em->getRepository('KunstmaanNodeBundle:QueuedNodeTranslationAction')->findOneBy(array('nodeTranslation' => $activeNodeTranslation));
+
+        $isFirst = true;
+        $canEdit = $this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node);
+        $canPublish = $this->context->isGranted(PermissionMap::PERMISSION_PUBLISH, $node);
+
+        if ($activeNodeVersion->isDraft() && $this->isEditableNode) {
+            if ($canEdit) {
+                $menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'js-save-btn btn btn--raise-on-hover btn-primary', 'value' => 'save', 'name' => 'save'), 'extras' => array('renderType' => 'button')));
+                $isFirst = false;
             }
 
-            $page = $activeNodeVersion->getRef($this->em);
-            if (!is_null($page) && $page instanceof PageInterface) {
-                $possibleChildPages = $page->getPossibleChildTypes();
-                if (!empty($possibleChildPages)) {
-		    $menu->addChild('action.addsubpage', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#add-subpage-modal'), 'extras' => array('renderType' => 'button')));
+            $menu->addChild('action.preview', array('uri' => $this->router->generate('_slug_preview', array('url' => $activeNodeTranslation->getUrl(), 'version' => $activeNodeVersion->getId())), 'linkAttributes' => array('target' => '_blank', 'class' => 'btn btn-default btn--raise-on-hover')));
+
+            if (empty($queuedNodeTranslationAction) && $canPublish) {
+                $menu->addChild('action.publish', array('linkAttributes' => array('data-toggle' => 'modal', 'data-target' => '#pub', 'class' => 'btn btn--raise-on-hover' . ($isFirst ? ' btn-primary btn-save' : ' btn-default'))));
+            }
+
+        } else {
+            if ($canEdit && $canPublish) {
+                $menu->addChild('action.save', array('linkAttributes' => array('type' => 'submit', 'class' => 'js-save-btn btn btn--raise-on-hover btn-primary', 'value' => 'save', 'name' => 'save'), 'extras' => array('renderType' => 'button')));
+                $isFirst = false;
+            }
+
+            if ($this->isEditableNode) {
+                $menu->addChild('action.preview', array('uri' => $this->router->generate('_slug_preview', array('url' => $activeNodeTranslation->getUrl())), 'linkAttributes' => array('target' => '_blank', 'class' => 'btn btn-default btn--raise-on-hover')));
+
+                if (empty($queuedNodeTranslationAction) && $activeNodeTranslation->isOnline() &&  $this->context->isGranted(PermissionMap::PERMISSION_UNPUBLISH, $node)) {
+                    $menu->addChild('action.unpublish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#unpub')));
+                } elseif (empty($queuedNodeTranslationAction) && !$activeNodeTranslation->isOnline() && $canPublish) {
+                    $menu->addChild('action.publish', array('linkAttributes' => array('class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#pub')));
+                }
+
+                if ($canEdit) {
+                    $menu->addChild('action.saveasdraft', array('linkAttributes' => array('type' => 'submit', 'class' => 'btn btn--raise-on-hover' . ($isFirst ? ' btn-primary btn-save' : ' btn-default'), 'value' => 'saveasdraft', 'name' => 'saveasdraft'), 'extras' => array('renderType' => 'button')));
                 }
             }
-            if (!is_null($node->getParent()) && ($this->context->isGranted(PermissionMap::PERMISSION_EDIT, $node))) {
-                $menu->addChild('action.duplicate', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#duplicate-page-modal'), 'extras' => array('renderType' => 'button')));
-            }
-            if (!is_null($node->getParent()) && ($this->context->isGranted(PermissionMap::PERMISSION_DELETE, $node))) {
-		$menu->addChild('action.delete', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'onClick' => 'oldEdited = isEdited; isEdited=false', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#delete-page-modal'), 'extras' => array('renderType' => 'button')));
-            }
+        }
+
+        if ($this->pagesConfiguration->getPossibleChildTypes($node->getRefEntityName())) {
+            $menu->addChild('action.addsubpage', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#add-subpage-modal'), 'extras' => array('renderType' => 'button')));
+        }
+
+        if (null !== $node->getParent() && $canEdit) {
+            $menu->addChild('action.duplicate', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#duplicate-page-modal'), 'extras' => array('renderType' => 'button')));
+        }
+
+        if (null !== $node->getParent() && $this->context->isGranted(PermissionMap::PERMISSION_DELETE, $node)) {
+            $menu->addChild('action.delete', array('linkAttributes' => array('type' => 'button', 'class' => 'btn btn-default btn--raise-on-hover', 'onClick' => 'oldEdited = isEdited; isEdited=false', 'data-toggle' => 'modal', 'data-keyboard' => 'true', 'data-target' => '#delete-page-modal'), 'extras' => array('renderType' => 'button')));
         }
 
         $this->dispatcher->dispatch(Events::CONFIGURE_ACTION_MENU, new ConfigureActionMenuEvent($this->factory, $menu, $activeNodeVersion));
@@ -161,15 +178,13 @@ class ActionsMenuBuilder
     }
 
     /**
-     * @param Request $request
-     *
      * @return ItemInterface
      */
-    public function createTopActionsMenu(Request $request = null)
+    public function createTopActionsMenu()
     {
-        $menu = $this->createActionsMenu($request);
-	$menu->setChildrenAttribute('id', 'page-main-actions-top');
-	$menu->setChildrenAttribute('class', 'page-main-actions page-main-actions--top');
+        $menu = $this->createActionsMenu();
+        $menu->setChildrenAttribute('id', 'page-main-actions-top');
+        $menu->setChildrenAttribute('class', 'page-main-actions page-main-actions--top');
 
         return $menu;
     }

--- a/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
+++ b/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
@@ -21,7 +21,7 @@ class PagesConfiguration
 
     public function getName($refName)
     {
-        return $this->getValue($refName, 'name');
+        return $this->getValue($refName, 'name', substr($refName, strrpos($refName, '\\')+1));
     }
 
     public function getIcon($refName)

--- a/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
+++ b/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Helper;
+
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use /** @noinspection PhpDeprecationInspection */
+    Kunstmaan\NodeBundle\Entity\HideFromNodeTreeInterface;
+use /** @noinspection PhpDeprecationInspection */
+    Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
+use Kunstmaan\SearchBundle\Helper\IndexableInterface;
+use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
+
+class PagesConfiguration
+{
+    private $configuration;
+
+    public function __construct($configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function getName($refName)
+    {
+        return $this->getValue($refName, 'name');
+    }
+
+    public function getIcon($refName)
+    {
+        return $this->getValue($refName, 'icon');
+    }
+
+    public function isHiddenFromTree($refName)
+    {
+        return $this->getValue($refName, 'hidden_from_tree', function ($page) {
+            /** @noinspection PhpDeprecationInspection */
+            return $page instanceof HideFromNodeTreeInterface;
+        });
+    }
+
+    public function isIndexable($refName)
+    {
+        return $this->getValue($refName, 'indexable', function ($page) {
+            /** @var IndexableInterface $page */
+            return false === $page instanceof IndexableInterface || $page->isIndexable();
+        });
+    }
+
+    public function getSearchType($refName)
+    {
+        return $this->getValue($refName, 'search_type', function ($page) {
+            /** @noinspection PhpDeprecationInspection */
+            return $page instanceof SearchTypeInterface ? $page->getSearchType() : ClassLookup::getClass($page);
+        });
+    }
+
+    public function isStructureNode($refName)
+    {
+        return $this->getValue($refName, 'structure_node', function ($page) {
+            /** @noinspection PhpDeprecationInspection */
+            return $page instanceof HasNodeInterface && $page->isStructureNode();
+        });
+    }
+
+    public function getPossibleChildTypes($refName)
+    {
+        $types = $this->getValue($refName, 'allowed_children', function ($page) {
+            /** @noinspection PhpDeprecationInspection */
+            return ($page instanceof HasNodeInterface) ? $page->getPossibleChildTypes() : [];
+        });
+
+        return array_map(function ($type) {
+            return $type + ['name' => $this->getName($type['class'])]; // add if not set
+        }, $types);
+    }
+
+    /**
+     * @param string         $ref
+     * @param string         $name
+     * @param Callable|mixed $default
+     *
+     * @return mixed
+     */
+    private function getValue($ref, $name, $default = null)
+    {
+        $refName = is_object($ref) ? ClassLookup::getClass($ref) : $ref;
+
+        if (isset($this->configuration[$refName][$name])) {
+            return $this->configuration[$refName][$name];
+        }
+
+        if (false === is_callable($default)) {
+            return $default;
+        }
+
+        $page = is_object($ref) ? $ref : new $refName;
+        $result = $default($page);
+        unset($page);
+
+        $this->configuration[$refName][$name] = $result;
+
+        return $result;
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
+++ b/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php
@@ -92,7 +92,7 @@ class PagesConfiguration
             return $default;
         }
 
-        $page = is_object($ref) ? $ref : new $refName;
+        $page = is_string($ref) ? new $refName : $ref;
         $result = $default($page);
         unset($page);
 

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     kunstmaan_node.menu.adaptor.pages:
         class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor
-        arguments: ["@doctrine.orm.entity_manager", "@kunstmaan_admin.acl.native.helper"]
+        arguments: ["@doctrine.orm.entity_manager", "@kunstmaan_admin.acl.native.helper", "@kunstmaan_node.pages_configuration" ]
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
@@ -34,7 +34,7 @@ services:
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ["@knp_menu.factory", "@doctrine.orm.entity_manager", "@router", "@event_dispatcher", "@security.context"]
+        arguments: ["@knp_menu.factory", "@doctrine.orm.entity_manager", "@router", "@event_dispatcher", "@security.context", "@kunstmaan_node.pages_configuration" ]
 
     kunstmaan_node.menu.sub_actions:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
@@ -89,6 +89,13 @@ services:
     kunstmaan_node.node.twig.extension:
         class: Kunstmaan\NodeBundle\Twig\NodeTwigExtension
         arguments: ["@doctrine.orm.entity_manager", "@router", "@security.context", "@kunstmaan_admin.acl.helper"]
+        tags:
+            - { name: twig.extension }
+
+    kunstmaan_node.pages_configuration.twig_extension:
+        class: Kunstmaan\NodeBundle\Twig\PagesConfigurationTwigExtension
+        public: false
+        arguments: [ @kunstmaan_node.pages_configuration ]
         tags:
             - { name: twig.extension }
 

--- a/src/Kunstmaan/NodeBundle/Resources/doc/PagesConfiguration.md
+++ b/src/Kunstmaan/NodeBundle/Resources/doc/PagesConfiguration.md
@@ -1,0 +1,34 @@
+# Pages Configuration
+
+## Example
+
+```
+kunstmaan_node:
+    pages:
+        AcmeBundle\Entity\Pages\HomePage:
+            name: Home page
+            indexable: false
+            # font awesome icons:
+            icon: fa fa-home
+            # hide from sidebar tree in admin panel:
+            hidden_from_tree: false
+            allowed_children:
+                # simple reference:
+                - AcmeBundle\Entity\Pages\SearchPage
+                # custom reference:
+                - name: Custom name
+                  class: AcmeBundle\Entity\Pages\ArticlePage
+
+        AcmeBundle\Entity\Pages\ArticlePage:
+            # the name is translated by default:
+            name: pages.article
+            indexable: true
+            icon: fa fa-newspaper
+            search_type: article
+
+        AcmeBundle\Entity\Pages\SearchPage:
+            name: Search results page
+            indexable: false
+            icon: fa fa-search
+
+```

--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
@@ -208,7 +208,7 @@
 
 
 <!-- Modal - Add subpage -->
-{% set pagePossibleChildPages = page.possibleChildTypes %}
+{% set pagePossibleChildPages = get_possible_child_types(page) %}
 {% if pagePossibleChildPages is not empty %}
     <div id="add-subpage-modal" class="modal fade">
     <div class="modal-dialog">
@@ -238,7 +238,7 @@
                 </label>
                 <select name="type" id="addpage_type" class="form-control">
                 {% for pageType in pagePossibleChildPages %}
-                    <option value="{{ pageType.class }}">{{ pageType.name }}</option>
+                    <option value="{{ pageType.class }}">{{ pageType.name|trans }}</option>
                 {% endfor %}
                 </select>
             </div>

--- a/src/Kunstmaan/NodeBundle/Tests/Helper/Menu/ActionsMenuBuilderTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/Helper/Menu/ActionsMenuBuilderTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\NodeBundle\Tests\Helper\Menu;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\Integration\Symfony\RoutingExtension;
 use Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder;
+use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
 use Kunstmaan\NodeBundle\Tests\Stubs\TestRepository;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
@@ -48,7 +49,8 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         /* @var SecurityContextInterface $context */
-        $this->builder = new ActionsMenuBuilder($factory, $em, $router, $dispatcher, $context);
+        $this->builder = new ActionsMenuBuilder($factory, $em, $router, $dispatcher, $context,
+            new PagesConfiguration([]));
     }
 
     /**
@@ -58,13 +60,14 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockedEntityManager()
     {
-        $emMock  = $this->getMock('\Doctrine\ORM\EntityManager', array('getRepository', 'getClassMetadata', 'persist', 'flush'), array(), '', false);
+        $emMock = $this->getMock('\Doctrine\ORM\EntityManager',
+            array('getRepository', 'getClassMetadata', 'persist', 'flush'), array(), '', false);
         $emMock->expects($this->any())
             ->method('getRepository')
             ->will($this->returnValue(new TestRepository()));
         $emMock->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnValue((object) array('name' => 'aClass')));
+            ->will($this->returnValue((object)array('name' => 'aClass')));
         $emMock->expects($this->any())
             ->method('persist')
             ->will($this->returnValue(null));
@@ -100,7 +103,7 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $menu = $this->builder->createSubActionsMenu();
         $this->assertNotNull($menu->getChild('subaction.versions'));
 
-	$this->assertEquals('page-sub-actions',$menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-sub-actions', $menu->getChildrenAttribute('class'));
     }
 
     /**
@@ -125,7 +128,7 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($menu->getChild('action.save'));
         $this->assertNull($menu->getChild('action.delete'));;
 
-	$this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
     }
 
     /**
@@ -160,7 +163,7 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($menu->getChild('action.unpublish'));
         $this->assertNull($menu->getChild('action.delete'));
 
-	$this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
     }
 
     /**
@@ -187,7 +190,7 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($menu->getChild('action.publish'));
         $this->assertNull($menu->getChild('action.unpublish'));
 
-	$this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
     }
 
     /**
@@ -201,14 +204,12 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $nodeVersion = new NodeVersion();
         $nodeVersion->setNodeTranslation($nodeTranslation);
 
-        $testEntity = new \Kunstmaan\NodeBundle\Tests\Entity\TestEntity();
-
         $this->builder->setActiveNodeVersion($nodeVersion);
 
 
         $menu = $this->builder->createTopActionsMenu();
-	$this->assertEquals('page-main-actions page-main-actions--top', $menu->getChildrenAttribute('class'));
-	$this->assertEquals('page-main-actions-top', $menu->getChildrenAttribute('id'));
+        $this->assertEquals('page-main-actions page-main-actions--top', $menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-main-actions-top', $menu->getChildrenAttribute('id'));
     }
 
     /**
@@ -242,7 +243,7 @@ class ActionsMenuBuilderTest extends \PHPUnit_Framework_TestCase
         $menu = $this->builder->createActionsMenu();
         $this->assertNotNull($menu->getChild('action.delete'));
 
-	$this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
+        $this->assertEquals('page-main-actions js-auto-collapse-buttons', $menu->getChildrenAttribute('class'));
     }
 
 }

--- a/src/Kunstmaan/NodeBundle/Twig/PagesConfigurationTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/PagesConfigurationTwigExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Twig;
+
+use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
+
+class PagesConfigurationTwigExtension extends \Twig_Extension
+{
+    /** @var PagesConfiguration */
+    private $pagesConfiguration;
+
+    /**
+     * @param PagesConfiguration $pagesConfiguration
+     */
+    public function __construct(PagesConfiguration $pagesConfiguration)
+    {
+        $this->pagesConfiguration = $pagesConfiguration;
+    }
+
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return [
+            'get_possible_child_types' => new \Twig_SimpleFunction('get_possible_child_types', function ($ref) {
+                return $this->pagesConfiguration->getPossibleChildTypes($ref);
+            })
+        ];
+    }
+
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'pages_configuration_twig_extension';
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -11,10 +11,8 @@ use Kunstmaan\NodeSearchBundle\Helper\SearchViewTemplateInterface;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
-use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\SearchBundle\Configuration\SearchConfigurationInterface;
-use Kunstmaan\SearchBundle\Helper\IndexableInterface;
 use Kunstmaan\SearchBundle\Provider\SearchProviderInterface;
 use Kunstmaan\SearchBundle\Search\AnalysisFactoryInterface;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
@@ -241,8 +239,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     protected function isIndexable(HasNodeInterface $page)
     {
-        // If the page doesn't implement IndexableInterface interface or it returns true on isIndexable, index the page
-        return (!($page instanceof IndexableInterface) || $page->isIndexable());
+        return $this->container->get('kunstmaan_node.pages_configuration')->isIndexable($page);
     }
 
     /**
@@ -473,12 +470,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     protected function addSearchType($page, &$doc)
     {
-        // Type
-        $type = ClassLookup::getClassName($page);
-        if ($page instanceof SearchTypeInterface) {
-            $type = $page->getSearchType();
-        }
-        $doc['type'] = $type;
+        $doc['type'] = $this->container->get('kunstmaan_node.pages_configuration')->getSearchType($page);
     }
 
     /**

--- a/src/Kunstmaan/NodeSearchBundle/Helper/SearchTypeInterface.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/SearchTypeInterface.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeSearchBundle\Helper;
 
 /**
  * Implement this interface to override the default 'type' (class name) to be indexed for this class.
+ * @deprecated — use PagesConfiguration
  */
 interface SearchTypeInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | -

## Deprecations:
 * `SearchTypeInterface`
 * `HideFromNodeTreeInterface`
 * `HasNodeInterface::getPossibleChildTypes()`

## New featres
 * `PagesConfiguration` — a service responsible for providing static configuration of page types, such as `isIndexable`, `isStructureNode` or `possibleChildTypes`
 * JsTree icons can now be changed using configuration (see example in documentation)
 * Nodes can be moved outside of their parents in JsTree but only according to `possibleChildTypes` configuration

## Configuration example

```yaml
kunstmaan_node:
    pages:
        AcmeBundle\Entity\Pages\HomePage:
            name: Home page
            indexable: false
            # font awesome icons:
            icon: fa fa-home
            # hide from sidebar tree in admin panel:
            hidden_from_tree: false
            allowed_children:
                # simple reference:
                - AcmeBundle\Entity\Pages\SearchPage
                # custom reference:
                - name: Custom name
                  class: AcmeBundle\Entity\Pages\ArticlePage

        AcmeBundle\Entity\Pages\ArticlePage:
            # the name is translated by default:
            name: pages.article
            indexable: true
            icon: fa fa-newspaper
            search_type: article

        AcmeBundle\Entity\Pages\SearchPage:
            name: Search results page
            indexable: false
            icon: fa fa-search

```