### PR TITLE
Allow overriding of the Session variable

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
@@ -303,4 +303,17 @@ class NodeTranslationListener
             return $string . $append . '1';
         }
     }
+    
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\Session $session
+     *
+     * @return $this
+     */
+    public function setSession($session)
+    {
+        $this->session = $session;
+
+        return $this;
+    }
+    
 }


### PR DESCRIPTION
When I try to create Nodes in my fixtures, I get errors due to the NodeTranslationListener emitting flash messages even though the work happens in the console.

I'm not sure if there is a better way, but allowing the console to inject a MockSession is the simplest way to get around this problem.

The code I end up using is: (ImportNodesFixture.php)
```php
$listener = $this->container->get('kunstmaan_node.nodetranslation.listener');
$session = new Session(new MockArraySessionStorage(), new AttributeBag(), new FlashBag());
$listener->setSession($session);
```