### PR TITLE
[AdminBundle] Improve submenu caret alignment

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/vendors/bootstrap-components/_dropdown-menu.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/vendors/bootstrap-components/_dropdown-menu.scss
@@ -5,6 +5,13 @@
 
 .dropdown-menu__item--has-submenu {
     position: relative;
+    @extend %clearfix;
+
+    i.fa {
+        float: right;
+        margin-top: 3px;
+        margin-right: -5px;
+    }
 }
 
 .dropdown-toggle--submenu {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The submenu carets were positioned right next to their respective labels instead of on the right side of the menu which made it less clear what items had submenu's. This PR fixes that issue.