### PR TITLE
[MenuBundle] Refactor MenuBundle to use a MenuService

### DIFF
--- a/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
@@ -9,8 +9,6 @@ use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\MenuBundle\Entity\Menu;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 
 class MenuAdminListController extends AdminListController
@@ -34,8 +32,8 @@ class MenuAdminListController extends AdminListController
 
             $create_route = function ($item) {
                 return array(
-                    'path'   => 'kunstmaanmenubundle_admin_menuitem',
-                    'params' => array('menuid' => $item->getId())
+                    'path' => 'kunstmaanmenubundle_admin_menuitem',
+                    'params' => array('menuid' => $item->getId()),
                 );
             };
             $this->configurator->addItemAction(
@@ -57,56 +55,11 @@ class MenuAdminListController extends AdminListController
     public function indexAction(Request $request)
     {
         // Make sure we have a menu for each possible locale
-        $this->makeSureMenusExist();
+        $this->get('kunstmaan_menu.menu.service')->makeSureMenusExist();
 
         return parent::doIndexAction(
             $this->getAdminListConfigurator($request),
             $request
         );
-    }
-
-    /**
-     * Make sure the menu objects exist in the database for each locale.
-     */
-    private function makeSureMenusExist()
-    {
-        $menuNames = $this->container->getParameter('kunstmaan_menu.menus');
-        $locales   = $this->getLocales();
-        $required  = array();
-        foreach ($menuNames as $name) {
-            $required[$name] = $locales;
-        }
-
-        $em          = $this->getDoctrine()->getManager();
-        $menuObjects = $em->getRepository('KunstmaanMenuBundle:Menu')->findAll(
-        );
-        foreach ($menuObjects as $menu) {
-            if (array_key_exists($menu->getName(), $required)) {
-                $index = array_search(
-                    $menu->getLocale(),
-                    $required[$menu->getName()]
-                );
-                if ($index !== false) {
-                    unset($required[$menu->getName()][$index]);
-                }
-            }
-        }
-
-        foreach ($required as $name => $locales) {
-            foreach ($locales as $locale) {
-                $menu = new Menu();
-                $menu->setName($name);
-                $menu->setLocale($locale);
-                $em->persist($menu);
-            }
-        }
-
-        $em->flush();
-    }
-
-    private function getLocales()
-    {
-        return $this->get('kunstmaan_node.domain_configuration')
-            ->getBackendLocales();
     }
 }

--- a/src/Kunstmaan/MenuBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     kunstmaan_menu.menu.adaptor.class: Kunstmaan\MenuBundle\Service\MenuAdaptor
+    kunstmaan_menu.menu.service.class: Kunstmaan\MenuBundle\Service\MenuService
     kunstmaan_menu.menu.twig.extension.class: Kunstmaan\MenuBundle\Twig\MenuTwigExtension
 
 services:
@@ -8,6 +9,14 @@ services:
         arguments: ["%kunstmaan_menu.menus%"]
         tags:
             - { name: kunstmaan_admin.menu.adaptor }
+
+
+    kunstmaan_menu.menu.service:
+        class: %kunstmaan_menu.menu.service.class%
+        arguments:
+            - "%kunstmaan_menu.menus%"
+            -  @kunstmaan_node.domain_configuration
+            - "@doctrine.orm.entity_manager"
 
     kunstmaan_menu.menu.twig.extension:
         class: %kunstmaan_menu.menu.twig.extension.class%

--- a/src/Kunstmaan/MenuBundle/Service/MenuService.php
+++ b/src/Kunstmaan/MenuBundle/Service/MenuService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Kunstmaan\MenuBundle\Service;
+
+use Kunstmaan\MenuBundle\Entity\Menu;
+
+class MenuService
+{
+    /**
+     * @var array
+     */
+    private $menuNames;
+
+    /**
+     * @var \Kunstmaan\NodeBundle\Helper\DomainConfiguration
+     */
+    private $domainConfiguration;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * @param array  $menuNames
+     * @param \Kunstmaan\NodeBundle\Helper\DomainConfiguration $domainConfiguration
+     * @param \Doctrine\ORM\EntityManager $em
+     */
+    public function __construct(
+        array $menuNames,
+        $domainConfiguration,
+        $em
+    ) {
+        $this->menuNames = $menuNames;
+        $this->domainConfiguration = $domainConfiguration;
+        $this->em = $em;
+    }
+
+    /**
+     * Make sure the menu objects exist in the database for each locale.
+     */
+    public function makeSureMenusExist()
+    {
+        $locales = $this->getLocales();
+        $required = array();
+
+        foreach ($this->menuNames as $name) {
+            $required[$name] = $locales;
+        }
+
+        $menuObjects = $this->em->getRepository('KunstmaanMenuBundle:Menu')->findAll();
+
+        foreach ($menuObjects as $menu) {
+            if (array_key_exists($menu->getName(), $required)) {
+                $index = array_search(
+                    $menu->getLocale(),
+                    $required[$menu->getName()]
+                );
+                if ($index !== false) {
+                    unset($required[$menu->getName()][$index]);
+                }
+            }
+        }
+
+        foreach ($required as $name => $locales) {
+            foreach ($locales as $locale) {
+                $menu = new Menu();
+                $menu->setName($name);
+                $menu->setLocale($locale);
+                $this->em->persist($menu);
+            }
+        }
+
+        $this->em->flush();
+    }
+
+    private function getLocales()
+    {
+        return $this->domainConfiguration
+            ->getBackendLocales();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

In order to create MenuItems via fixtures, the logic of creating MenuItems should be in a service class instead of the controller.

This PR removes this logic from the controller and moves it into a service. I've created a wrapper function in the controller to avoid BC breaks.

