### PR TITLE
[NodeBundle] Option to fix `StructureNodes` on save

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/doc/FormCollectionAdditions.md
+++ b/src/Kunstmaan/AdminBundle/Resources/doc/FormCollectionAdditions.md
@@ -82,7 +82,7 @@ form type has a getter and setter for a weight field if you don't set it).
 ## Many to Many relations
 
 If you have a many-to-many relation, you wouldn’t want to delete the related entity when removing it from page part.
-In order to skip this, set 'nested_deletable => false` attribute, i.e.:
+In order to skip this, set `nested_deletable => false` attribute, i.e.:
 
 ```
 'attr' => array(

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -50,6 +50,8 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
+        $root->children()->booleanNode('fix_structure_nodes')->defaultFalse();
+
         return $treeBuilder;
     }
 }

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -35,6 +35,10 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
             'Kunstmaan\NodeBundle\Helper\PagesConfiguration', [$config['pages']]
         ));
 
+        if (false === $config['fix_structure_nodes']) {
+            $container->removeDefinition('kunstmaan_node.event_listener.structure_node_listener');
+        }
+
         $loader->load('services.yml');
     }
 

--- a/src/Kunstmaan/NodeBundle/EventListener/StructureNodeSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/StructureNodeSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\EventListener;
+
+use Kunstmaan\NodeBundle\Event\Events;
+use Kunstmaan\NodeBundle\Event\NodeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class StructureNodeSubscriber implements EventSubscriberInterface
+{
+    public function onNodeSave(NodeEvent $event)
+    {
+        $page = $event->getPage();
+        if (false === $page->isStructureNode()) {
+            return;
+        }
+
+        $node = $event->getNode();
+        $nodeTranslation = $event->getNodeTranslation();
+
+        $node->setHiddenFromNav(true);
+        $nodeTranslation->setOnline(true);
+        $nodeTranslation->setUrl('');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PRE_PERSIST => 'onNodeSave',
+            Events::ADD_NODE => 'onNodeSave',
+        ];
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -148,6 +148,11 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
+    kunstmaan_node.event_listener.structure_node_listener:
+        class: Kunstmaan\NodeBundle\EventListener\StructureNodeSubscriber
+        tags:
+            - { name: kernel.event_subscriber }
+
     kunstmaan_node.node_menu:
         class: Kunstmaan\NodeBundle\Helper\NodeMenu
         arguments: ["@doctrine.orm.entity_manager", "@security.context", "@kunstmaan_admin.acl.helper", "@kunstmaan_node.domain_configuration"]

--- a/src/Kunstmaan/NodeBundle/Resources/doc/NodeBundle.md
+++ b/src/Kunstmaan/NodeBundle/Resources/doc/NodeBundle.md
@@ -27,3 +27,13 @@ Nodes can be published on a specified date, you have to configure a cronjob for 
 ```cron
 * * * * * /....../app/console kuma:nodes:cron
 ```
+
+## Structure nodes
+
+Structure nodes are used to group other nodes and as such they don’t need to have a published version, they don’t need to be online themselves, etc. This may cause problems for some (see [#701](https://github.com/Kunstmaan/KunstmaanBundlesCMS/issues/701) for example). If you’d like your StructureNodes always online, hidden from nav and with empty URL, enable it in config:
+
+```yaml
+# config.yml
+kunstmaan_node:
+    fix_structure_nodes: true
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #701

I don’t have my project env set up, so I wasn’t able to test it, but it seems to be straight forward enough to make a PR anyway.

And since the behaviour may cause problems to some, I added a config switch for it (off by default).