### PR TITLE
[NodeBundle] Re-add the nodemenu again and make it lazy loading

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -101,16 +101,6 @@ and the -adminpwd- placeholder will be replaced by the generated password.
 Note that all Kunstmaan fixtures have been relocated from the AdminBundle to the GeneratorBundle. An extra 'AdminLoginFirstTime.feature' has been added
 to the admintests.
 
-## Nodemenu parameter no longer available in twigfiles
-
-the nodemenu variable has been removed from the renderContext, so to acces it in a twig file just add
-
-    {% set node = null %}
-    {% if nodetranslation is defined %}
-       {% set node = nodetranslation.node %}
-    {% endif %}
-    {% set nodemenu = get_node_menu(app.request.locale, node) %}
-    
 ## Refactored search to seperate service
 
 A lot of the functionality from the AbstractSearchPageController has been moved to the SearchService class. So if you have extended the AbstractSearchPageController

--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -3,11 +3,13 @@
 namespace Kunstmaan\NodeBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Event\SlugEvent;
+use Kunstmaan\NodeBundle\Helper\NodeMenu;
 use Kunstmaan\NodeBundle\Helper\RenderContext;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -80,7 +82,12 @@ class SlugController extends Controller
             throw new AccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
+        /* @var AclHelper $aclHelper */
+        $aclHelper      = $this->container->get('kunstmaan_admin.acl.helper');
+        $includeOffline = $preview;
+        $nodeMenu       = new NodeMenu($em, $securityContext, $aclHelper, $locale, $node, PermissionMap::PERMISSION_VIEW, $includeOffline);
         unset($securityContext);
+        unset($aclHelper);
 
         //render page
         $renderContext = new RenderContext(
@@ -89,6 +96,7 @@ class SlugController extends Controller
                 'slug'            => $url,
                 'page'            => $entity,
                 'resource'        => $entity,
+                'nodemenu'        => $nodeMenu,
             )
         );
         if (method_exists($entity, 'getDefaultView')) {

--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
@@ -83,6 +83,11 @@ class NodeMenu
     private $nodesByInternalName = array();
 
     /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
      * @param EntityManagerInterface   $em                   The entity manager
      * @param SecurityContextInterface $securityContext      The security context
      * @param AclHelper                $aclHelper            The ACL helper
@@ -110,24 +115,32 @@ class NodeMenu
         $this->includeHiddenFromNav = $includeHiddenFromNav;
         $this->permission           = $permission;
         $this->currentNode          = $currentNode;
+    }
 
-        /* @var NodeRepository $repo */
-        $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+    /**
+     * This method initializes the nodemenu only once, the method may be executed multiple times
+     */
+    private function init() {
+        if (!$this->initialized) {
+            /* @var NodeRepository $repo */
+            $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
 
-        // Get all possible menu items in one query (also fetch offline nodes)
-        $nodes = $repo->getChildNodes(false, $this->lang, $permission, $this->aclHelper, $includeHiddenFromNav);
-        foreach ($nodes as $node) {
-            $this->allNodes[$node->getId()] = $node;
+            // Get all possible menu items in one query (also fetch offline nodes)
+            $nodes = $repo->getChildNodes(false, $this->lang, $this->permission, $this->aclHelper, $this->includeHiddenFromNav);
+            foreach ($nodes as $node) {
+                $this->allNodes[$node->getId()] = $node;
 
-            if ($node->getParent()) {
-                $this->childNodes[$node->getParent()->getId()][] = $node;
-            } else {
-                $this->childNodes[0][] = $node;
+                if ($node->getParent()) {
+                    $this->childNodes[$node->getParent()->getId()][] = $node;
+                } else {
+                    $this->childNodes[0][] = $node;
+                }
+
+                if ($node->getInternalName()) {
+                    $this->nodesByInternalName[$node->getInternalName()][] = $node;
+                }
             }
-
-            if ($node->getInternalName()) {
-                $this->nodesByInternalName[$node->getInternalName()][] = $node;
-            }
+            $this->initialized = true;
         }
     }
 
@@ -136,6 +149,7 @@ class NodeMenu
      */
     public function getTopNodes()
     {
+        $this->init();
         if (!is_array($this->topNodeMenuItems)) {
             $this->topNodeMenuItems = array();
 
@@ -229,6 +243,7 @@ class NodeMenu
      */
     public function getChildren(Node $node, $includeHiddenFromNav = true)
     {
+        $this->init();
         $children = array();
 
         if (array_key_exists($node->getId(), $this->childNodes)) {
@@ -260,6 +275,7 @@ class NodeMenu
      */
     public function getParent(Node $node)
     {
+        $this->init();
         if ($node->getParent() && array_key_exists($node->getParent()->getId(), $this->allNodes)) {
             return $this->allNodes[$node->getParent()->getId()];
         }
@@ -287,6 +303,7 @@ class NodeMenu
      */
     public function getNodeByInternalName($internalName, $parent = null, $includeOffline = null)
     {
+        $this->init();
         $resultNode = null;
 
         if (is_null($includeOffline)) {
@@ -433,6 +450,14 @@ class NodeMenu
         }
 
         return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInitialized()
+    {
+        return $this->initialized;
     }
 
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

Removing the nodemenu from the rendercontext brought lots of problems in:

* everywhere you need it you first need to check if it's already created. You absolutely don't want to create it twice for one page rendering.
* you had to create it in twig (!= template logic) and you sometimes need it already in the service method where you get it from the rendercontext. So also there you needed to create it
* it's not always possible to create the nodemenu correct because you do not have all parameters (i.e. if it's a preview context or not)

My solution:
* make it default available again, but made the contructor empty and use lazy loading

For the sluglistener-controllerserviceaction the nodemenu was never removed (see SlugSecurityListener L 76) , so these will also become faster since this lazy loading strategy.