### PR TITLE
[MediaBundle] Empty media preview is resulting in a request to homepage

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/views/Form/formWidgets.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Form/formWidgets.html.twig
@@ -79,7 +79,7 @@
                         </figcaption>
                     {% endif %}
                 {% else %}
-                    <img src="/" id="{{ id }}__preview__img" class="thumbnail-img media-chooser__preview__img">
+                    <img id="{{ id }}__preview__img" class="thumbnail-img media-chooser__preview__img">
                     <figcaption id="{{ id }}__preview__title" class="media-chooser__preview__title"></figcaption>
                 {% endif %}
             </figure>


### PR DESCRIPTION
Trying to load / as image when no image is available in media preview.