### PR TITLE
[RedirectBundle] Add domain field when configuring redirects

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -189,7 +189,7 @@
                 <div class="input-group">
                     {{ form_widget(form) }}
                     <span class="input-group-addon">
-                        <strong class="input-group-addon--tooltip" data-toggle="tooltip" data-container="body" data-placement="top" title="{{ attr['info_text'] }}" id="{{ id }}_info_text">?</strong>
+                        <strong class="input-group-addon--tooltip" data-toggle="tooltip" data-container="body" data-placement="top" title="{{ attr['info_text']|trans }}" id="{{ id }}_info_text">?</strong>
                     </span>
                 </div>
             {% else %}

--- a/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
+++ b/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
@@ -9,9 +9,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * The admin list controller for Redirect
- */
 class RedirectAdminListController extends AdminListController
 {
     /**
@@ -25,7 +22,7 @@ class RedirectAdminListController extends AdminListController
     public function getAdminListConfigurator()
     {
         if (!isset($this->configurator)) {
-            $this->configurator = new RedirectAdminListConfigurator($this->getEntityManager());
+            $this->configurator = new RedirectAdminListConfigurator($this->getEntityManager(), null, $this->get('kunstmaan_node.domain_configuration'));
         }
 
         return $this->configurator;

--- a/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
@@ -7,13 +7,18 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
 
 /**
- * Redirect
- *
  * @ORM\Table(name="kuma_redirects")
  * @ORM\Entity(repositoryClass="Kunstmaan\RedirectBundle\Repository\RedirectRepository")
  */
 class Redirect extends AbstractEntity
 {
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="domain", type="string", length=255, nullable=true)
+     */
+    private $domain;
+
     /**
      * @var string
      *
@@ -37,6 +42,28 @@ class Redirect extends AbstractEntity
      */
     private $permanent;
 
+    /**
+     * Get domain
+     *
+     * @return string
+     */
+    public function getDomain()
+    {
+        return $this->domain;
+    }
+
+    /**
+     * Set domain
+     *
+     * @param string $domain
+     * @return Redirect
+     */
+    public function setDomain($domain)
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
 
     /**
      * Set origin

--- a/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
+++ b/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
@@ -2,14 +2,24 @@
 
 namespace Kunstmaan\RedirectBundle\Form;
 
+use Kunstmaan\NodeBundle\Helper\DomainConfigurationInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
 
-/**
- * The type for Redirect
- */
 class RedirectAdminType extends AbstractType
 {
+    /**
+     * @var DomainConfigurationInterface
+     */
+    private $domainConfiguration;
+
+    /**
+     * @param DomainConfigurationInterface $domainConfiguration
+     */
+    public function __construct(DomainConfigurationInterface $domainConfiguration)
+    {
+        $this->domainConfiguration = $domainConfiguration;
+    }
 
     /**
      * Builds the form.
@@ -24,9 +34,37 @@ class RedirectAdminType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('origin');
-        $builder->add('target');
-        $builder->add('permanent');
+        if ($this->domainConfiguration->isMultiDomainHost()) {
+            $hosts = $this->domainConfiguration->getHosts();
+            $domains = array_combine($hosts, $hosts);
+            $domains = array_merge(array('' => 'redirect.all'), $domains);
+
+            $builder->add('domain', 'choice', array(
+                'choices' => $domains,
+                'required' => true,
+                'expanded' => false,
+                'multiple' => false,
+                'attr' => array(
+                    'info_text' => 'redirect.origin_info'
+                )
+            ));
+        }
+
+        $builder->add('origin', 'text', array(
+            'required' => true,
+            'attr' => array(
+                'info_text' => 'redirect.origin_info'
+            )
+        ));
+        $builder->add('target', 'text', array(
+            'required' => true,
+            'attr' => array(
+                'info_text' => 'redirect.target_info'
+            )
+        ));
+        $builder->add('permanent', 'checkbox', array(
+            'required' => false
+        ));
     }
 
     /**
@@ -38,5 +76,4 @@ class RedirectAdminType extends AbstractType
     {
         return 'redirect_form';
     }
-
 }

--- a/src/Kunstmaan/RedirectBundle/Helper/Menu/RedirectMenuAdaptor.php
+++ b/src/Kunstmaan/RedirectBundle/Helper/Menu/RedirectMenuAdaptor.php
@@ -9,7 +9,6 @@ use Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder;
 
 class RedirectMenuAdaptor implements MenuAdaptorInterface
 {
-
     /**
      * In this method you can add children for a specific parent, but also remove and change the already created children
      *
@@ -20,9 +19,7 @@ class RedirectMenuAdaptor implements MenuAdaptorInterface
      */
     public function adaptChildren(MenuBuilder $menu, array &$children, MenuItem $parent = null, Request $request = null)
     {
-        if (is_null($parent)) {
-
-        } elseif ('KunstmaanAdminBundle_settings' == $parent->getRoute()) {
+        if (!is_null($parent) &&'KunstmaanAdminBundle_settings' == $parent->getRoute()) {
             $menuItem = new MenuItem($menu);
             $menuItem
                 ->setRoute('kunstmaanredirectbundle_admin_redirect')
@@ -37,5 +34,4 @@ class RedirectMenuAdaptor implements MenuAdaptorInterface
             $children[] = $menuItem;
         }
     }
-
 }

--- a/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
@@ -17,6 +17,6 @@ services:
 
     kunstmaan_redirect.redirectrouter:
         class: Kunstmaan\RedirectBundle\Router\RedirectRouter
-        arguments: ["@kunstmaan_redirect.repositories.redirect"]
+        arguments: ["@kunstmaan_redirect.repositories.redirect", "@kunstmaan_node.domain_configuration"]
         tags:
             - { name: router, priority: 1 }

--- a/src/Kunstmaan/RedirectBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,4 @@
+redirect:
+    all: All domains
+    origin_info: The URL that you want to redirect, eg. /contest
+    target_info: The destination redirect URL, eg. /en/contests/summer-contest

--- a/src/Kunstmaan/RedirectBundle/Tests/AdminList/RedirectAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/AdminList/RedirectAdminListConfiguratorTest.php
@@ -33,12 +33,15 @@ class RedirectAdminListConfiguratorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        $domainConfiguration = $this->getMockBuilder('Kunstmaan\NodeBundle\Helper\DomainConfigurationInterface')
+            ->disableOriginalConstructor()->getMock();
+
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()->getMock();
         $this->aclHelper = $this->getMockBuilder('Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper')
             ->disableOriginalConstructor()->getMock();
 
-        $this->object = new RedirectAdminListConfigurator($this->em, $this->aclHelper);
+        $this->object = new RedirectAdminListConfigurator($this->em, $this->aclHelper, $domainConfiguration);
     }
 
     /**

--- a/src/Kunstmaan/RedirectBundle/Tests/Entity/RedirectTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/Entity/RedirectTest.php
@@ -32,6 +32,16 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Kunstmaan\RedirectBundle\Entity\Redirect::getDomain
+     * @covers Kunstmaan\RedirectBundle\Entity\Redirect::setDomain
+     */
+    public function testGetSetDomain()
+    {
+        $this->object->setDomain('domain.com');
+        $this->assertEquals('domain.com', $this->object->getDomain());
+    }
+
+    /**
      * @covers Kunstmaan\RedirectBundle\Entity\Redirect::getOrigin
      * @covers Kunstmaan\RedirectBundle\Entity\Redirect::setOrigin
      */

--- a/src/Kunstmaan/RedirectBundle/Tests/Form/RedirectAdminTypeTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/Form/RedirectAdminTypeTest.php
@@ -12,7 +12,12 @@ class RedirectAdminTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * @var RedirectAdminType
      */
-    protected $object;
+    protected $objectMultiDomain;
+
+    /**
+     * @var RedirectAdminType
+     */
+    protected $objectSingleDomain;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -20,7 +25,18 @@ class RedirectAdminTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->object = new RedirectAdminType();
+        $multiDomainConfiguration = $this->getMockBuilder('Kunstmaan\NodeBundle\Helper\DomainConfigurationInterface')
+            ->disableOriginalConstructor()->getMock();
+        $multiDomainConfiguration->expects($this->any())->method('isMultiDomainHost')->will($this->returnValue(true));
+        $multiDomainConfiguration->expects($this->any())->method('getHosts')->will($this->returnValue(array('domain.com', 'domain.be')));
+
+        $singleDomainConfiguration = $this->getMockBuilder('Kunstmaan\NodeBundle\Helper\DomainConfigurationInterface')
+            ->disableOriginalConstructor()->getMock();
+        $singleDomainConfiguration->expects($this->any())->method('isMultiDomainHost')->will($this->returnValue(false));
+        $singleDomainConfiguration->expects($this->any())->method('getHosts')->will($this->returnValue(array()));
+
+        $this->objectMultiDomain = new RedirectAdminType($multiDomainConfiguration);
+        $this->objectSingleDomain = new RedirectAdminType($singleDomainConfiguration);
     }
 
     /**
@@ -50,7 +66,27 @@ class RedirectAdminTypeTest extends \PHPUnit_Framework_TestCase
             ->method('add')
             ->with('permanent');
 
-        $this->object->buildForm($builder, array());
+        $this->objectSingleDomain->buildForm($builder, array());
+
+        $builder = $this->getMock('Symfony\Component\Form\Test\FormBuilderInterface');
+        $builder
+            ->expects($this->at(0))
+            ->method('add')
+            ->with('domain');
+        $builder
+            ->expects($this->at(1))
+            ->method('add')
+            ->with('origin');
+        $builder
+            ->expects($this->at(2))
+            ->method('add')
+            ->with('target');
+        $builder
+            ->expects($this->at(3))
+            ->method('add')
+            ->with('permanent');
+
+        $this->objectMultiDomain->buildForm($builder, array());
     }
 
     /**
@@ -58,6 +94,6 @@ class RedirectAdminTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetName()
     {
-        $this->assertEquals('redirect_form', $this->object->getName());
+        $this->assertEquals('redirect_form', $this->objectMultiDomain->getName());
     }
 }

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -18,6 +18,7 @@
         "symfony-cmf/routing-bundle": "~1.1.1",
         "kunstmaan/adminlist-bundle": "~3.2",
         "kunstmaan/admin-bundle": "~3.2",
+        "kunstmaan/node-bundle": "~3.2",
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When you have a website that has multiple domains, it was not possible to use the same origin url and point it to a different target url for each domain. This PR solves this by allowing the administrator to choose the domain for which the redirect should work. It is also possible to choose "All domains".

When there is only a single domain configured, the domain input field will not be shown and the domain column will not be visible in the adminlist.

Eg:
domain.com/cola -> domain.com/actions/cola
domain.nl/cola -> domain.nl/acties/cola
