### PR TITLE
[MultiDomainBundle] Replaced host override cookie with session

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
+++ b/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
@@ -4,7 +4,6 @@ namespace Kunstmaan\MultiDomainBundle\Controller;
 
 use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -34,15 +33,13 @@ class SiteSwitchController extends Controller
             throw $this->createNotFoundException('Invalid host specified');
         }
 
-        $request->cookies->set(DomainConfiguration::OVERRIDE_HOST, $host);
+        $session = $request->getSession();
+        $session->set(DomainConfiguration::OVERRIDE_HOST, $host);
         $defaultLocale = $this->get('kunstmaan_admin.domain_configuration')->getDefaultLocale();
 
         $response = new RedirectResponse(
             $this->get('router')->generate('KunstmaanAdminBundle_homepage', array('_locale' => $defaultLocale))
         );
-
-        $cookie = new Cookie(DomainConfiguration::OVERRIDE_HOST, $host);
-        $response->headers->setCookie($cookie);
 
         return $response;
     }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -172,15 +172,20 @@ class DomainConfiguration extends BaseDomainConfiguration
 
         return !is_null($request) &&
             $this->isAdminRoute($request->getRequestUri()) &&
-            $request->cookies->has(self::OVERRIDE_HOST);
+            $request->hasPreviousSession() &&
+            $request->getSession()->has(self::OVERRIDE_HOST);
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     protected function getHostOverride()
     {
-        return $this->getMasterRequest()->cookies->get(self::OVERRIDE_HOST);
+        if (null !== ($request = $this->getMasterRequest()) && $request->hasPreviousSession()) {
+            return $request->getSession()->get(self::OVERRIDE_HOST);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
@@ -20,9 +20,9 @@ class HostOverrideCleanupHandler implements LogoutHandlerInterface
      */
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
-        // Remove host override cookie
-        if ($request->cookies->has(DomainConfiguration::OVERRIDE_HOST)) {
-            $response->headers->clearCookie(DomainConfiguration::OVERRIDE_HOST);
+        // Remove host override
+        if ($request->hasPreviousSession() && $request->getSession()->has(DomainConfiguration::OVERRIDE_HOST)) {
+            $request->getSession()->remove(DomainConfiguration::OVERRIDE_HOST);
         }
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
@@ -5,6 +5,8 @@ namespace Kunstmaan\MultiDomainBundle\Tests\Helper;
 use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
 {
@@ -373,8 +375,12 @@ class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
 
     private function getRequestWithOverride($uri)
     {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(DomainConfiguration::OVERRIDE_HOST, 'singlelangdomain.tld');
+
         $request = Request::create('http://multilangdomain.tld' . $uri);
-        $request->cookies->set(DomainConfiguration::OVERRIDE_HOST, 'singlelangdomain.tld');
+        $request->setSession($session);
+        $request->cookies->set($session->getName(), null);
 
         return $request;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

I had a problem with the host override cookie was unset by Varnish because it is prefixed with underscore.
As it is a session cookie it is easy replaced by using the request session instead of an extra cookie.