### PR TITLE
[GeneratorBundle] Preserve environment in defaultController:indexAction redirect

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
@@ -17,7 +17,7 @@ class DefaultController extends Controller
      */
     public function indexAction()
     {
-        return new RedirectResponse('/' . $this->container->getParameter('locale'));
+        return new RedirectResponse($this->generateUrl('_slug', array('url'=>'', '_locale'=>$this->container->getParameter('locale'))));
     }
     {% endif %}
 


### PR DESCRIPTION
The existing code will cause http://yoursite/app_dev.php to be redirected to http://yoursite/{locale} instead of http://yoursite/app_dev.php/{locale}.  This redirect should preserve the dev environment.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no