### PR TITLE
[DashboardBundle] Only allow super admin to configure the dashboard

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
@@ -6,6 +6,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class GoogleAnalyticsController extends Controller
 {
@@ -82,10 +83,16 @@ class GoogleAnalyticsController extends Controller
      *
      * @param Request $request
      *
+     * @throws AccessDeniedException
+     *
      * @return array
      */
     public function setTokenAction(Request $request)
     {
+        if (false === $this->container->get('security.context')->isGranted('ROLE_SUPER_ADMIN')) {
+            throw new AccessDeniedException();
+        }
+
         $code = urldecode($request->query->get('code'));
 
         if (isset($code)) {
@@ -107,10 +114,16 @@ class GoogleAnalyticsController extends Controller
      *
      * @param Request $request
      *
+     * @throws AccessDeniedException
+     *
      * @return array
      */
     public function configAction(Request $request)
     {
+        if (false === $this->container->get('security.context')->isGranted('ROLE_SUPER_ADMIN')) {
+            throw new AccessDeniedException();
+        }
+
         $params = array();
         $configHelper = $this->container->get('kunstmaan_dashboard.helper.google.analytics.config');
 
@@ -151,9 +164,15 @@ class GoogleAnalyticsController extends Controller
 
     /**
      * @Route("/resetProfile", name="KunstmaanDashboardBundle_analytics_resetProfile")
+     *
+     * @throws AccessDeniedException
      */
     public function resetProfileAction()
     {
+        if (false === $this->container->get('security.context')->isGranted('ROLE_SUPER_ADMIN')) {
+            throw new AccessDeniedException();
+        }
+
         $em = $this->getDoctrine()->getManager();
         $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->resetProfileId();
         return $this->redirect($this->generateUrl('KunstmaanDashboardBundle_ProfileSelection'));
@@ -161,9 +180,15 @@ class GoogleAnalyticsController extends Controller
 
     /**
      * @Route("/resetProperty", name="KunstmaanDashboardBundle_analytics_resetProperty")
+     *
+     * @throws AccessDeniedException
      */
     public function resetPropertyAction()
     {
+        if (false === $this->container->get('security.context')->isGranted('ROLE_SUPER_ADMIN')) {
+            throw new AccessDeniedException();
+        }
+
         $em = $this->getDoctrine()->getManager();
         $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->resetPropertyId();
         return $this->redirect($this->generateUrl('KunstmaanDashboardBundle_Config'));

--- a/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/connect.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/connect.html.twig
@@ -1,3 +1,4 @@
+{% if is_granted('ROLE_SUPER_ADMIN') %}
 <h2>{{ 'dashboard.ga.setup.title' | trans }}</h2>
 <p>
     {{ 'dashboard.ga.setup.content' | trans }} <a href="{{ 'dashboard.ga.setup.docs_url' | trans }}">{{ 'dashboard.ga.setup.docs' | trans }}</a>.
@@ -12,4 +13,5 @@
     <p>
         {{ 'dashboard.ga.setup.refresh' | trans }}
     </p>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

We don't want to allow normal admins to configure the dashboard, so we added a check to only allow super admins to configure the dashboard.