### PR TITLE
[NodeBundle] Minor performance tweak on loading the page

### DIFF
--- a/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
@@ -317,6 +317,10 @@ class NodeTranslation extends AbstractEntity
      */
     public function getNodeVersion($type)
     {
+        if($type == 'public') {
+            return $this->publicNodeVersion;
+        }
+
         $nodeVersions = $this->getNodeVersions();
 
         $max = count($nodeVersions);
@@ -343,6 +347,10 @@ class NodeTranslation extends AbstractEntity
     {
         $this->nodeVersions[] = $nodeVersion;
         $nodeVersion->setNodeTranslation($this);
+
+        if($nodeVersion->getType() == 'public') {
+            $this->publicNodeVersion = $nodeVersion;
+        }
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When loading a page which has for example 40 versions, the performance gain is about 20ms. All nodeversions does not have to be loaded anymore, since there is already a link to the latest public nodeversion. Performance is the existence reason of that publicNodeVersion property.