### PR TITLE
[AdminBundle] Warning in collection when using media as type

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -156,7 +156,7 @@
                 {% for obj in form %}
                     <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
                             {% if attr['nested_deletable'] is not defined or attr['nested_deletable'] != false %}
-                                data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.compound %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
+                                data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
                             {% endif %}
                             {% if sortable %}data-sortkey="{{ obj.children[sortableField].vars.id }}"{% endif %}>
                         {# Header #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

When you try to build a form with a collection of media you will get a `array to string conversion` warning.
Forms like 'entity' or 'media' are not compound forms but are also tight to entities.

Example code to reproduce this warning:

```
    $builder->add('images', 'collection', array(
            'type' => 'media',
            'allow_add' => true,
            'allow_delete' => true,
            'by_reference' => false,
            'cascade_validation' => true,
            'attr' => array(
                'nested_form' => true,
                'nested_form_min' => 1,
                'nested_form_max' => 5,
            )
    ));
```