### PR TITLE
[FixturesBundle] Add MenuItemBuilder for MenuItem fixtures

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Builder/MenuItemBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/MenuItemBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kunstmaan\FixturesBundle\Builder;
+
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\FixturesBundle\Loader\Fixture;
+use Kunstmaan\FixturesBundle\Populator\Populator;
+use Kunstmaan\MenuBundle\Entity\BaseMenuItem;
+
+class MenuItemBuilder implements BuilderInterface
+{
+    public function canBuild(Fixture $fixture)
+    {
+        if ($fixture->getEntity() instanceof BaseMenuItem) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function preBuild(Fixture $fixture)
+    {
+        $parameters = $fixture->getParameters();
+
+        if (isset($parameters['page']) && $parameters['page'] instanceof Fixture) {
+            $additionalEntities = $parameters['page']->getAdditionalEntities();
+            $properties = $fixture->getProperties();
+
+            if (isset($properties['menu']) &&
+                $properties['menu']->getLocale() &&
+                isset($additionalEntities['translationNode_' . $properties['menu']->getLocale()])) {
+                $fixture->getEntity()->setType(BaseMenuItem::TYPE_PAGE_LINK);
+                $fixture->getEntity()->setNodeTranslation($additionalEntities['translationNode_' . $properties['menu']->getLocale()]);
+            }
+        }
+
+        return;
+    }
+
+    public function postBuild(Fixture $fixture)
+    {
+        return;
+    }
+
+    public function postFlushBuild(Fixture $fixture)
+    {
+        return;
+    }
+}

--- a/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
@@ -32,6 +32,11 @@ services:
         tags:
             - { name: kunstmaan_fixtures.builder, alias: MediaBuilder }
 
+    kunstmaan_fixtures.builder.menuitem:
+        class: Kunstmaan\FixturesBundle\Builder\MenuItemBuilder
+        tags:
+            - { name: kunstmaan_fixtures.builder, alias: MenuItemBuilder }
+
     kunstmaan_fixtures.parser.parser:
         class: Kunstmaan\FixturesBundle\Parser\Parser
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Very simple MenuItemBuilder so that MenuItems in fixtures can be easily linked to pages.

It can be used like this:

```
\Kunstmaan\MenuBundle\Entity\Menu:
    menu_main:
        name: main
        locale: nl

\Kunstmaan\MenuBundle\Entity\MenuItem:
    menu_item_home:
        menu: @menu_main
        parameters:
            page: @homepage
```

There are no other parameters other than page. All other properties can be set through the default properties functionality of the fixtures.