### PR TITLE
[MediaBundle] Show internal name field for media folders

### DIFF
--- a/src/Kunstmaan/MediaBundle/Form/FolderType.php
+++ b/src/Kunstmaan/MediaBundle/Form/FolderType.php
@@ -67,6 +67,14 @@ class FolderType extends AbstractType
                         return $er->selectFolderQueryBuilder($folder);
                     }
                 )
+            )
+            ->add(
+                'internalName',
+                'text',
+                array(
+                    'label' => 'Internal name',
+                    'required' => false
+                )
             );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The internalName is already visible for pages (nodes). Now it's also editable for media folders.