### PR TITLE
[NodeBundle] Re-add nodemenu again in the rendercontext

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -58,14 +58,20 @@ class SlugController extends Controller
             $em,
             $nodeTranslation
         );
+        $node = $nodeTranslation->getNode();
 
         $securityEvent = new SlugSecurityEvent();
         $securityEvent
-            ->setNode($nodeTranslation->getNode())
+            ->setNode($node)
             ->setEntity($entity)
             ->setRequest($request)
             ->setNodeTranslation($nodeTranslation);
 
+        $nodeMenu = $this->container->get('kunstmaan_node.node_menu');
+        $nodeMenu->setLocale($locale);
+        $nodeMenu->setCurrentNode($node);
+        $nodeMenu->setIncludeOffline($preview);
+        
         $eventDispatcher = $this->get('event_dispatcher');
         $eventDispatcher->dispatch(Events::SLUG_SECURITY, $securityEvent);
 
@@ -76,6 +82,7 @@ class SlugController extends Controller
                 'slug'            => $url,
                 'page'            => $entity,
                 'resource'        => $entity,
+                'nodemenu'        => $nodeMenu,
             )
         );
         if (method_exists($entity, 'getDefaultView')) {

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -52,6 +52,7 @@ class RenderContextListener
         if ($nodeTranslation) {
             $entity     = $request->attributes->get('_entity');
             $url        = $request->attributes->get('url');
+            $nodeMenu   = $request->attributes->get('_nodeMenu');
             $parameters = $request->attributes->get('_renderContext');
 
             if ($request->get('preview') == true) {
@@ -71,6 +72,7 @@ class RenderContextListener
                 'slug'            => $url,
                 'page'            => $entity,
                 'resource'        => $entity,
+                'nodemenu'        => $nodeMenu,
             );
 
             if (is_array($parameters) || $parameters instanceof \ArrayObject) {

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
@@ -10,6 +10,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Kunstmaan\NodeBundle\Helper\NodeMenu;
 
 /**
  * Class SlugSecurityListener
@@ -27,6 +28,11 @@ class SlugSecurityListener
      * @var EntityManager
      */
     protected $em;
+    
+    /**
+     * @var NodeMenu
+     */
+    protected $nodeMenu;
 
     /**
      * @param EntityManager   $entityManager
@@ -34,10 +40,12 @@ class SlugSecurityListener
      */
     public function __construct(
         EntityManager $entityManager,
-        SecurityContext $securityContext
+        SecurityContext $securityContext,
+        NodeMenu $nodeMenu
     ) {
         $this->em              = $entityManager;
         $this->securityContext = $securityContext;
+        $this->nodeMenu        = $nodeMenu;
     }
 
     /**
@@ -66,5 +74,12 @@ class SlugSecurityListener
         if (!$isPreview && !$nodeTranslation->isOnline()) {
             throw new NotFoundHttpException('The requested page is not online');
         }
+        
+        $nodeMenu = $this->nodeMenu;
+        $nodeMenu->setLocale($nodeTranslation->getLang());
+        $nodeMenu->setCurrentNode($node);
+        $nodeMenu->setIncludeOffline($isPreview);
+        
+        $request->attributes->set('_nodeMenu', $nodeMenu);
     }
 }

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -138,7 +138,7 @@ services:
 
     kunstmaan_node.slug.security.listener:
         class: Kunstmaan\NodeBundle\EventListener\SlugSecurityListener
-        arguments: ["@doctrine.orm.entity_manager", "@security.context"]
+        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@kunstmaan_node.node_menu"]
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.slug.security, method: onSlugSecurityEvent }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

So you don't have to write 5 twig lines or 27 php lines to get it.
See #581 why this is usefull.