### PR TITLE
[NodeBundle] fix reorder method in case the node hasn't been translated

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -779,24 +779,27 @@ class NodeAdminController extends Controller
 
             /* @var NodeTranslation $nodeTranslation */
             $nodeTranslation = $node->getNodeTranslation($this->locale, true);
-            $nodeVersion     = $nodeTranslation->getPublicNodeVersion();
-            $page            = $nodeVersion->getRef($this->em);
+            
+            if ($nodeTranslation) {
+                $nodeVersion     = $nodeTranslation->getPublicNodeVersion();
+                $page            = $nodeVersion->getRef($this->em);
 
-            $this->get('event_dispatcher')->dispatch(
-                Events::PRE_PERSIST,
-                new NodeEvent($node, $nodeTranslation, $nodeVersion, $page)
-            );
+                $this->get('event_dispatcher')->dispatch(
+                    Events::PRE_PERSIST,
+                    new NodeEvent($node, $nodeTranslation, $nodeVersion, $page)
+                );
 
-            $nodeTranslation->setWeight($weight);
-            $this->em->persist($nodeTranslation);
-            $this->em->flush($nodeTranslation);
+                $nodeTranslation->setWeight($weight);
+                $this->em->persist($nodeTranslation);
+                $this->em->flush($nodeTranslation);
 
-            $this->get('event_dispatcher')->dispatch(
-                Events::POST_PERSIST,
-                new NodeEvent($node, $nodeTranslation, $nodeVersion, $page)
-            );
+                $this->get('event_dispatcher')->dispatch(
+                    Events::POST_PERSIST,
+                    new NodeEvent($node, $nodeTranslation, $nodeVersion, $page)
+                );
 
-            $weight++;
+                $weight++;
+            }
         }
 
         return new JsonResponse(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This fix solve an issue when a user hasn't translated all the pages in a locale and try to reorder them.