### PR TITLE
[FixturesBundle] Fix for fixtures populator entity array

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Populator/Populator.php
+++ b/src/Kunstmaan/FixturesBundle/Populator/Populator.php
@@ -25,6 +25,13 @@ class Populator
                 if ($populator->canSet($entity, $property, $value)) {
                     if ($value instanceof \Kunstmaan\FixturesBundle\Loader\Fixture) {
                         $populator->set($entity, $property, $value->getEntity());
+                    } elseif(is_array($value)) {
+                        foreach($value as &$item) {
+                            if($item instanceof \Kunstmaan\FixturesBundle\Loader\Fixture) {
+                                $item = $item->getEntity();
+                            }
+                        }
+                        $populator->set($entity, $property, $value);
                     } else {
                         $populator->set($entity, $property, $value);
                     }


### PR DESCRIPTION
If your fixtures contain an array of related entities like this
```
\App\SiteBundle\Entity\Pages\ArticlePage:
    article_{1..25}:
        categories: [@cat_1, @cat_4]
        ...
```
You end up with following error, as the entity references in this array are not treated as entities while populatoring: `Expected value of type "Doctrine\Common\Collections\Collection|array" for association field "App\SiteBundle\Entity\Pages\ArticlePage#$categories", got "Kunstmaan\Fixtures
  Bundle\Loader\Fixture" instead.
`

This pull request takes care of this, although I guess there might be some prettier way...