### PR TITLE
[NodeBundle] Added 3 new helper methods

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
@@ -269,6 +269,76 @@ class NodeMenu
     }
 
     /**
+     * @param \Kunstmaan\NodeBundle\Entity\Node $node
+     * @param bool $includeHiddenFromNav
+     *
+     * @return array|\Kunstmaan\NodeBundle\Helper\NodeMenuItem[]
+     */
+    public function getSiblings(Node $node, $includeHiddenFromNav = true)
+    {
+        $this->init();
+        $siblings = array();
+
+        if (false !== $parent = $this->getParent($node)) {
+            $siblings = $this->getChildren($parent, $includeHiddenFromNav);
+
+            foreach($siblings as $index => $child) {
+                if ($child === $node) {
+                    unset($siblings[$index]);
+                }
+            }
+        }
+
+        return $siblings;
+    }
+
+    /**
+     * @param \Kunstmaan\NodeBundle\Entity\Node $node
+     * @param bool $includeHiddenFromNav
+     *
+     * @return bool|\Kunstmaan\NodeBundle\Helper\NodeMenuItem
+     */
+    public function getPreviousSibling(Node $node, $includeHiddenFromNav = true)
+    {
+        $this->init();
+
+        if (false !== $parent = $this->getParent($node)) {
+            $siblings = $this->getChildren($parent, $includeHiddenFromNav);
+
+            foreach($siblings as $index => $child) {
+                if ($child->getNode() === $node && ($index - 1 >= 0)) {
+                    return $siblings[$index - 1];
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \Kunstmaan\NodeBundle\Entity\Node $node
+     * @param bool $includeHiddenFromNav
+     *
+     * @return bool|\Kunstmaan\NodeBundle\Helper\NodeMenuItem
+     */
+    public function getNextSibling(Node $node, $includeHiddenFromNav = true)
+    {
+        $this->init();
+
+        if (false !== $parent = $this->getParent($node)) {
+            $siblings = $this->getChildren($parent, $includeHiddenFromNav);
+
+            foreach($siblings as $index => $child) {
+                if ($child->getNode() === $node && (($index+1) < count($siblings))) {
+                    return $siblings[$index + 1];
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param Node $node
      *
      * @return NodeMenuItem


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Added 3 new helper methods to NodeMenu:
- getSiblings($node)
- getNextSibling($node)
- getPreviousSibling($node)

Useful for things like linear-style nav (in my case, Next Project/Previous Project), while retaining progressive enhancement.

Some simple template logic, once nodemenu is defined:

```twig
{% set currentNode = nodemenu.getCurrent() %}
{% set nextSibling = nodemenu.getNextSibling(currentNode.node, false) %}
{% set prevSibling = nodemenu.getPreviousSibling(currentNode.node, false) %}
                    {% if prevSibling %}
                        <a data-pager="prev"
                           href="{{ path('_slug', {'url': prevSibling.nodeTranslation.url }) }}">
                            ({{ prevSibling.nodeTranslation.title }})
                        </a>
                    {% endif %}

                    {% if nextSibling %}
                        <a data-pager="next"
                           href="{{ path('_slug', {'url': nextSibling.nodeTranslation.url }) }}">
                            ({{ nextSibling.nodeTranslation.title }})
                        </a>
                    {% endif %}
```
