### PR TITLE
[AdminBundle] fix admin locale listener

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -57,7 +57,7 @@ class AdminLocaleListener implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $url = $event->getRequest()->getRequestUri();
-        if ($this->isAdminToken($this->context->getToken(), $this->providerKey) && $this->isAdminRoute($url)) {
+        if ($this->isAdminToken($this->providerKey, $this->context->getToken()) && $this->isAdminRoute($url)) {
             $token = $this->context->getToken();
             $locale = $token->getUser()->getAdminLocale();
 
@@ -75,7 +75,7 @@ class AdminLocaleListener implements EventSubscriberInterface
      *
      * @return bool
      */
-    private function isAdminToken(TokenInterface $token, $providerKey)
+    private function isAdminToken($providerKey, TokenInterface $token = null)
     {
         return $token instanceof UsernamePasswordToken && $token->getProviderKey() === $providerKey;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The securitycontext getToken method also provides NULL when there is no token found.