### PR TITLE
[Dependencies] Support for symfony2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-
-        "symfony/symfony": "~2.5,<2.7.0",
+        "symfony/symfony": "~2.5,<2.8.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The problem was:
In Symfony 2.7 the securitycontext is deprecated and logs a deprecation warning that you should use the security.token_storage which is introduced in 2.6. When logging a deprecation warning in the classloader, there was a circular dependency in the services: the logger has a UserProcessor which need the securitycontext but it was already in the classloading process of the securitycontext.

We do not change to the new security.token_storage because otherwise we cannot support symfony2.5 anymore.