### PR TITLE
[SeoBundle] Logical operators should be avoided

### DIFF
--- a/src/Kunstmaan/SeoBundle/Helper/Menu/SeoManagementMenuAdaptor.php
+++ b/src/Kunstmaan/SeoBundle/Helper/Menu/SeoManagementMenuAdaptor.php
@@ -32,7 +32,7 @@ class SeoManagementMenuAdaptor implements MenuAdaptorInterface
      */
     public function adaptChildren(MenuBuilder $menu, array &$children, MenuItem $parent = null, Request $request = null)
     {
-        if (!is_null($parent) and ('KunstmaanAdminBundle_settings' == $parent->getRoute()) and $this->security->isGranted('ROLE_SUPER_ADMIN')) {
+        if (!is_null($parent) && ('KunstmaanAdminBundle_settings' == $parent->getRoute()) && $this->security->isGranted('ROLE_SUPER_ADMIN')) {
             $menuItem = new MenuItem($menu);
             $menuItem
                 ->setRoute('KunstmaanSeoBundle_settings_robots')


### PR DESCRIPTION
Logical operators should be avoided
You should use '&&' instead of 'and' and '||' instead of 'or'