### PR TITLE
[FixturesBundle] When a value holds a Fixture, it should get the entity of the fixture.

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Populator/Populator.php
+++ b/src/Kunstmaan/FixturesBundle/Populator/Populator.php
@@ -23,7 +23,11 @@ class Populator
         foreach ($data as $property => $value) {
             foreach ($this->populators as $populator) {
                 if ($populator->canSet($entity, $property, $value)) {
-                    $populator->set($entity, $property, $value);
+                    if ($value instanceof \Kunstmaan\FixturesBundle\Loader\Fixture) {
+                        $populator->set($entity, $property, $value->getEntity());
+                    } else {
+                        $populator->set($entity, $property, $value);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
When a value holds a Fixture, it should get the entity of the fixture. Otherwise the ORM will complain about the association.

```
Expected value of type "Kunstmaan\MediaBundle\Entity\Media" for association field "Demo\WebsiteBundle\Entity\PageParts\HomepageHeaderPagePart#$medi  
  a", got "Kunstmaan\FixturesBundle\Loader\Fixture" instead.
```

Fixtures example:

```
\Kunstmaan\MediaBundle\Entity\Media:
    image_homepage_header:
        folder: image
        originalFilename: <image('/tmp/', 1024, 500, 'cats')>


\Demo\WebsiteBundle\Entity\Pages\HomePage:
    homepage:
        title: 'Homepage'
        parameters:
            page_internal_name: homepage
            set_online: true
            hidden_from_nav: false
            creator: <adminUser()>
        translations:
            nl:
                title: Demo site
            fr:
                title: Demo site

\Demo\WebsiteBundle\Entity\PageParts\HomepageHeaderPagePart:
    homepage_header_pp:
        title: ""
        niv: 1
        parameters:
            page: @homepage
            context: header
        translations:
            nl:
                title: Demp header text
                paragraph: >
                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat dui sed feugiat pharetra. Proin sollicitudin malesuada vulputate. Duis feugiat felis at ligula dictum, quis cursus ex placerat. Cras ornare vitae enim eu laoreet. Fusce fringilla, arcu at pretium tempus, massa nulla tincidunt tortor, molestie mattis mi magna non orci. Praesent molestie mauris id tortor consequat rhoncus.
                media: @image_homepage_header
            fr: []
```