### PR TITLE
[TaggingBundle] lazy-load tags

### DIFF
--- a/src/Kunstmaan/TaggingBundle/Entity/LazyLoadingTaggableInterface.php
+++ b/src/Kunstmaan/TaggingBundle/Entity/LazyLoadingTaggableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kunstmaan\TaggingBundle\Entity;
+
+interface LazyLoadingTaggableInterface extends Taggable
+{
+    public function setTagLoader(\Closure $loader);
+}

--- a/src/Kunstmaan/TaggingBundle/Entity/TagManager.php
+++ b/src/Kunstmaan/TaggingBundle/Entity/TagManager.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\TaggingBundle\Entity;
 
 use DoctrineExtensions\Taggable\TagManager as BaseTagManager;
+use DoctrineExtensions\Taggable\Taggable as BaseTaggable;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 
@@ -13,12 +14,40 @@ class TagManager extends BaseTagManager
 
     const TAGGING_HYDRATOR = 'taggingHydrator';
 
+    public function loadTagging(Taggable $resource)
+    {
+        if ($resource instanceof LazyLoadingTaggableInterface) {
+            $resource->setTagLoader(function (Taggable $taggable) {
+                parent::loadTagging($taggable);
+            });
+
+            return ;
+        }
+
+        parent::loadTagging($resource);
+    }
+
+    public function saveTagging(Taggable $resource)
+    {
+        $tags = $resource->getTags();
+        parent::saveTagging($resource);
+        if (sizeof($tags) !== sizeof($resource->getTags())) {
+            // parent::saveTagging uses getTags by reference and removes elements, so it ends up empty :-/
+            // this causes all tags to be deleted when an entity is persisted more than once in a request
+            // Restore:
+            $this->replaceTags($tags->toArray(), $resource);
+        }
+
+    }
+
+
     /**
      * Gets all tags for the given taggable resource
      *
-     * @param \DoctrineExtensions\Taggable\Taggable $resource Taggable resource
+     * @param BaseTaggable $resource Taggable resource
+     * @return array
      */
-    public function getTagging(\DoctrineExtensions\Taggable\Taggable $resource)
+    public function getTagging(BaseTaggable $resource)
     {
         $em = $this->em;
 

--- a/src/Kunstmaan/TaggingBundle/Entity/TaggableTrait.php
+++ b/src/Kunstmaan/TaggingBundle/Entity/TaggableTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kunstmaan\TaggingBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Proxy\Proxy;
+
+/**
+ * @method getId
+ */
+trait TaggableTrait
+{
+    /**
+     * @var Collection
+     */
+    private $tags;
+    /**
+     * @var \Closure
+     */
+    private $lazyTagLoader;
+
+    /**
+     * Returns the unique taggable resource type
+     *
+     * @return string
+     */
+    public function getTaggableType()
+    {
+        return ($this instanceof Proxy) ? get_parent_class($this) : get_class($this);
+    }
+
+    /**
+     * Returns the unique taggable resource identifier
+     *
+     * @return string
+     */
+    public function getTaggableId()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * Returns the collection of tags for this Taggable entity
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getTags()
+    {
+        if (null === $this->tags) {
+            $this->tags = new ArrayCollection();
+
+            if ($this->lazyTagLoader) {
+                call_user_func($this->lazyTagLoader, $this);
+            }
+        }
+
+        return $this->tags;
+    }
+
+    public function setTags(Collection $tags)
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    public function setTagLoader(\Closure $loader)
+    {
+        $this->lazyTagLoader = $loader;
+    }
+}

--- a/src/Kunstmaan/TaggingBundle/EventListener/TagsListener.php
+++ b/src/Kunstmaan/TaggingBundle/EventListener/TagsListener.php
@@ -6,13 +6,17 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use DoctrineExtensions\Taggable\Taggable;
 
 use Kunstmaan\NodeBundle\Event\NodeEvent;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class TagsListener
 {
 
+    /**
+     * @var ContainerInterface
+     */
     protected $container;
 
-    public function __construct($container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Don’t load all tags when loading entity — delay it until they are needed.

Also a `Trait` for convenience.