### PR TITLE
[PagePartBundle] Translate PageTemplate and PagePart names

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/FormWidgets/PageTemplateWidget/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/FormWidgets/PageTemplateWidget/widget.html.twig
@@ -62,7 +62,7 @@
                                 <input type="radio" id="pagetemplate_template_choice_{{ loop.index }}" class="choice-block__input" name="pagetemplate_template_choice" value="{{ pagetemplate.name }}"{% if resource.pagetemplate.name == pagetemplate.name %} checked="checked"{% endif %}>
                                 <label for="pagetemplate_template_choice_{{ loop.index }}" class="choice-block__item">
                                     <h5 class="choice-block__item__head">
-                                        {{ pagetemplate.name }}
+                                        {{ pagetemplate.name|trans }}
                                         {% if resource.pagetemplate.name == pagetemplate.name %}
                                             <small>(Current)</small>
                                         {% endif %}

--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
@@ -31,7 +31,7 @@
         <header class="js-sortable-item__handle pp__header {% if not form['pagepartadmin_'~id].count %}pp__header--no-edit{% endif %}">
             <i class="fa fa-arrows pp__header__move-icon"></i>
             <h5 class="pp__header__head">
-                {{pagepartadmin.getType(pagepart)}}
+                {{pagepartadmin.getType(pagepart)|trans}}
             </h5>
         </header>
 
@@ -72,7 +72,7 @@
         <select class="js-add-pp-select form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
             <option value="">Add a pagepart</option>
             {% for pagePartType in pagepartadmin.possiblePagePartTypes %}
-                <option value="{{pagePartType.class}}">{{pagePartType.name}}</option>
+                <option value="{{pagePartType.class}}">{{pagePartType.name|trans}}</option>
             {% endfor %}
         </select>
     </div>

--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
@@ -5,7 +5,7 @@
         <select class="js-add-pp-select js-add-pp-select--first form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
             <option value="">Add a pagepart</option>
             {% for pagePartType in pagepartadmin.possiblePagePartTypes %}
-                <option value="{{ pagePartType.class }}">{{ pagePartType.name }}</option>
+                <option value="{{ pagePartType.class }}">{{ pagePartType.name|trans }}</option>
             {% endfor %}
         </select>
     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This pull request changes some views in the admin so that the names of pagetemplates and pageparts are run through translations before they are shown. This allows for more clean names such as `contentpage_sidebar` to be used in the code and database, while still having a readable string in the admin.