### PR TITLE
[MultiDomainBundle] Get Extra Multi Domain data twig extension

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/Twig/MultiDomainTwigExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/Twig/MultiDomainTwigExtension.php
@@ -29,7 +29,23 @@ class MultiDomainTwigExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFunction('get_multi_domain_hosts', array($this, 'getMultiDomainHosts')),
             new \Twig_SimpleFunction('get_current_host', array($this, 'getCurrentHost')),
+            new \Twig_SimpleFunction('get_extra_data', array($this, 'getExtraData')),
         );
+    }
+
+    /**
+     * @param $key
+     * @return null
+     */
+    public function getExtraData($key)
+    {
+        $extraData = $this->domainConfiguration->getExtraData();
+
+        if ($extraData[$key]) {
+            return $extraData[$key];
+        }
+
+        return null;
     }
 
     /**

--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -57,8 +57,8 @@
     {% else %}
     <meta property="og:image" content="{{ app.request.schemeandhttphost ~ asset(seo.getOgImage().getUrl()) }}">
     <meta property="og:image:type" content="{{ seo.ogImage.contentType }}">
-    {% if seo.ogImage.metaData.original_height is defined %}<meta property="og:image:height" content="{{ seo.ogImage.metaData.height }}">{% endif %}
-    {% if seo.ogImage.metaData.original_width is defined %}<meta property="og:image:width" content="{{ seo.ogImage.metaData.width }}">{% endif %}
+    {% if seo.ogImage.metaData.original_height is defined %}<meta property="og:image:height" content="{{ seo.ogImage.metaData.original_height }}">{% endif %}
+    {% if seo.ogImage.metaData.original_width is defined %}<meta property="og:image:width" content="{{ seo.ogImage.metaData.original_width }}">{% endif %}
     <link rel="image_src" href="{{ app.request.schemeandhttphost ~ asset(seo.getOgImage().getUrl()) }}" />
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Add a twig function to gain access to the defined extra parameters of your multi domain bundle config.
This is useful in case you need to conditionally format templates based on domain.

Also, I noticed a error in the SeoBundle, this has been fixed.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 