### PR TITLE
[SeoBundle] Remove incorrect slash from image_src tag

### DIFF
--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -32,7 +32,7 @@
 {% endif %}
 {% if seo.getOgImage() is defined and seo.getOgImage() is not null %}
     <meta property="og:image" content="{{ app.request.schemeandhttphost ~ asset(seo.getOgImage().getUrl()) }}">
-    <link rel="image_src" href="{{ app.request.schemeandhttphost ~ asset(seo.getOgImage().getUrl()) }}" / >
+    <link rel="image_src" href="{{ app.request.schemeandhttphost ~ asset(seo.getOgImage().getUrl()) }}">
 {% endif %}
 {% if seo.getExtraMetadata() %}
     {{ seo.getExtraMetadata() | raw }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Remove a incorrect slash so the html is valid