### PR TITLE
[SearchBundle] Add the locale to the request context when populating the search index

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/views/Pages/SearchPage/pagetemplate.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/views/Pages/SearchPage/pagetemplate.html.twig
@@ -56,13 +56,15 @@
                             {% endif %}
                         </p>
                         <nav role="navigation" class="breadcrumb">
-                            {% for node_id in searchresult['_source']['ancestors']|reverse %}
-                                {% set nt = get_node_trans_by_node_id(node_id, app.request.locale) %}
-                                {% if nt %}
-                                    <a href="{{ path('_slug', { 'url': nt.url }) }}" class="breadcrumb__item">{{ nt.title }}</a>
-                                    <i class="icon icon--arrow-right breadcrumb__icon"></i>
-                                {% endif %}
-                            {% endfor %}
+                            {% if searchresult['_source']['ancestors'] is defined %}
+                                {% for node_id in searchresult['_source']['ancestors']|reverse %}
+                                    {% set nt = get_node_trans_by_node_id(node_id, app.request.locale) %}
+                                    {% if nt %}
+                                        <a href="{{ path('_slug', { 'url': nt.url }) }}" class="breadcrumb__item">{{ nt.title }}</a>
+                                        <i class="icon icon--arrow-right breadcrumb__icon"></i>
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif %}
                             <a href="{{ path('_slug', { 'url': searchresult['_source']['slug'] }) }}" class="breadcrumb__item breadcrumb__item--current search-results__breadcrumb__item--current">{{ searchresult['_source']['title'] }}</a>
                         </nav>
                     {% endfor %}

--- a/src/Kunstmaan/NodeBundle/Entity/StructureNode.php
+++ b/src/Kunstmaan/NodeBundle/Entity/StructureNode.php
@@ -2,14 +2,11 @@
 
 namespace Kunstmaan\NodeBundle\Entity;
 
-use Kunstmaan\NodeBundle\Entity\AbstractPage;
-
 /**
  * A StructureNode will always be offline and its nodes will never have a slug.
  */
 abstract class StructureNode extends AbstractPage
 {
-
     /**
      * A StructureNode will always be offline.
      *
@@ -29,5 +26,4 @@ abstract class StructureNode extends AbstractPage
     {
         return true;
     }
-
 }

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -508,6 +508,9 @@ class NodePagesConfiguration implements SearchConfigurationInterface
             $request = new Request();
             $request->setLocale($lang);
 
+            $context = $this->container->get('router')->getContext();
+            $context->setParameter('_locale', $lang);
+
             $major = Kernel::MAJOR_VERSION;
             $minor = Kernel::MINOR_VERSION;
             if ((int)$major > 2 || ((int)$major == 2 && (int)$minor >= 4)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When the search index gets populated, their was no `_locale` parameter in the `RenderContext` because the command is executed from the command line. The `_locale` parameter is in the context for browser requests, so it is also needed when populating the search index.

Example use case:
When you have this peace of code in twig, it works for browser requests, but not when populating the search index.

```
<a href="{{ path('_slug', { url: nodeTranslation.url }) }}">click here</a>
```