### PR TITLE
[NodeSearchBundle] Fix indexing children of StructureNodes

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -205,21 +205,25 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     public function indexNodeTranslation(NodeTranslation $nodeTranslation, $add = false)
     {
-        // Only index online NodeTranslations
-        if (!$nodeTranslation->isOnline()) {
-            return false;
-        }
-
         // Retrieve the public NodeVersion
         $publicNodeVersion = $nodeTranslation->getPublicNodeVersion();
         if (is_null($publicNodeVersion)) {
             return false;
         }
-        $node = $nodeTranslation->getNode();
 
         // Retrieve the referenced entity from the public NodeVersion
         $page = $publicNodeVersion->getRef($this->em);
 
+        if ($page->isStructureNode()) {
+            return true;
+        }
+
+        // Only index online NodeTranslations
+        if (!$nodeTranslation->isOnline()) {
+            return false;
+        }
+
+        $node = $nodeTranslation->getNode();
         if ($this->isIndexable($page)) {
             $this->addPageToIndex($nodeTranslation, $node, $publicNodeVersion, $page);
             if ($add) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

By adding a check if the page is a structure node we will be able to index it's children. This was not yet possible.