### PR TITLE
[MediaBundle] Update required KnpGaufretteBundle version in MediaBundle

### DIFF
--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -19,7 +19,7 @@
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",
         "liip/imagine-bundle": "v0.20.2",
-        "knplabs/knp-gaufrette-bundle": "0.1.*",
+        "knplabs/knp-gaufrette-bundle": "~0.1",
         "sensio/framework-extra-bundle": ">=2.3.0,<4.0.0",
         "kunstmaan/admin-bundle": "~3.2",
         "kunstmaan/adminlist-bundle": "~3.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

Synchronize required version of KnpGaufretteBundle in KunstmaanBundlesCMS and KunstmaanMediaBundle (similar problem as #772).