### PR TITLE
[AdminBundle] nested form: don’t remove entities in many-to-many relation

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/doc/FormCollectionAdditions.md
+++ b/src/Kunstmaan/AdminBundle/Resources/doc/FormCollectionAdditions.md
@@ -79,6 +79,19 @@ class MySubAdminType extends AbstractType
 If you don't set the nested_sortable_field attribute, a default of "weight" will be used (so you must make sure your
 form type has a getter and setter for a weight field if you don't set it).
 
+## Many to Many relations
+
+If you have a many-to-many relation, you wouldn’t want to delete the related entity when removing it from page part.
+In order to skip this, set 'nested_deletable => false` attribute, i.e.:
+
+```
+'attr' => array(
+    'nested_form'           => true,
+    'nested_deletable'      => false,
+)
+```                
+
+
 ## References
 
 - [Using sub entities in pageparts](http://bundles.kunstmaan.be/news/using-sub-entities-in-pageparts)

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -155,7 +155,9 @@
                 {# Items #}
                 {% for obj in form %}
                     <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
-                            data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.compound %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
+                            {% if attr['nested_deletable'] is not defined or attr['nested_deletable'] != false %}
+                                data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.compound %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
+                            {% endif %}
                             {% if sortable %}data-sortkey="{{ obj.children[sortableField].vars.id }}"{% endif %}>
                         {# Header #}
                         <header class="{% if sortable %}js-sortable-item__handle{% endif %} nested-form__item__header">
@@ -173,6 +175,8 @@
                             {% else %}
                                 {% for child in obj.children %}
                                     {{ form_row(child) }}
+                                {% else %}
+                                    {{ form_widget(obj) }}
                                 {% endfor %}
                             {% endif %}
                         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #584 (partially)

An option to the `delete-key` from nested form item HTML. This way nested form can handle many-to-many relations: simpli missing the item from the form will remove the relation, but the entity won’t be removed. 

This also partially fixes #584 — when a form is non-compound, but doesn’t have any children either, just print the whole `form_widget()`.