### PR TITLE
[NodeBundle] fix loading hidden nodes with internalnames

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
@@ -115,7 +115,7 @@ class NodeMenu
         $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
 
         // Get all possible menu items in one query (also fetch offline nodes)
-        $nodes = $repo->getChildNodes(false, $this->lang, $permission, $this->aclHelper, $includeHiddenFromNav);
+        $nodes = $repo->getChildNodes(false, $this->lang, $permission, $this->aclHelper, $includeHiddenFromNav, true);
         foreach ($nodes as $node) {
             $this->allNodes[$node->getId()] = $node;
 

--- a/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
@@ -43,7 +43,7 @@ class NodeRepository extends NestedTreeRepository
      *
      * @return Node[]
      */
-    public function getChildNodes($parentId, $lang, $permission, AclHelper $aclHelper, $includeHiddenFromNav = false)
+    public function getChildNodes($parentId, $lang, $permission, AclHelper $aclHelper, $includeHiddenFromNav = false, $includeHiddenWithInternalName = false)
     {
         $qb = $this->createQueryBuilder('b')
             ->select('b', 't', 'v')
@@ -55,7 +55,11 @@ class NodeRepository extends NestedTreeRepository
             ->addOrderBy('t.title', 'ASC');
 
         if (!$includeHiddenFromNav) {
-            $qb->andWhere('b.hiddenFromNav != true');
+        	if ($includeHiddenWithInternalName) {
+        		$qb->andWhere('(b.hiddenFromNav != true OR b.internalName IS NOT NULL)');
+        	} else {
+        		$qb->andWhere('b.hiddenFromNav != true');
+        	}
         }
 
         if (is_null($parentId)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

This is a fix for:

Since 3.2.0 hidden nodes with internalnames were not returning anymore with the NodeMenu.getNodeByInternalName method.