### PR TITLE
[AdminListBundle] Deprecated twig function my_router_params()

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
@@ -2,7 +2,7 @@
 {% form_theme form 'KunstmaanAdminBundle:Form:fields.html.twig' %}
 
 {% block header %}
-    <form action="{{ path(app.request.attributes.get('_route'), my_router_params()) }}" method="post" {{ form_enctype(form) }} novalidate="novalidate">
+    <form action="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" method="post" {{ form_enctype(form) }} novalidate="novalidate">
     {{ parent() }}
 {% endblock %}
 

--- a/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
+++ b/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
@@ -92,6 +92,8 @@ class AdminListTwigExtension extends \Twig_Extension
      * Emulating the symfony 2.1.x $request->attributes->get('_route_params') feature.
      * Code based on PagerfantaBundle's twig extension.
      *
+     * @deprecated: you should use _route_params from the request attributes param bag now
+     *
      * @return array
      */
     public function routerParams()

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/addTranslation.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/addTranslation.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     {% form_theme form 'KunstmaanAdminBundle:Form:fields.html.twig' %}
-    <form action="{{ path(app.request.attributes.get('_route'), my_router_params()) }}" method="post" {{ form_enctype(form) }} novalidate>
+    <form action="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" method="post" {{ form_enctype(form) }} novalidate>
         <fieldset class="form__fieldset--padded">
             {{ form_rest(form) }}
 

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/editTranslation.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/editTranslation.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
     {% form_theme form 'KunstmaanAdminBundle:Form:fields.html.twig' %}
-    <form action="{{ path(app.request.attributes.get('_route'), my_router_params()) }}" method="post" {{ form_enctype(form) }} novalidate >
+    <form action="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" method="post" {{ form_enctype(form) }} novalidate >
         <fieldset class="form__fieldset--padded">
             {{ form_rest(form) }}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

This deprecates the my_router_params() twig function. Calls should be replaced by request attribute param bag variable '_route_params' which didn't exist in Symfony 2.0.