### PR TITLE
[AdminBundle] allow nesting non-compound forms

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -153,7 +153,9 @@
 
                 {# Items #}
                 {% for obj in form %}
-                    <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}" data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{{ obj.vars.value.id }}"{% if sortable %} data-sortkey="{{ obj.children[sortableField].vars.id }}"{% endif %}>
+                    <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
+                            data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.compound %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
+                            {% if sortable %}data-sortkey="{{ obj.children[sortableField].vars.id }}"{% endif %}>
                         {# Header #}
                         <header class="{% if sortable %}js-sortable-item__handle{% endif %} nested-form__item__header">
                             {% if sortable %}
@@ -165,9 +167,13 @@
 
                         {# View #}
                         <div class="js-nested-form__item__view nested-form__item__view">
-                            {% for child in obj.children %}
-                                {{ form_row(child) }}
-                            {% endfor %}
+                            {% if obj.vars.compound %}
+                                {{ form_widget(obj) }}
+                            {% else %}
+                                {% for child in obj.children %}
+                                    {{ form_row(child) }}
+                                {% endfor %}
+                            {% endif %}
                         </div>
                     </div>
                 {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

For non-compound (for example a doctrine `entity` type) forms the `obj.vars.value` attribute is a scalar, so you cannot get an `id` from it. Use the whole value as a `delete-key`. I didn’t test it on the pageparts, but on the main form it works well and the delete-key isn’t used any way.

Also, the non-compound form does not have children, so the whole thing is dumped using `form_widget()`