### PR TITLE
[TranslatorBundle] Don't warm up the database translations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.5,<2.8.0",
-        "doctrine/orm": "~2.2,>=2.2.3,<2.5",
-        "doctrine/dbal": "<2.5",
+        "doctrine/orm": "~2.5.0",
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",

--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
@@ -31,6 +31,14 @@ class Translator extends SymfonyTranslator
             $this->addResourcesFromDatabaseAndCacheThem();
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        return;
+    }
 
     /**
      * Add resources to the Translator from the cache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

The WarmableInterface was added in Symfony 2.7 and at a lot of times in the process we don't have a database yet