### PR TITLE
[NodeBundle] Do not load all nodes when you are not in the page section

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -76,7 +76,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
                 $menuItem->setActive(true);
             }
             $children[] = $menuItem;
-        } else {
+        } elseif (stripos($request->attributes->get('_route'), 'KunstmaanNodeBundle_nodes') === 0) {
             $treeNodes     = $this->getTreeNodes(
                 $request->getLocale(),
                 PermissionMap::PERMISSION_EDIT,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This change reduces the pageload on all backend pages that are not in the page section.
On my local "prod" environment the pageload is reduced with 120ms, so media now loads in 280ms instead of 400, and settings 70ms instead of 190ms