### PR TITLE
sensio/generator-bundle >=2.5.0

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
-        "sensio/generator-bundle": ">=2.3.0, <2.5.0",
+        "sensio/generator-bundle": ">=2.5.0",
         "fzaninotto/faker": "~1.4.0",
         "kunstmaan/utilities-bundle": "~3.2"
     },


### PR DESCRIPTION
getQuestionHelper vs. getDialogHelper in `sensio/generator-bundle/Sensio/Bundle/GeneratorBundle/Command/GeneratorCommand.php` as they renamed this function and the KunstmaanGeneratorBundle is using the newer `getQuestionHelper`.

should fix this issue:

```
root@67a783839e01:/var/www/app# composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - kunstmaan/generator-bundle 3.2.3 requires sensio/generator-bundle >=2.3.0, <2.5.0 -> satisfiable by sensio/generator-bundle[2.4.x-dev].
    - kunstmaan/generator-bundle 3.2.3 requires sensio/generator-bundle >=2.3.0, <2.5.0 -> satisfiable by sensio/generator-bundle[2.4.x-dev].
    - Removal request for sensio/generator-bundle == 2.4.9999999.9999999-dev
    - Installation request for kunstmaan/generator-bundle 3.2.3 -> satisfiable by kunstmaan/generator-bundle[3.2.3].
```

When using in `composer.json`

```
"sensio/generator-bundle": ">=2.5.0",
```

in combo with

```
"kunstmaan/generator-bundle": "3.2.3",
```

A quickfix :see_no_evil: :
```
"sensio/generator-bundle": "2.5.3 as 2.4.0"
```

