### PR TITLE
[AdminBundle] simple menu adaptor

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->fixXmlConfig('admin_locale')
+            ->fixXmlConfig('menu_item')
             ->children()
                 ->scalarNode('admin_password')->end()
                 ->scalarNode('dashboard_route')->end()
@@ -40,6 +41,18 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_admin_locale')->cannotBeEmpty()->defaultValue('en')->end()
                 ->booleanNode('enable_console_exception_listener')->defaultTrue()->end()
+                ->arrayNode('menu_items')
+                    ->defaultValue([])
+                    ->useAttributeAsKey('route', false)
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('route')->isRequired()->end()
+                            ->scalarNode('label')->isRequired()->end()
+                            ->arrayNode('params')->defaultValue([])->prototype('scalar')->end()->end()
+                            ->scalarNode('parent')->defaultValue('KunstmaanAdminBundle_modules')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -48,6 +48,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('route')->isRequired()->end()
                             ->scalarNode('label')->isRequired()->end()
+                            ->scalarNode('role')->defaultNull()->end()
                             ->arrayNode('params')->defaultValue([])->prototype('scalar')->end()->end()
                             ->scalarNode('parent')->defaultValue('KunstmaanAdminBundle_modules')->end()
                         ->end()

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -109,7 +110,10 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
 
     private function addSimpleMenuAdaptor(ContainerBuilder $container, array $menuItems)
     {
-        $definition = new Definition('Kunstmaan\AdminBundle\Helper\Menu\SimpleMenuAdaptor', [$menuItems]);
+        $definition = new Definition('Kunstmaan\AdminBundle\Helper\Menu\SimpleMenuAdaptor', [
+            new Reference('security.context'),
+            $menuItems
+        ]);
         $definition->addTag('kunstmaan_admin.menu.adaptor');
 
         $container->setDefinition('kunstmaan_admin.menu.adaptor.simple', $definition);

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -54,6 +55,10 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         if (!empty($config['enable_console_exception_listener']) && $config['enable_console_exception_listener']) {
             $loader->load('console_listener.yml');
         }
+
+        if (0 !== sizeof($config['menu_items'])) {
+            $this->addSimpleMenuAdaptor($container, $config['menu_items']);
+        }
     }
 
     public function prepend(ContainerBuilder $container)
@@ -74,7 +79,7 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $fosUserConfig['resetting']['email']['template']    = 'FOSUserBundle:Resetting:email.txt.twig';
         $fosUserConfig['resetting']['form']['type']                 = 'fos_user_resetting';
         $fosUserConfig['resetting']['form']['name']                 = 'fos_user_resetting_form';
-        $fosUserConfig['resetting']['form']['validation_groups']    = array('ResetPassword');
+        $fosUserConfig['resetting']['form']['validation_groups']    = ['ResetPassword'];
         $container->prependExtensionConfig('fos_user', $fosUserConfig);
 
         $monologConfig['handlers']['main']['type']  = 'rotating_file';
@@ -100,5 +105,13 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
     public function getXsdValidationBasePath()
     {
         return __DIR__.'/../Resources/config/schema';
+    }
+
+    private function addSimpleMenuAdaptor(ContainerBuilder $container, array $menuItems)
+    {
+        $definition = new Definition('Kunstmaan\AdminBundle\Helper\Menu\SimpleMenuAdaptor', [$menuItems]);
+        $definition->addTag('kunstmaan_admin.menu.adaptor');
+
+        $container->setDefinition('kunstmaan_admin.menu.adaptor.simple', $definition);
     }
 }

--- a/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Helper\Menu;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SimpleMenuAdaptor implements MenuAdaptorInterface
+{
+
+    private $menuItems;
+
+    public function __construct(array $menuItems)
+    {
+        $this->menuItems = $menuItems;
+    }
+
+    /**
+     * In this method you can add children for a specific parent, but also remove and change the already created
+     * children
+     *
+     * @param MenuBuilder   $menu      The MenuBuilder
+     * @param MenuItem[]    &$children The current children
+     * @param MenuItem|null $parent    The parent Menu item
+     * @param Request       $request   The Request
+     */
+    public function adaptChildren(MenuBuilder $menu, array &$children, MenuItem $parent = null, Request $request = null)
+    {
+        if (null === $parent) {
+            return;
+        }
+
+        foreach ($this->menuItems as $item) {
+            if ($item['parent'] == $parent->getRoute()) {
+
+                $menuItem = new TopMenuItem($menu);
+                $menuItem
+                    ->setRoute($item['route'], $item['params'])
+                    ->setLabel($item['label'])
+                    ->setUniqueId($item['route'])
+                    ->setParent($parent);
+
+                if ($request && stripos($request->attributes->get('_route'), $menuItem->getRoute()) === 0) {
+                    $menuItem->setActive(true);
+                    $parent->setActive(true);
+                }
+
+                $children[] = $menuItem;
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/doc/CustomizingTheTopMenu.md
+++ b/src/Kunstmaan/AdminBundle/Resources/doc/CustomizingTheTopMenu.md
@@ -27,5 +27,6 @@ kunstmaan_admin:
         label: FooBaring Module
         parent: ~                        # attach it under specified menu item, default: KunstmaanAdminBundle_modules
         params: { source: "menuitem" }   # optional, array with custom route parameters
+        role: ROLE_ADMIN                 # optional, only show for users with this role
 
 ```

--- a/src/Kunstmaan/AdminBundle/Resources/doc/CustomizingTheTopMenu.md
+++ b/src/Kunstmaan/AdminBundle/Resources/doc/CustomizingTheTopMenu.md
@@ -15,3 +15,17 @@ kunstmaan_admin.menu.adaptor.settings:
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 ```
+
+## Simple Menu Adaptor
+
+If you only wish to add a simple menu item (for example under the "Modules" section), you can use the `SimpleMenuAdaptor` by adding a configuration:
+
+```
+kunstmaan_admin:
+    menu_items:
+      - route: AcmeBundle_mymodule_list  # your route name
+        label: FooBaring Module
+        parent: ~                        # attach it under specified menu item, default: KunstmaanAdminBundle_modules
+        params: { source: "menuitem" }   # optional, array with custom route parameters
+
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #509 

Add menu items using configuration.

```yaml
kunstmaan_admin:
    menu_items:
      - route: AcmeBundle_mymodule_list  # your route name
        label: FooBaring Module
        parent: ~                        # attach it under specified menu item, default: KunstmaanAdminBundle_modules
        params: { source: "menuitem" }   # optional, array with custom route parameters
        role: ROLE_ADMIN                 # optional, only show for users with this role
```