### PR TITLE
[NodeBundle] Removed fallback logic for simple route loaders

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -61,3 +61,10 @@ Refer to the DefaultAdminPanelAdaptor source to see how this is done.
 - ```get_backend_locales()``` - returns the admin (back-end) locales for the current host
 
 For multi-site / multi-domain you should make sure you no longer use the requiredlocales
+`
+
+## Custom route loaders not possible anymore when they use a page controller (BC breaking)
+
+It is not possible anymore to use custom route loaders (`LoaderInterface`) for defining extra routes
+that are handled via the controller of a `Page`. You should use a custom router (`RouterInterface`) instead
+to define the route, and put the `_nodeTranslation` variable in the `_route_params` in the match function.

--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -46,10 +46,6 @@ class SlugController extends Controller
 
         /* @var NodeTranslation $nodeTranslation */
         $nodeTranslation = $request->get('_nodeTranslation');
-        if (!$nodeTranslation) {
-            // When the SlugController is used from a different Routing or RouteLoader class, the _nodeTranslation is not set, so we need this fallback
-            $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getNodeTranslationForUrl($url, $locale);
-        }
 
         // If no node translation -> 404
         if (!$nodeTranslation) {

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -42,6 +42,7 @@ class SlugListener
 
     /**
      * @param FilterControllerEvent $event
+     * @throws \Exception
      */
     public function onKernelController(FilterControllerEvent $event)
     {
@@ -53,9 +54,8 @@ class SlugListener
         }
 
         $nodeTranslation = $request->attributes->get('_nodeTranslation');
-        if (!($nodeTranslation instanceof NodeTranslation)) {
-            $nodeTranslation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')->find($nodeTranslation);
-            $request->attributes->set('_nodeTranslation', $nodeTranslation);
+        if (! ($nodeTranslation instanceof NodeTranslation)) {
+            throw new \Exception('Invalid _nodeTranslation value found in request attributes');
         }
         $entity = $nodeTranslation->getRef($this->em);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 

With these changes, it is not possible anymore to use custom route loaders (`LoaderInterface`) for defining extra routes that are handled via the controller of a `Page`. You should use a custom router (`RouterInterface`) instead. This is a BC break!

Example use case:
 - `/video` -> VideoOverviewPage with custom controller
 - `/video/123` -> no page linked tot this url, **a custom defined route** (`/{url}/{videoid}`) that is also using the controller of the VideoOverviewPage

(as discussed with @kimausloos and @wimvds)