### PR TITLE
[NodeBundle] StructureNode now have a folder icon in the pages tree

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Menu/MenuItem.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Menu/MenuItem.php
@@ -397,6 +397,30 @@ class MenuItem
     }
 
     /**
+     * Get menu item folder state
+     *
+     * @return bool
+     */
+    public function getFolder()
+    {
+        return $this->folder;
+    }
+
+    /**
+     * Set menu item folder state
+     *
+     * @param bool $folder
+     *
+     * @return MenuItem
+     */
+    public function setFolder($folder)
+    {
+        $this->folder = $folder;
+
+        return $this;
+    }
+
+    /**
      * Get appearInNavigation flag
      *
      * @return bool

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/rectreeview.html.twig
@@ -1,12 +1,17 @@
 {% set nodeId = menuitem.uniqueId %}
 
-<li id="{{ nodeId }}"{% if menuitem.offline %} data-jstree='{"type":"offline"}'{% endif %}
-        {% if menuitem.attributes.page is defined %}
-            {% if menuitem.attributes.page.icon is defined %}
-                data-jstree='{{ {"icon": menuitem.attributes.page.icon}|json_encode }}'
-            {% endif %}
-            data-page="{{ menuitem.attributes.page|json_encode }}"
+<li id="{{ nodeId }}"
+    {% if menuitem.folder %}
+        data-jstree='{"type":"folder"}'
+    {% elseif menuitem.offline %}
+        data-jstree='{"type":"offline"}'
+    {% endif %}
+    {% if menuitem.attributes.page is defined %}
+        {% if menuitem.attributes.page.icon is defined %}
+            data-jstree='{{ {"icon": menuitem.attributes.page.icon}|json_encode }}'
         {% endif %}
+        data-page="{{ menuitem.attributes.page|json_encode }}"
+    {% endif %}
     class="{% if menuitem.active or treeLevel == 1 %}jstree-open{% endif %}{% if menuitem.offline %} jstree-node--offline{% endif %}"{% if menuitem.role %} rel="{{menuitem.role}}"{% endif %}>
     {% if menuitem.route %}
         <a href="{{ path(menuitem.route, menuitem.routeparams) }}" class="{% if currentMenuItem is not null and currentMenuItem.uniqueId == menuitem.uniqueId %}active{% endif %}">

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -226,6 +226,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
                 ->setLabel($child['title'])
                 ->setParent($parent)
                 ->setOffline(!$child['online'] && !$this->pagesConfiguration->isStructureNode($refName))
+                ->setFolder($this->pagesConfiguration->isStructureNode($refName))
                 ->setRole('page')
                 ->setWeight($child['weight'])
                 ->addAttributes(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #528 


The StructureNode now has a folder icon in the pages tree:

![screen shot 2015-11-20 at 11 12 26](https://cloud.githubusercontent.com/assets/5577291/11297287/a74f18ee-8f77-11e5-84a6-2efc7791ad5a.png)
