### PR TITLE
Fixed wrong dependency for sensio/generator-bundle 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony-cmf/routing-bundle": "~1.3",
         "ruflin/elastica": "~2.3",
         "fpn/doctrine-extensions-taggable": "~0.9",
-	    "sensio/generator-bundle": ">=2.5.0",
+        "sensio/generator-bundle": "~2.5",
         "twig/extensions": "~1.0",
         "egulias/email-validator": "~1.2"
     },


### PR DESCRIPTION
As it is not compatible with v3.0

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #810