### PR TITLE
[FixturesBundle] Pass arguments to Faker provider

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Parser/Property/Method.php
+++ b/src/Kunstmaan/FixturesBundle/Parser/Property/Method.php
@@ -65,7 +65,7 @@ class Method implements PropertyParserInterface
                     $value = $this->processValue($pattern, $refl->invokeArgs($provider, $arguments), $value, $matches[0]);
                     break;
                 } elseif (is_callable([$provider, $method])) {
-                    $value = $this->processValue($pattern, $provider->$method(), $value, $matches[0]);
+                    $value = $this->processValue($pattern, call_user_func_array(array($provider, $method), $arguments), $value, $matches[0]);
                     break;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Currently no arguments are passed to Faker when using its providers in the FixturesBundle. Because Faker uses `__call` to handle calls to its providers, the methods are not found using reflection. The method is however callable, but was called without the parsed arguments. This PR makes sure those arguments are passed.