### PR TITLE
[Tests] Do not use n-a as default slugified text

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -15,7 +15,7 @@ class Slugifier implements SlugifierInterface
      *
      * @return string
      */
-    public function slugify($text, $default = 'n-a', $replace = array("'"), $delimiter = '-')
+    public function slugify($text, $default = '', $replace = array("'"), $delimiter = '-')
     {
         if (!empty($replace)) {
             $text = str_replace($replace, ' ', $text);

--- a/src/Kunstmaan/UtilitiesBundle/Tests/Helper/SlugifierTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/Helper/SlugifierTest.php
@@ -48,7 +48,7 @@ class SlugifierTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('', '', ''),
-            array('', null, 'n-a'),
+            array('', null, ''),
             array('test', '', 'test'),
             array('een titel met spaties', '', 'een-titel-met-spaties'),
             array('à partir d\'aujourd\'hui', null, 'a-partir-d-aujourd-hui'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes, the slug is now an empty string if it was null
| Deprecations? | no
| Fixed tickets | #575 (part of)

Since we changed the slugifier to a service, the slugifier also applied to pages that were not save through the backend, the homepage for example got an 'n-a' slug after generating it...

This wil fix a lot of tests in the standard edition.