### PR TITLE
[NodeSearchBundle] `indexType` needs to have language appended

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -265,7 +265,8 @@ class NodePagesConfiguration implements SearchConfigurationInterface
     public function deleteNodeTranslation(NodeTranslation $nodeTranslation)
     {
         $uid = 'nodetranslation_' . $nodeTranslation->getId();
-        $this->searchProvider->deleteDocument($this->indexName, $this->indexType, $uid);
+        $indexType = $this->indexType . '_' . $nodeTranslation->getLang();
+        $this->searchProvider->deleteDocument($this->indexName, $indexType, $uid);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

I noticed that unpublished nodes are kept in the index. If I understant it correctly, a document in elasticsearch is identified by id and type, so the `indexType` needs to be fixed to contain the language for the `delete` operation to succeed.