### PR TITLE
CSV export: Fix issue where only first row below the header has content

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/export.csv.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/export.csv.twig
@@ -1,23 +1,22 @@
 {% set quote = '"' %}
 {%- for column in adminlist.exportColumns -%}
-{{- quote|raw -}}{{- column.header | trans -}}{{- quote|raw -}}
-{%- if not loop.last -%},{%- endif -%}
+    {{- quote|raw -}}{{- column.header | trans -}}{{- quote|raw -}}
+    {%- if not loop.last -%},{%- endif -%}
 {%- endfor -%}
-{% for item in iterator %}
-{% if item[0] is defined %}
-{% set item = item[0] %}
-{% else %}
-{% set item = item %}
-{% endif %}
 
-{% for column in adminlist.exportColumns -%}
-{%- set columnName = column.name -%}
-{%- set template = column.template -%}
-{% if template is not null and template != 1 and template != "" %}
-{{- quote|raw -}}{% include template with {'row': item, 'columnName': columnName, 'object': adminlist.getValue(item, columnName)} %}{{- quote|raw -}}
-{% else %}
-{{- quote|raw -}}{{- adminlist.getStringValue(item, columnName) -}}{{- quote|raw -}}
-{% endif %}
-{%- if not loop.last -%},{%- endif -%}
-{%- endfor -%}
+{% set counter = 0 %}
+{% for item in iterator %}
+    {% set item = item[counter] %}
+    {% set counter = counter + 1 %}
+
+    {% for column in adminlist.exportColumns -%}
+        {%- set columnName = column.name -%}
+        {%- set template = column.template -%}
+        {% if template is not null and template != 1 and template != "" %}
+            {{- quote|raw -}}{% include template with {'row': item, 'columnName': columnName, 'object': adminlist.getValue(item, columnName)} %}{{- quote|raw -}}
+        {% else %}
+            {{- quote|raw -}}{{- adminlist.getStringValue(item, columnName) -}}{{- quote|raw -}}
+        {% endif %}
+        {%- if not loop.last -%},{%- endif -%}
+    {%- endfor -%}
 {% endfor %}


### PR DESCRIPTION
Fix for the issue where only the first row below the header row has actual table row content

...so rows actually contain the information they should contain instead of only the very first result.

This fix is tested on Kunstmaan 3.2.2 so that is why it is commited on branch 3.2.

FYI: the Excel export has the same issue.