### PR TITLE
Hide pagepart dropdown when there are no options configured

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
@@ -72,7 +72,7 @@
     </section>
 
 
-
+    {% if pagepartadmin.possiblePagePartTypes | length > 0 %}
     <!-- New PP select -->
     <div class="pp-container__add">
         <select class="js-add-pp-select form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
@@ -82,6 +82,7 @@
             {% endfor %}
         </select>
     </div>
+    {% endif %}
 
 
 

--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
@@ -1,5 +1,6 @@
 <div class="js-pp-container pp-container" data-context="{{ pagepartadmin.context }}" data-pageid="{{ pagepartadmin.page.id }}" data-pageclassname="{{ pagepartadmin.getClassName(pagepartadmin.page) }}">
 
+    {% if pagepartadmin.possiblePagePartTypes | length > 0 %}
     <!-- First New PP select -->
     <div class="pp-container__add">
         <select class="js-add-pp-select js-add-pp-select--first form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
@@ -9,6 +10,7 @@
             {% endfor %}
         </select>
     </div>
+    {% endif %}
 
     <!-- Sortable container -->
     <div id="parts-{{ pagepartadmin.context }}" class="js-sortable-container sortable-container" data-scope="{% spaceless %}{% for type in pagepartadmin.possiblePagePartTypes %}{{ type.class|replace({'\\':""})~' ' }}{% endfor %}{% endspaceless %}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Sometimes u use a context as a placeholder (for a very custom context) on a page.
A user can't add any pageparts to it, so there shouldn't be a useless dropdown with no select options.
