### PR TITLE
[Nodebundle] [critical] Fix services.yml error in NodeBundle

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -8,8 +8,8 @@ services:
     kunstmaan_node.nodetranslation.listener:
         class: Kunstmaan\NodeBundle\EventListener\NodeTranslationListener
         arguments: ["@session", "@kunstmaan_admin.logger" , "@kunstmaan_utilities.slugifier", "@kunstmaan_node.domain_configuration"]
-        calls: 
-            - [ "setRequestStack", @request_stack ]
+        calls:
+            - [ "setRequestStack", [@request_stack] ]
         tags:
             - { name: 'doctrine.event_listener', event: 'onFlush', method: 'onFlush' }
             - { name: 'doctrine.event_listener', event: 'postFlush', method: 'postFlush' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

```
  Catchable Fatal Error: Argument 2 passed to Symfony\Component\DependencyInjection\Definition::addMethodCall() must be of the type array, object given, called in /vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php on line 253 and defined  
```

This is caused by services.yml in the NodeBundle.