### PR TITLE
[AdminBundle] Fix admin locale listener for >= Symfony 2.6

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -60,7 +60,7 @@ class AdminLocaleListener implements EventSubscriberInterface
         $url = $event->getRequest()->getRequestUri();
         $token = $this->context->getToken();
 
-        if ($token && $this->isAdminToken($token, $this->providerKey) && $this->isAdminRoute($url)) {
+        if ($token && $this->isAdminToken($this->providerKey, $token) && $this->isAdminRoute($url)) {
             $locale = $token->getUser()->getAdminLocale();
 
             if (!$locale) {
@@ -77,7 +77,7 @@ class AdminLocaleListener implements EventSubscriberInterface
      *
      * @return bool
      */
-    private function isAdminToken(TokenInterface $token, $providerKey)
+    private function isAdminToken($providerKey, TokenInterface $token = null)
     {
         return ($token instanceof UsernamePasswordToken || $token instanceof RememberMeToken) && $token->getProviderKey() === $providerKey;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

The securitycontext getToken method also provides NULL when there is no token found.