### PR TITLE
[MultiDomainBundle] Allows to configure/retrieve extra parameters for each domain locale

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -28,3 +28,22 @@ You should generate a migration and run it on all your databases (dev/production
 app/console doctrine:migrations:diff
 app/console doctrine:migrations:migrate
 ```
+
+## Add extra method to the DomainConfigurationInterface.
+
+The `getLocalesExtraData` method was added. If you have created your own DomainConfiguration class you will need
+to implement the extra method.
+
+This extra method will allow you to retrieve the extra parameters defined for each domain locale.
+
+```
+kunstmaan_multi_domain:
+    hosts:
+        general:
+            host: domain.com
+            type: multi_lang
+            default_locale: en
+            locales:
+                - { uri_locale: 'en', locale: 'en', extra: {country: 'UK', code: 'abc'} }
+                - { uri_locale: 'fr', locale: 'fr', extra: {country: 'FR', code: 'xyz'} }
+```

--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
@@ -117,6 +117,14 @@ class DomainConfiguration implements DomainConfigurationInterface
     }
 
     /**
+     * @return array
+     */
+    public function getLocalesExtraData()
+    {
+        return array();
+    }
+
+    /**
      * @return null|\Symfony\Component\HttpFoundation\Request
      */
     protected function getMasterRequest()

--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfigurationInterface.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfigurationInterface.php
@@ -68,4 +68,12 @@ interface DomainConfigurationInterface
      * @return mixed
      */
     public function getExtraData();
+
+    /**
+     * Return optional extra locales data for the current host from the multi domain
+     * configuration. Returns an empty array if no data was defined...
+     *
+     * @return mixed
+     */
+    public function getLocalesExtraData();
 }

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
@@ -52,6 +52,7 @@ class Configuration implements ConfigurationInterface
                                     ->children()
                                         ->scalarNode('uri_locale')->isRequired()->end()
                                         ->scalarNode('locale')->isRequired()->end()
+                                        ->variableNode('extra')->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
@@ -24,6 +24,7 @@ class KunstmaanMultiDomainExtension extends Extension
         $config        = $this->processConfiguration($configuration, $configs);
 
         $hostConfigurations = $this->getHostConfigurations($config['hosts']);
+
         $container->setParameter(
             'kunstmaan_multi_domain.hosts',
             $hostConfigurations
@@ -66,11 +67,12 @@ class KunstmaanMultiDomainExtension extends Extension
         $hostConfigurations = array();
         foreach ($hosts as $name => $settings) {
             $host = $settings['host'];
+
             foreach ($settings as $setting => $data) {
                 if ($setting === 'locales') {
+                    $hostConfigurations[$host]['locales_extra'] = $this->getLocalesExtra($data);
                     $data = $this->getHostLocales($data);
-                    $hostConfigurations[$host]['reverse_locales'] =
-                        array_flip($data);
+                    $hostConfigurations[$host]['reverse_locales'] = array_flip($data);
                 }
                 $hostConfigurations[$host][$setting] = $data;
             }
@@ -94,5 +96,22 @@ class KunstmaanMultiDomainExtension extends Extension
         }
 
         return $hostLocales;
+    }
+
+    /**
+     * Return the extra data configured for each locale
+     *
+     * @param $localeSettings
+     *
+     * @return array
+     */
+    private function getLocalesExtra($localeSettings)
+    {
+        $localesExtra = array();
+        foreach ($localeSettings as $key => $localeMapping) {
+            $localesExtra[$localeMapping['locale']] = array_key_exists('extra', $localeMapping) ? $localeMapping['extra'] : array();
+        }
+
+        return $localesExtra;
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -31,6 +31,7 @@ class DomainConfiguration extends BaseDomainConfiguration
     public function __construct(ContainerInterface $container)
     {
         parent::__construct($container);
+
         $this->hosts = $container->getParameter('kunstmaan_multi_domain.hosts');
         foreach ($this->hosts as $host => $hostInfo) {
             if (isset($hostInfo['aliases'])) {
@@ -161,6 +162,19 @@ class DomainConfiguration extends BaseDomainConfiguration
         }
 
         return $this->hosts[$host]['extra'];
+    }
+
+    /**
+     * Return (optional) extra config settings for the locales for the current host
+     */
+    public function getLocalesExtraData()
+    {
+        $host = $this->getHost();
+        if (!isset($this->hosts[$host]['locales_extra'])) {
+            return parent::getLocalesExtraData();
+        }
+
+        return $this->hosts[$host]['locales_extra'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 

Allows you to configure locale specific extra parameters.

```
kunstmaan_multi_domain:
    hosts:
        general:
            host: domain.com
            type: multi_lang
            default_locale: en
            locales:
                - { uri_locale: 'en', locale: 'en', extra: {country: 'UK', code: 'abc'} }
                - { uri_locale: 'fr', locale: 'fr', extra: {country: 'FR', code: 'xyz'} }
            extra:
                param: 'bla' 
```
