### PR TITLE
[MenuBundle] Add templating possibilities for menuItems

### DIFF
--- a/src/Kunstmaan/MenuBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/services.yml
@@ -3,7 +3,7 @@ parameters:
     kunstmaan_menu.menu.service.class: Kunstmaan\MenuBundle\Service\MenuService
     kunstmaan_menu.menu.twig.extension.class: Kunstmaan\MenuBundle\Twig\MenuTwigExtension
     kunstmaan_menu.menu.repository.class: Kunstmaan\MenuBundle\Repository\MenuItemRepository
-
+    kunstmaan_menu.menu.render_service.class: Kunstmaan\MenuBundle\Service\RenderService
 
 services:
     kunstmaan_menu.menu.adaptor:
@@ -20,6 +20,11 @@ services:
             - "@kunstmaan_admin.domain_configuration"
             - "@doctrine.orm.entity_manager"
 
+    kunstmaan_menu.menu.render_service:
+        class: %kunstmaan_menu.menu.render_service.class%
+        arguments:
+            - "@router"
+
     kunstmaan_menu.menu.repository:
         class:            %kunstmaan_menu.menu.repository.class%
         factory_service:  "doctrine.orm.entity_manager"
@@ -28,6 +33,8 @@ services:
 
     kunstmaan_menu.menu.twig.extension:
         class: %kunstmaan_menu.menu.twig.extension.class%
-        arguments: ["@kunstmaan_menu.menu.repository", "@router"]
+        arguments:
+            - "@kunstmaan_menu.menu.repository"
+            - "@kunstmaan_menu.menu.render_service"
         tags:
             - { name: twig.extension }

--- a/src/Kunstmaan/MenuBundle/Resources/views/menu-item.html.twig
+++ b/src/Kunstmaan/MenuBundle/Resources/views/menu-item.html.twig
@@ -1,0 +1,1 @@
+<a href="{{ url }}" class="{% if options['linkClass'] is defined %}{{ options['linkClass'] }}{% endif %}{% if active and options['activeClass'] is defined %} {{ options['activeClass'] }}{% endif %}" {% if options['newWindow'] is defined and options['newWindow']%}target="_blank"{% endif %}>{{ title }}</a>

--- a/src/Kunstmaan/MenuBundle/Service/RenderService.php
+++ b/src/Kunstmaan/MenuBundle/Service/RenderService.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kunstmaan\MenuBundle\Service;
+
+use Kunstmaan\MenuBundle\Entity\MenuItem;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class RenderService
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @param \Twig_Environment $environment
+     * @param $node
+     * @param array $options
+     * @return string
+     */
+    public function renderMenuItemTemplate(\Twig_Environment $environment, $node, $options = array())
+    {
+        $template = isset($options['template']) ? $options['template'] : false;
+        if ($template === false) {
+            $template = 'KunstmaanMenuBundle::menu-item.html.twig';
+        }
+
+        $active = false;
+        if ($node['type'] == MenuItem::TYPE_PAGE_LINK) {
+            $url = $this->router->generate('_slug', array('url' => $node['nodeTranslation']['url']));
+
+            if ($this->router->getContext()->getPathInfo() == $url) {
+                $active = true;
+            }
+        } else {
+            $url = $node['url'];
+        }
+
+        if ($node['type'] == MenuItem::TYPE_PAGE_LINK) {
+            if ($node['title']) {
+                $title = $node['title'];
+            } else {
+                $title = $node['nodeTranslation']['title'];
+            }
+        } else {
+            $title = $node['title'];
+        }
+
+        return $environment->render($template, array(
+            'menuItem' => $node,
+            'url' => $url,
+            'options' => $options,
+            'title' => $title,
+            'active' => $active
+        ));
+    }
+}


### PR DESCRIPTION
Needs some refactoring.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | /

Added the possibility to render the menuItem with twig templates.
There are 2 options:
- set a general template by using the service parameter `kunstmaan_menu.menu.template` 
(defaults to "KunstmaanMenuBundle::menu-item.html.twig")
- set a template per menu by adding the optional template parameter in your menu twig file.

```
{{ get_menu('side', app.request.locale, {
    'rootOpen': '<ul class="main-nav__list">',
    'rootClose': '</ul>',
    'childOpen': '<li class="main-nav__list-item">',
    'childClose': '</li>',
    'template': 'MyBundle:Menu:menu-item.html.twig'
})
}}
```