### PR TITLE
[NodeBundle] Added get_translation_url() twig method

### DIFF
--- a/docs/05-08-using-the-multi-domain-bundle.md
+++ b/docs/05-08-using-the-multi-domain-bundle.md
@@ -133,3 +133,17 @@ The following extra Twig functions are available when you enable the multi domai
 
 - ```get_multi_domain_hosts()``` - returns the hosts that are defined in the multi domain configuration
 - ```get_current_host()``` - returns the current host (either the real one or the current override)
+
+
+## Translate url generation
+
+If you want to generate an absolute url for a translated page you can use the `get_translation_url()` twig function.
+
+This function will check if for a given node, nodemenuitem, nodetranslation or page a translation is available in a 
+different locale. If it is not available it will try to find a translation on the root node.
+An absolute url (with scheme and hostname) will be returned for the found translation node. Otherwise a empty string
+will be returned.
+
+```
+    <a href="{{ get_translation_url(nodemenu.current, 'nl') }}">View Dutch website</a>
+```

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -110,6 +110,32 @@ class DomainConfiguration extends BaseDomainConfiguration
     }
 
     /**
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function getTranslationHost($locale)
+    {
+        $host = $this->getHost();
+
+        if ($this->isMultiDomainHost() && !$this->isMultiLanguage()) {
+            $internalName = $this->hosts[$host]['root'];
+            foreach ($this->hosts as $hostName => $hostInfo) {
+                if ($hostName !== $host && $hostInfo['root'] === $internalName
+                    && (
+                        'single_lang' === $hostInfo['type'] && $hostInfo['default_locale'] === $locale
+                        || 'multi_lang' === $hostInfo['type'] && isset($hostInfo['locales'][$locale])
+                    )
+                ) {
+                    return $hostName;
+                }
+            }
+        }
+
+        return $host;
+    }
+
+    /**
      * Fetch the root node for the current host
      */
     public function getRootNode()

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -37,6 +37,8 @@ class DomainBasedLocaleRouter extends SlugRouter
                 if (isset($reverseLocaleMap[$locale])) {
                     $parameters['_locale'] = $reverseLocaleMap[$locale];
                 }
+            } elseif ($this->isMultiDomainHost() && isset($parameters['_locale']) && !isset($parameters['host'])) {
+                $parameters['host'] = $this->domainConfiguration->getTranslationHost($parameters['_locale']);
             }
         }
 

--- a/src/Kunstmaan/NodeBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/NodeBundle/Helper/DomainConfiguration.php
@@ -66,6 +66,16 @@ class DomainConfiguration implements DomainConfigurationInterface
     }
 
     /**
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function getTranslationHost($locale)
+    {
+        return $this->getHost();
+    }
+
+    /**
      * @return string
      */
     public function getDefaultLocale()

--- a/src/Kunstmaan/NodeBundle/Helper/DomainConfigurationInterface.php
+++ b/src/Kunstmaan/NodeBundle/Helper/DomainConfigurationInterface.php
@@ -21,6 +21,15 @@ interface DomainConfigurationInterface
     public function getHosts();
 
     /**
+     * Return host for a specific locale
+     *
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function getTranslationHost($locale);
+
+    /**
      * Get the default locale for the current host.
      *
      * @return string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #684

With this method you can generate a translation url for a node from a twig template.
It also works (and especially) when the MultiDomainBundle is enabled.

The SlugRouter is modified to allow host parameter to be set, which allows you to change the hostname when generating an absolute url.

This could probably also be used to generate url's to nodes on different hosts by setting the host parameter. However you probably want a wrapper function to determine the right hostname for a node.