### PR TITLE
[SearchBundle] fixed typo in SearchConfigurationChain::getConfiguration

### DIFF
--- a/src/Kunstmaan/SearchBundle/Configuration/SearchConfigurationChain.php
+++ b/src/Kunstmaan/SearchBundle/Configuration/SearchConfigurationChain.php
@@ -37,7 +37,7 @@ class SearchConfigurationChain
      */
     public function getConfiguration($alias)
     {
-        if (array_key_exists($alias, $this->searchConfiguration)) {
+        if (array_key_exists($alias, $this->searchConfigurations)) {
             return $this->searchConfigurations[$alias];
         }
 

--- a/src/Kunstmaan/SearchBundle/Tests/DependencyInjection/Configuration/SearchConfigurationChainTest.php
+++ b/src/Kunstmaan/SearchBundle/Tests/DependencyInjection/Configuration/SearchConfigurationChainTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Kunstmaan\SearchBundle\Tests\Configuration;
+
+
+use Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain;
+
+class SearchConfigurationChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddAndGetConfiguration()
+    {
+        $configuration = $this->getMock('Kunstmaan\SearchBundle\Configuration\SearchConfigurationInterface');
+
+        $chain = new SearchConfigurationChain();
+        $chain->addConfiguration($configuration, 'configuration');
+
+        $this->assertEquals($configuration, $chain->getConfiguration('configuration'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |