### PR TITLE
Make it possible to add extra JS to the Admin area

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -141,5 +141,10 @@
 
     <!-- JS - Extra -->
     {% block extrajavascript %}{% endblock %}
+
+    <!-- JS extension point for external users -->
+    {% include "KunstmaanAdminBundle:Default:_js_extra_footer.html.twig" %}
+
+
 </body>
 </html>


### PR DESCRIPTION
Without extending layout.html.twig.

Since layout.html.twig is an important file, you do not want to extend
it. Instead extend the
KunstmaanAdminBundle:Default:_js_extra_footer.html.twig file to add an
extra JS file or two.

Usefull for example if you are creating advanced form types to include
in editing a PagePart.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

