### PR TITLE
Fix for page generation when there are no Page entities available in a bundle.

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
@@ -44,7 +44,7 @@ class GeneratePageCommand extends KunstmaanGenerateCommand
     /**
      * @var array
      */
-    private $parentPages;
+    private $parentPages = array();
 
     /**
      * @see Command


### PR DESCRIPTION
Generating a new page when your bundle has no Page entities yields an error (maybe it's an edge use case?)

```bash
app/console kuma:generate:page
[....]

Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                                                                                  
  Catchable Fatal Error: Argument 7 passed to Kunstmaan\GeneratorBundle\Generator\PageGenerator::generate() must be of the type array, null given, called in /home/blair/Documents/workspace/my-studio/vendor/kunstmaan/bundles-cms/src/Kun  
  stmaan/GeneratorBundle/Command/GeneratePageCommand.php on line 80 and defined
```

PR sets the default value of $parentPages to an empty array in GeneratePageCommand.