### PR TITLE
[AdminBundle] fixed nested-form multiple add buttons

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
@@ -15,11 +15,14 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
     init = function() {
         $('.js-nested-form').each(function() {
             var $form = $(this),
-                initialized = $form.data('initialized');
+                initialized = $form.data('initialized'),
+                initializing = $form.data('initializing');
 
-            if(!initialized) {
+            if(!initialized && !initializing) {
+                $form.data('initializing', true);
                 setupForm($form);
                 $form.data('initialized', true);
+                $form.data('initializing', false);
             }
         });
     };

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -150,7 +150,7 @@
                 {% set sortableField = attr['nested_sortable_field']|default('weight') %}
             {% endif %}
 
-            <div id="{{ form.vars.id }}__nested-form" class="js-nested-form nested-form{% if sortable %} js-sortable-container sortable-container nested-form--sortable{% endif %}" data-sortable="{% if sortable %}true{% else %}false{% endif %}" data-allow-new="{{ form.vars.allow_add|default('0') }}" data-allow-delete="{{ form.vars.allow_delete|default('0') }}" data-min-items="{{ attr['nested_form_min']|default('0') }}" data-max-items="{{ attr['nested_form_max']|default('false') }}" data-sortable="{{ attr['nested_sortable']|default('false') }}" {% if sortable %} data-sortkey="{{ form.vars.id }}___name___{{ sortableField }}"{% endif %}{% if form.vars.allow_add %} data-prototype="{{ form_widget(form.vars.prototype)|e }}"{% endif %} data-initialized="false">
+            <div id="{{ form.vars.id }}__nested-form" class="js-nested-form nested-form{% if sortable %} js-sortable-container sortable-container nested-form--sortable{% endif %}" data-sortable="{% if sortable %}true{% else %}false{% endif %}" data-allow-new="{{ form.vars.allow_add|default('0') }}" data-allow-delete="{{ form.vars.allow_delete|default('0') }}" data-min-items="{{ attr['nested_form_min']|default('0') }}" data-max-items="{{ attr['nested_form_max']|default('false') }}" data-sortable="{{ attr['nested_sortable']|default('false') }}" {% if sortable %} data-sortkey="{{ form.vars.id }}___name___{{ sortableField }}"{% endif %}{% if form.vars.allow_add %} data-prototype="{{ form_widget(form.vars.prototype)|e }}"{% endif %} data-initialized="false" data-initializing="false">
 
                 {# Items #}
                 {% for obj in form %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When adding a new PagePart that contains a collection the init function of nested-form is called multiple times which results in displaying multiple add buttons.