### PR TITLE
[AdminBundle] Fix CreateUserCommand with --group option

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
@@ -101,13 +101,11 @@ EOT
 
         // Attach groups
         $groupNames = explode(',', $groupOption);
-    $groups = $this->getContainer()->get('fos_user.group_manager')->findGroups();
-
-    $groupOutput = "";
+        $groupOutput = "";
 
         foreach ($groupNames as $groupName) {
-        $group = $em->getRepository('KunstmaanAdminBundle:Group')->findOneBy(array('name' => $groups[$groupName]->getName()));
-        $groupOutput .= $groups[$groupName] . ", ";
+        $group = $em->getRepository('KunstmaanAdminBundle:Group')->findOneBy(array('name' => $groupName));
+        $groupOutput .= $groupName . ", ";
             if (!empty($group)) {
                 $user->getGroups()->add($group);
             }


### PR DESCRIPTION
Fixes

```
[Symfony\Component\Debug\Exception\ContextErrorException]  
  Notice: Undefined index: Admin 
```

When running:

```
app/console kuma:role:create ROLE_SUPER_ADMIN
app/console kuma:group:create --role="ROLE_SUPER_ADMIN" "Admin"
app/console kuma:user:create user user@demo.be demo en --group="Admin"
```

This could be regression from a FOSUserbundle update.