### PR TITLE
[NodeBundle] Possible to create a page type which is default hidden from navigation

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/HiddenFromNavInterface.php
+++ b/src/Kunstmaan/NodeBundle/Helper/HiddenFromNavInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Helper;
+
+/**
+ * Implement this interface to give you control over the navigation behavior of this page
+ */
+interface HiddenFromNavInterface
+{
+    /**
+     * Returns true when the page is to be hidden from the navigation
+     *
+     * @return bool
+     */
+    public function isHiddenFromNav();
+
+}

--- a/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
@@ -12,6 +12,7 @@ use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
+use Kunstmaan\NodeBundle\Helper\HiddenFromNavInterface;
 
 /**
  * NodeRepository
@@ -165,6 +166,9 @@ class NodeRepository extends NestedTreeRepository
             if ($parentNodeVersion) {
                 $node->setParent($parentNodeVersion->getNodeTranslation()->getNode());
             }
+        }
+        if ($hasNode instanceof HiddenFromNavInterface) {
+            $node->setHiddenFromNav($hasNode->isHiddenFromNav());
         }
         $em->persist($node);
         $em->flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This is needed if you don't want to load those pages in the nodemenu (performance impact).