### PR TITLE
Make is easier to append javascript/css/CKConfiguration

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
@@ -45,3 +45,5 @@
         }
     };
 </script>
+
+{% include "KunstmaanAdminBundle:Default:_ckeditor_configs_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs_extra.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs_extra.html.twig
@@ -1,0 +1,4 @@
+{#
+  Don't edit this file in the Kunstmaan Bundles.
+  You can extend this file to add ckeditor configuration without removing the complete configuration.
+#}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_css.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_css.html.twig
@@ -29,3 +29,5 @@
         color: {{ titlecolor }};
     }
 </style>
+
+{% include "KunstmaanAdminBundle:Default:_css_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_css_extra.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_css_extra.html.twig
@@ -1,0 +1,4 @@
+{#
+  Don't edit this file in the Kunstmaan Bundles.
+  You can extend this file to add css without removing the complete configuration.
+#}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -53,3 +53,5 @@
 %}
     <script src="{{ asset_url }}"></script>
 {% endjavascripts %}
+
+{% include "KunstmaanAdminBundle:Default:_js_footer_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer_extra.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer_extra.html.twig
@@ -1,0 +1,4 @@
+{#
+  Don't edit this file in the Kunstmaan Bundles.
+  You can extend this file to add javascript without removing the complete configuration.
+#}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
@@ -1,0 +1,1 @@
+{% include "KunstmaanAdminBundle:Default:_js_header_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header_extra.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header_extra.html.twig
@@ -1,0 +1,4 @@
+{#
+  Don't edit this file in the Kunstmaan Bundles.
+  You can extend this file to add javascript in the head without removing the complete configuration.
+#}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Now you can override the extra files which are included after the default configurations. So no need to copy paste the big configuration files if you only have to append one line.

This is a workarround the problem that parent() does not work when you override twig files in your /app folder.