### PR TITLE
[MultiDomainBundle] Fix host override warnings

### DIFF
--- a/docs/05-08-using-the-multi-domain-bundle.md
+++ b/docs/05-08-using-the-multi-domain-bundle.md
@@ -126,9 +126,6 @@ Homepages should implement the HomePageInterface in order to be visible in the h
 
 In the back-end you will be able to switch to the different domains.
 
-There's one side-effect to site switching you should be aware of : while logged in and switched to a different
-site in the back-end you might be able to see that other site's content if you access the front-end.
-
 
 ## Extra Twig functions
 

--- a/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
+++ b/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
@@ -34,6 +34,7 @@ class SiteSwitchController extends Controller
             throw $this->createNotFoundException('Invalid host specified');
         }
 
+        $request->cookies->set(DomainConfiguration::OVERRIDE_HOST, $host);
         $defaultLocale = $this->get('kunstmaan_node.domain_configuration')->getDefaultLocale();
 
         $response = new RedirectResponse(

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -3,8 +3,10 @@
 namespace Kunstmaan\MultiDomainBundle\EventListener;
 
 use Kunstmaan\NodeBundle\Helper\DomainConfigurationInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -33,15 +35,24 @@ class HostOverrideListener
     }
 
     /**
-     * @param GetResponseEvent $event
+     * @param FilterResponseEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelResponse(FilterResponseEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
         }
 
+        $response = $event->getResponse();
+        if ($response instanceof RedirectResponse) {
+            return;
+        }
+
         $request = $event->getRequest();
+        if ($request->isXmlHttpRequest()) {
+            return;
+        }
+
         if (!$this->isAdminRoute($request->getRequestUri())) {
             return;
         }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -22,7 +22,7 @@ class DomainConfiguration extends BaseDomainConfiguration
     public function __construct(ContainerInterface $container)
     {
         parent::__construct($container);
-        $this->hosts   = $container->getParameter('kunstmaan_multi_domain.hosts');
+        $this->hosts = $container->getParameter('kunstmaan_multi_domain.hosts');
     }
 
     /**
@@ -147,7 +147,9 @@ class DomainConfiguration extends BaseDomainConfiguration
     {
         $request = $this->getMasterRequest();
 
-        return !is_null($request) && $request->cookies->has(self::OVERRIDE_HOST);
+        return !is_null($request) &&
+            $this->isAdminRoute($request->getRequestUri()) &&
+            $request->cookies->has(self::OVERRIDE_HOST);
     }
 
     /**
@@ -156,5 +158,26 @@ class DomainConfiguration extends BaseDomainConfiguration
     protected function getHostOverride()
     {
         return $this->getMasterRequest()->cookies->get(self::OVERRIDE_HOST);
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    protected function isAdminRoute($url)
+    {
+        preg_match(
+            '/^\/(app_(.*)\.php\/)?([a-zA-Z_-]{2,5}\/)?admin\/(.*)/',
+            $url,
+            $matches
+        );
+
+        // Check if path is part of admin area
+        if (count($matches) === 0) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -18,7 +18,7 @@ services:
         class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
         arguments: ["@session", "@kunstmaan_node.domain_configuration"]
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
     kunstmaan_multi_domain.host_override_cleanup:
         class: Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This PR fixes the override warning, so it doesn't appear multiple times (after redirects & AJAX calls).
Host overrides are restricted to the admin area from now on and the documentation was updated accordingly.