### PR TITLE
[AdminBundle] fix JS undefined issue & add translations in permissions widget

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
@@ -68,3 +68,11 @@ omnext:
   welcome: Welcome.
   information: <strong>Information.</strong> There are no new notifications.
 
+permissions:
+  you_made_changes: You have made changes to the permissions on this page.
+  apply_recursively: Apply these changes recursively on all child pages
+  review_changes: Review your changes
+  changes: Permission changes
+  permissions_added: 'The following permissions will be <strong>added</strong>:'
+  permissions_removed: 'The following permissions will be <strong>removed</strong>:'
+  role_name: Role name

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_page-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_page-editor.js
@@ -245,7 +245,7 @@ kunstmaanbundles.pageEditor = (function(window, undefined) {
 
             // Add hidden fields
             var hiddenfieldsContainer = $("#permission-hidden-fields"),
-                hiddenfields;
+                hiddenfields = '';
 
             if (changes['add'].length > 0) {
                 for (var i=0; i<changes['add'].length; i++) {

--- a/src/Kunstmaan/AdminBundle/Resources/views/PermissionsAdminTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/PermissionsAdminTwigExtension/widget.html.twig
@@ -3,14 +3,14 @@
         <!-- Info container -->
         <div id="permission-changes-info-container" class="alert alert-info hidden">
             <h5>
-                {{ "You have made changes to the permissions on this page."|trans|raw }}
+                {{ "permissions.you_made_changes"|trans|raw }}
             </h5>
             <div class="checkbox">
                 <label>
                     <input type="checkbox" id="apply-recursive" name="applyRecursive" value="1">
-                    {{ "Apply these changes recursively on all child pages"|trans|raw }}
+                    {{ "permissions.apply_recursively"|trans|raw }}
                     (<a href="#permission-changes-modal" data-toggle="modal">
-                        {{ "Review your changes"|trans|raw }}
+                        {{ "permissions.review_changes"|trans|raw }}
                     </a>)
                 </label>
             </div>
@@ -25,7 +25,7 @@
                             <i class="fa fa-times"></i>
                         </button>
                         <h3>
-                            {{ 'Permission changes'|trans }}
+                            {{ "permissions.changes"|trans }}
                         </h3>
                     </div>
                     <div class="modal-body" id="permission-changes-modal__body"></div>
@@ -34,14 +34,14 @@
         </div>
     {% endif %}
 
-    <div id="permissions-container" class="permissionscontainer" data-recursive="{% if recursiveSupport %}true{% else %}false{% endif %}" data-trans-perms-added='{{ "The following permissions will be <strong>added</strong>:"|trans|raw }}' data-trans-perms-removed='{{ "The following permissions will be <strong>removed</strong>:"|trans|raw }}'>
+    <div id="permissions-container" class="permissionscontainer" data-recursive="{% if recursiveSupport %}true{% else %}false{% endif %}" data-trans-perms-added='{{ "permissions.permissions_added"|trans|raw }}' data-trans-perms-removed='{{ "permissions.permissions_removed"|trans|raw }}'>
         <div id="permission-hidden-fields"></div>
 
         {% spaceless %}
         <table class="table table-bordered table-striped">
             <thead>
                <tr>
-                   <th>Rollname</th>
+                   <th>{{ "permissions.role_name"|trans }}</th>
                     {% for permissionName in permissionadmin.getPossiblePermissions() %}
                         <th>{{ permissionName }}</th>
                     {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When you selected a new permission to be added or an existing permission to be removed the text "undefined" appeared below the "Apply recursive" dropdown. This PR fixes that, and adds translation labels in the widget view as well.