### PR TITLE
[AdminListBundle] Change image button image to icon

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
@@ -23,10 +23,9 @@
                         {% for itemAction in adminlistconfigurator.getItemActions() %}
                             <a class="btn btn-default btn--raise-on-hover" href="{{ path(itemAction.getUrlFor(entity)["path"], itemAction.getUrlFor(entity)[("params")] ) }}">
                                 {% if itemAction.getIconFor(entity) is not null %}
-                                    <img src="{{ asset(itemAction.getIconFor(entity)) }}" alt="{{ itemAction.getLabelFor(entity) }}">
-                                {% else %}
-                                    {{ itemAction.getLabelFor(entity) }}
+                                    <i class="fa fa-{{ itemAction.getIconFor(entity) }}"></i>
                                 {% endif %}
+                                {{ itemAction.getLabelFor(entity) }}
                             </a>
                         {% endfor %}
                     {% endif %}


### PR DESCRIPTION
Hello, I run into a problem. If I use list with configurator where I add buttons, they are printed different in [edit page](https://sc-cdn.scaleengine.net/i/8adf431260cf2d7b36f92a06809c5f41.png) than in [items list](https://sc-cdn.scaleengine.net/i/c243c8d21fa8f5a2ac8a2be7a1af81ce.png). I want them to [look the same](https://sc-cdn.scaleengine.net/i/6f4b8dc63a8c8c585e379547ecd5aecd.png).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no