### PR TITLE
[NodeSearchBundle] fix escaping the search query

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -31,6 +31,8 @@ class NodeSearcher extends AbstractElasticaSearcher
      */
     public function defineSearch($query, $lang, $type)
     {
+        $query = \Elastica\Util::escapeTerm($query);
+
         $elasticaQueryLang = new \Elastica\Query\Term();
         $elasticaQueryLang->setTerm('lang', $lang);
 
@@ -79,7 +81,7 @@ class NodeSearcher extends AbstractElasticaSearcher
     /**
      * Filter search results so only documents that are viewable by the current user will be returned...
      *
-     * @param $elasticaQueryBool
+     * @param \Elastica\Query\Bool $elasticaQueryBool
      */
     protected function applySecurityContext($elasticaQueryBool)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Search would fail if the query contained an unmatched quote for an instance.