### PR TITLE
[AdminBundle] Update required Symfony version in AdminBundle

### DIFF
--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.5,<2.7",
+        "symfony/symfony": "~2.5,<2.8.0",
         "doctrine/orm": "~2.2,>=2.2.3",
         "friendsofsymfony/user-bundle": "2.0.*@dev",
         "knplabs/knp-menu-bundle": "~2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

Complete suite (KunstmaanBundlesCMS) has Symfony version requirement set to "~2.5,<2.8.0" and when installed, it runs on Symfony 2.7. But AdminBundle alone has requirement set "~2.5,<2.7" which makes it imposible install it on Symfony 2.7 project.