### PR TITLE
[MultiDomainBundle] Update the MultiDomainBundle documentation + remove extra parameters from request _route_params

### DIFF
--- a/docs/05-08-using-the-multi-domain-bundle.md
+++ b/docs/05-08-using-the-multi-domain-bundle.md
@@ -31,6 +31,14 @@ class AppKernel extends Kernel
 }
 ```
 
+### Include the routing configuration in your main routing.yml
+
+```yml
+KunstmaanMultiDomainBundle:
+    resource: "@KunstmaanMultiDomainBundle/Resources/config/routing.yml"
+    requirements:
+        _locale: %requiredlocales%
+```
 
 ### Add the multi domain configuration in your config.yml :
 
@@ -70,9 +78,6 @@ This will define 2 node trees for 3 domains.
 The first tree is mapped to 2 single language domains, the second is mapped as a multi language site.
 
 *Note*: You will not be able to use a locale as both single and multi language for the same root.
-
-The ```extra``` parameters specified in the configuration will be available in the request parameter bag by
-accessing the ```_extra``` key.
 
 
 ### Accessing the back-end

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -54,8 +54,8 @@ class DomainBasedLocaleRouter extends SlugRouter
             $this->getRouteCollection(),
             $this->getContext()
         );
-        $result     = $urlMatcher->match($pathinfo);
 
+        $result     = $urlMatcher->match($pathinfo);
         if (!empty($result)) {
             // Remap locale for front-end requests
             if ($this->isMultiDomainHost() &&
@@ -64,14 +64,7 @@ class DomainBasedLocaleRouter extends SlugRouter
             ) {
                 $localeMap                 = $this->getLocaleMap();
                 $locale                    = $result['_locale'];
-                $result['_request_locale'] = $locale;
                 $result['_locale']         = $localeMap[$locale];
-            }
-
-            // Add extra parameters to parameter bag
-            $extraData = $this->domainConfiguration->getExtraData();
-            if (!empty($extraData)) {
-                $result['_extra'] = $extraData;
             }
 
             $nodeTranslation = $this->getNodeTranslation($result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I removed the extra `_route_params` because if you generate a url/path with the current request  `_route_params` you can expose sensitive information. For example when you have defined different api credentials for each host. 

When you have
```
kunstmaan_multi_domain:
    hosts:
        main_nl:
            host: domain.com
            type: single_lang
            default_locale: nl
            locales:
                - { uri_locale: 'nl', locale: 'nl' }
            extra: 
                api_passwordl: abc123
````
and in twig you do
```{{ url(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}```
visitors will see
`http://domain.com/contact?_extra[api_passwordl]=abc123`