### PR TITLE
[GeneratorBundle] moved NodeTranslationTwigExtension to separate extension

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -297,8 +297,9 @@ class DefaultSiteGenerator extends KunstmaanGenerator
     public function generateConfig()
     {
         $configFile = $this->rootDir.'/app/config/config.yml';
+        $config = file_get_contents($configFile);
 
-        $data = Yaml::parse($configFile);
+        $data = Yaml::parse($config);
         if (!array_key_exists('white_october_pagerfanta', $data)) {
             $ymlData = "\n\nwhite_october_pagerfanta:";
             $ymlData .= "\n    default_view: twitter_bootstrap\n";
@@ -404,9 +405,10 @@ class DefaultSiteGenerator extends KunstmaanGenerator
      */
     public function generateTwigExtensions($parameters)
     {
+        $relPath = '/Twig/';
+        $this->renderSingleFile($this->skeletonDir.$relPath, $this->bundle->getPath().$relPath, 'NodeTranslationTwigExtension.php', $parameters, true);
         if ($this->demosite) {
-            $relPath = '/Twig/';
-            $this->renderFiles($this->skeletonDir.$relPath, $this->bundle->getPath().$relPath, $parameters, true);
+            $this->renderSingleFile($this->skeletonDir.$relPath, $this->bundle->getPath().$relPath, 'BikesTwigExtension.php', $parameters, true);
         }
 
         $relPath = '/Resources/config/';

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/services.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/services.yml
@@ -1,4 +1,10 @@
 services:
+    {{ bundle.name|lower }}.node_translation.twig.extension:
+        class: {{ bundle.namespace }}\Twig\NodeTranslationTwigExtension
+        arguments: ["@doctrine.orm.entity_manager"]
+        tags:
+            - { name: twig.extension }
+
 {% if demosite %}
     {{ bundle.name|lower }}.bikes.twig.extension:
         class: {{ bundle.namespace }}\Twig\BikesTwigExtension

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/BikesTwigExtension.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/BikesTwigExtension.php
@@ -32,7 +32,6 @@ class BikesTwigExtension extends \Twig_Extension
 	return array(
 	    'get_bikes' => new \Twig_Function_Method($this, 'getBikes'),
 	    'get_submenu_items' => new \Twig_Function_Method($this, 'getSubmenuItems'),
-	    'get_node_trans_by_node_id' => new \Twig_Function_Method($this, 'getNodeTranslationByNodeId')
 	);
     }
 
@@ -63,31 +62,6 @@ class BikesTwigExtension extends \Twig_Extension
 	}
 
 	return $items;
-    }
-
-    /**
-     * Get the node translation object based on node id and language.
-     *
-     * @param int $nodeId
-     * @param string $lang
-     * @return NodeTranslation
-     */
-    public function getNodeTranslationByNodeId($nodeId, $lang)
-    {
-	$repo = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation');
-	$qb = $repo->createQueryBuilder('nt')
-	    ->select('nt')
-	    ->innerJoin('nt.node', 'n', 'WITH', 'nt.node = n.id')
-	    ->where('n.deleted != 1')
-	    ->andWhere('nt.online = 1')
-	    ->andWhere('nt.lang = :lang')
-	    ->setParameter('lang', $lang)
-	    ->andWhere('n.id = :node_id')
-	    ->setParameter('node_id', $nodeId)
-	    ->setFirstResult(0)
-	    ->setMaxResults(1);
-
-	return $qb->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/NodeTranslationTwigExtension.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/NodeTranslationTwigExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace {{ namespace }}\Twig;
+
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\NodeBundle\Entity\AbstractPage;
+
+class NodeTranslationTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var EntityManager $em
+     */
+    private $em;
+
+    /**
+     * Constructor
+     *
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            'get_node_trans_by_node_id' => new \Twig_Function_Method($this, 'getNodeTranslationByNodeId')
+        );
+    }
+
+    /**
+     * Get the node translation object based on node id and language.
+     *
+     * @param int $nodeId
+     * @param string $lang
+     * @return NodeTranslation
+     */
+    public function getNodeTranslationByNodeId($nodeId, $lang)
+    {
+        $repo = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation');
+        $qb = $repo->createQueryBuilder('nt')
+            ->select('nt')
+            ->innerJoin('nt.node', 'n', 'WITH', 'nt.node = n.id')
+            ->where('n.deleted != 1')
+            ->andWhere('nt.online = 1')
+            ->andWhere('nt.lang = :lang')
+            ->setParameter('lang', $lang)
+            ->andWhere('n.id = :node_id')
+            ->setParameter('node_id', $nodeId)
+            ->setFirstResult(0)
+            ->setMaxResults(1);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'node_translation_twig_extension';
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Tests/Generator/DefaultSiteGeneratorTest.php
+++ b/src/Kunstmaan/GeneratorBundle/Tests/Generator/DefaultSiteGeneratorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Kunstmaan\GeneratorBundle\Generator\Tests;
+
+
+use Kunstmaan\GeneratorBundle\Generator\DefaultSiteGenerator;
+use Kunstmaan\GeneratorBundle\Helper\CommandAssistant;
+use Symfony\Component\Filesystem\Filesystem;
+
+class DefaultSiteGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerator()
+    {
+        $filesystem = new Filesystem();
+        $path = sys_get_temp_dir() . '/' . uniqid();
+        $filesystem->remove($path);
+
+        $bundle = $this->getBundle($path);
+
+        $generator = new DefaultSiteGenerator($filesystem, $this->getRegistry(), '/defaultsite', $this->getAssistant());
+        $generator->generate($bundle, '', __DIR__ . '/../data', false);
+
+        $this->assertFileExists($path . '/Twig/NodeTranslationTwigExtension.php');
+    }
+
+    protected function getBundle($path)
+    {
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle
+            ->expects($this->any())
+            ->method('getNamespace')
+            ->will($this->returnValue('Kunstmaan\TestBundle'))
+        ;
+
+        $bundle
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('KunstmaanTestBundle'))
+        ;
+
+        $bundle
+            ->expects($this->any())
+            ->method('getPath')
+            ->will($this->returnValue($path))
+        ;
+
+        return $bundle;
+    }
+
+    protected function getRegistry()
+    {
+        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+
+        return $registry;
+    }
+
+    protected function getAssistant()
+    {
+        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+
+        $commandAssistant = new CommandAssistant();
+        $commandAssistant->setOutput($output);
+
+        return $commandAssistant;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Tests/data/app/config/config.yml
+++ b/src/Kunstmaan/GeneratorBundle/Tests/data/app/config/config.yml
@@ -1,0 +1,43 @@
+framework:
+    secret:          secret
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+        strict_requirements: %kernel.debug%
+    form:            ~
+    csrf_protection: ~
+    validation:      { enable_annotations: true, enabled: true }
+    templating:
+        engines: ['twig']
+    default_locale:  nl
+    trusted_proxies: ~
+    session:         ~
+    fragments:       ~
+
+kunstmaan_translator:
+    managed_locales: ['nl','en','de']
+    cache_dir: "%kernel.cache_dir%/translations"
+
+monolog:
+    handlers:
+        main:
+            type:  stream
+            path:  %kernel.logs_dir%/%kernel.environment%.log
+            level: debug
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                driver:   pdo_sqlite
+                path:     %kernel.cache_dir%/test.db
+    orm:
+        default_entity_manager:   default
+        entity_managers:
+            default:
+                connection:       default
+                mappings:
+                    KunstmaanTranslatorBundle: ~
+
+
+white_october_pagerfanta:
+    default_view: twitter_bootstrap


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

After generation of the default site with `--demosite` option, the `get_node_trans_by_node_id` Twig function was not available. 