### PR TITLE
[MultiDomainBundle] Fix host override

### DIFF
--- a/docs/05-08-using-the-multi-domain-bundle.md
+++ b/docs/05-08-using-the-multi-domain-bundle.md
@@ -75,6 +75,33 @@ The ```extra``` parameters specified in the configuration will be available in t
 accessing the ```_extra``` key.
 
 
+### Enable the multi domain logout handler in security.yml
+
+If you intend to use the host override functionality, you have to enable the ```kunstmaan_multi_domain.host_override_cleanup```
+logout handler in app/conf/security.yml. If you don't do this the host override will be active until you close the
+current browser session.
+
+```
+    firewalls:
+        main:
+            pattern: ^/([^/]*)/admin
+            form_login:
+                login_path: fos_user_security_login
+                check_path: fos_user_security_check
+                provider: fos_userbundle
+            logout:
+                path:   fos_user_security_logout
+                target: KunstmaanAdminBundle_homepage
+                handlers: ['kunstmaan_multi_domain.host_override_cleanup']
+            anonymous:    true
+            remember_me:
+                key:      %secret%
+                lifetime: 604800
+                path:     /
+                domain:   ~
+```
+
+
 ### Accessing the back-end
 
 If you were used to working with the older versions of the bundles CMS there's one thing to note : the admin

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_header.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/_header.html.twig
@@ -12,7 +12,7 @@
 
 
             {# Logo #}
-            {% set homepagePageNode = nodemenu.getNodeByInternalName('homepage') %}
+            {% set homepagePageNode = nodemenu.getRootNodeMenuItem() %}
             <a href="{{ path('_slug', { 'url': homepagePageNode.slug }) }}" class="main-header__logo">
                 <img src="/frontend/img/demosite/logo-thecrew.svg" alt="The Crew" class="main-header__logo__img">
             </a>

--- a/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
+++ b/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\MultiDomainBundle\Controller;
 
 use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -33,11 +34,15 @@ class SiteSwitchController extends Controller
             throw $this->createNotFoundException('Invalid host specified');
         }
 
-        $this->get('session')->set(DomainConfiguration::OVERRIDE_HOST, $host);
         $defaultLocale = $this->get('kunstmaan_node.domain_configuration')->getDefaultLocale();
 
-        return new RedirectResponse(
+        $response = new RedirectResponse(
             $this->get('router')->generate('KunstmaanAdminBundle_homepage', array('_locale' => $defaultLocale))
         );
+
+        $cookie = new Cookie(DomainConfiguration::OVERRIDE_HOST, $host);
+        $response->headers->setCookie($cookie);
+
+        return $response;
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -17,18 +17,12 @@ class DomainConfiguration extends BaseDomainConfiguration
     private $hosts;
 
     /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
         parent::__construct($container);
         $this->hosts   = $container->getParameter('kunstmaan_multi_domain.hosts');
-        $this->session = $container->get('session');
     }
 
     /**
@@ -36,10 +30,8 @@ class DomainConfiguration extends BaseDomainConfiguration
      */
     public function getHost()
     {
-        if ($this->session->isStarted() &&
-            $this->session->has(self::OVERRIDE_HOST)
-        ) {
-            return $this->session->get(self::OVERRIDE_HOST);
+        if ($this->hasHostOverride()) {
+            return $this->getHostOverride();
         }
 
         return parent::getHost();
@@ -146,5 +138,23 @@ class DomainConfiguration extends BaseDomainConfiguration
         }
 
         return $this->hosts[$host]['extra'];
+    }
+
+    /**
+     * @return bool
+     */
+    protected function hasHostOverride()
+    {
+        $request = $this->getMasterRequest();
+
+        return !is_null($request) && $request->cookies->has(self::OVERRIDE_HOST);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getHostOverride()
+    {
+        return $this->getMasterRequest()->cookies->get(self::OVERRIDE_HOST);
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kunstmaan\MultiDomainBundle\Helper;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+
+class HostOverrideCleanupHandler implements LogoutHandlerInterface
+{
+    /**
+     * This method is called by the LogoutListener when a user has requested
+     * to be logged out. Usually, you would unset session variables, or remove
+     * cookies, etc.
+     *
+     * @param Request        $request
+     * @param Response       $response
+     * @param TokenInterface $token
+     */
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        // Remove host override cookie
+        if ($request->cookies->has(DomainConfiguration::OVERRIDE_HOST)) {
+            $response->headers->clearCookie(DomainConfiguration::OVERRIDE_HOST);
+        }
+    }
+}

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -19,3 +19,6 @@ services:
         arguments: ["@session", "@kunstmaan_node.domain_configuration"]
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
+    kunstmaan_multi_domain.host_override_cleanup:
+        class: Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The host override didn't work because the session was not started, refactored so it uses a cookie instead.