### PR TITLE
Made validateTargetDir a local function

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
@@ -83,7 +83,7 @@ EOT
             $bundle = strtr($namespace, array('\\' => ''));
         }
         $bundle = Validators::validateBundleName($bundle);
-        $dir = Validators::validateTargetDir($input->getOption('dir'), $bundle, $namespace);
+        $dir = $this::validateTargetDir($input->getOption('dir'), $bundle, $namespace);
         $format = 'yml';
 
         $questionHelper->writeSection($output, 'Bundle generation');
@@ -162,7 +162,7 @@ EOT
         $output->writeln(array('', 'The bundle can be generated anywhere. The suggested default directory uses', 'the standard conventions.', '',));
         $question = new Question($questionHelper->getQuestion('Target directory', $dir), $dir);
         $question->setValidator(function ($dir) use ($bundle, $namespace) {
-            return Validators::validateTargetDir($dir, $bundle, $namespace);
+            return $this::validateTargetDir($dir, $bundle, $namespace);
         });
         $dir = $questionHelper->ask($input, $output, $question);
         $input->setOption('dir', $dir);
@@ -269,4 +269,19 @@ EOT
     {
         return new BundleGenerator();
     }
+
+    /**
+     * Validation function taken from <3.0 release of Sensio Generator bundle
+     *
+     * @param string $dir The target directory
+     * @param string $bundle The bundle name
+     * @param string $namespace The namespace
+     *
+     * @return string
+     */
+    public static function validateTargetDir($dir, $bundle, $namespace)
+    {
+        // add trailing / if necessary
+        return '/' === substr($dir, -1, 1) ? $dir : $dir.'/';
+    }    
 }


### PR DESCRIPTION
Made validateTargetDir a local function instead of depending on the sensiolabs/SensioGeneratorBundle < 2.5.x versions.

This will resolve the issue with `app/console kuma:generate:bundle` bug that prevents generating a new bundle.