### PR TITLE
[DashboardBundle] Fix https render_esi() dashboard problem

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -14,7 +14,7 @@
 
 {% block content %}
     {% for widget in widgets %}
-        {{ render_esi(url(widget.resolvedController, {'id' : id})) }}
+        {{ render_esi(path(widget.resolvedController, {'id' : id})) }}
     {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
Some reverse proxies have problems with ESI tags with absolute https links.
Using a relative path will solve this.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 