### PR TITLE
[MediaBundle] Create web safe filenames

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -213,17 +213,22 @@ class FileHandler extends AbstractMediaHandler
      */
     private function getFilePath(Media $media)
     {
-        $filename = $media->getOriginalFilename();
-        $filename = str_replace(array('/', '\\', '%'), '', $filename);
+        $filename  = $media->getOriginalFilename();
+        $filename  = str_replace(array('/', '\\', '%'), '', $filename);
+        $slugifier = new Slugifier();
 
         if (!empty($this->blacklistedExtensions)) {
             $filename = preg_replace('/\.('.join('|', $this->blacklistedExtensions).')$/', '.txt', $filename);
         }
 
+        $parts    = pathinfo($filename);
+        $filename = $slugifier->slugify($parts['filename']);
+        $filename .= '.'.$parts['extension'];
+
         return sprintf(
             '%s/%s',
             $media->getUuid(),
-            strtolower($filename)
+            $filename
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | unsure
| Deprecations? | no
| Fixed tickets | 

Around ~3.2, the media bundle stopped using uniqid's for filenames, which is good, but now filenames are kept as the original, uploaded filename (user-defined), which can be bad. This PR uses the slugifier utility to ensure web-safe filenames; stripping spaces, and other non-safe characters. When uploading an image with a filename like:

```
my-Nice.imAge(full resolution) 2.5Mb.jpg
```

The current FileHandler saves the media url as

```
/uploads/media/<uniqid>/my-Nice.imAge(full resolution) 2.5Mb.jpg
```

When trying to use that as an og_image, Facebook wasn't loving life (og_image not set/found). This PR will save the media's url as:

```
/uploads/media/<uniqid>/my-niceimage-full-resolution--25mb.jpg
```

Shouldn't cause any BC breaks, but you guys would know best. There's no FileHandlerTest in the MediaBundle to add to yet...