### PR TITLE
[SeoBundle] Idea for fix for possible multiple db-query issues

### DIFF
--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -31,6 +31,13 @@ class SeoTwigExtension extends Twig_Extension
     private $websiteTitle;
 
     /**
+     * Saves querying the db multiple times, if you happen to use any of the defined
+     * functions more than once in your templates
+     * @var array
+     */
+    private $seoCache = [];
+
+    /**
      * @param EntityManager $em
      */
     public function __construct(EntityManager $em)
@@ -86,7 +93,15 @@ class SeoTwigExtension extends Twig_Extension
      */
     public function getSeoFor(AbstractPage $entity)
     {
-        return $this->em->getRepository('KunstmaanSeoBundle:Seo')->findOrCreateFor($entity);
+        $key = md5(get_class($entity).$entity->getId());
+
+        if (!array_key_exists($key, $this->seoCache))
+        {
+            $seo = $this->em->getRepository('KunstmaanSeoBundle:Seo')->findOrCreateFor($entity);
+            $this->seoCache[$key] = $seo;
+        }
+
+        return $this->seoCache[$key];
     }
 
     /**


### PR DESCRIPTION
This took me a minute or two: according to the Profiler, I had multiple queries happening to kuma_seo, with the exact same parameters. Turns out I was calling to {{ get_title_for(page) }} twice, and {{ render_seo_for(page) }} once; causing 3 duplicate queries. 

This isn't a true caching mechanism by any means, but a potential fix to limit it to one query per request. 

You can see this in the current layout.html.twig that the GeneratorBundle outputs, which creates 2 queries. (KunstmaanGeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/layout.html.twig), it calls to get_title_for and render_seo_for.

Maybe not the perfect solution, but you can now call to get_title_for 100 times with no extra queries if you really want to :)
