### PR TITLE
[NodeBundle] Let SlugController fall through to kernel.view

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -125,6 +125,8 @@ class SlugController extends Controller
             throw $this->createNotFoundException('No page found for slug ' . $url);
         }
 
-        return $this->render($view, $renderContext->getArrayCopy());
+        $request->attributes->set('_template', $view);
+
+        return $renderContext->getArrayCopy();
     }
 }

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -35,9 +35,12 @@ class RenderContextListener
             return;
         }
 
-        $request            = $event->getRequest();
-        $nodeTranslation    = $request->attributes->get('_nodeTranslation');
+        $request = $event->getRequest();
+        if ($request->attributes->has('_template')) { //template is already set
+            return;
+        }
 
+        $nodeTranslation    = $request->attributes->get('_nodeTranslation');
         if ($nodeTranslation) {
             $entity          = $request->attributes->get('_entity');
             $url             = $request->attributes->get('url');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Currently the RenderContextListener falls through to the kernel.view, but the SlugController didn't do that. This applies the same principle to the SlugController so the kernel.view event is also fired.