### PR TITLE
[AdminBundle] pp view block overflow clearfix fix

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/structures/_pp.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/structures/_pp.scss
@@ -164,6 +164,8 @@
 }
 
 .pp__view__block {
+    @include clearfix;
+
     .container {
         max-width: 100%!important;
     }


### PR DESCRIPTION
Overflow: hidden was removed before for the datepicker.
This broke the block when floated elements were inside.
Clearfix added.