### PR TITLE
[FormBundle - Insights] PHP code should follow PSR-1 basic coding standard

### DIFF
--- a/src/Kunstmaan/FormBundle/Tests/Entity/FormSubmissionTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Entity/FormSubmissionTest.php
@@ -107,7 +107,7 @@ class FormSubmissionTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\FormBundle\Entity\FormSubmission::__toString
      */
-    public function test__toString()
+    public function testToString()
     {
         $stringValue = $this->object->__toString();
         $this->assertNotNull($stringValue);

--- a/src/Kunstmaan/FormBundle/Tests/Entity/PageParts/SubmitButtonPagePartTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Entity/PageParts/SubmitButtonPagePartTest.php
@@ -47,7 +47,7 @@ class SubmitButtonPagePartTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\FormBundle\Entity\PageParts\SubmitButtonPagePart::__toString
      */
-    public function test__toString()
+    public function testToString()
     {
         $stringValue = $this->object->__toString();
         $this->assertNotNull($stringValue);


### PR DESCRIPTION
This is a small thing but it will remove a item from the list in the insights page.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /