### PR TITLE
[AdminBundle] Show only icons of table actions

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/blocks/_tables.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/blocks/_tables.scss
@@ -61,7 +61,7 @@
 
 
 .table__actions__item {
-    display: block;
+    display: inline-block;
     margin: 0 .8rem 0 0;
 
     white-space: nowrap;
@@ -71,7 +71,8 @@
         text-decoration: none;
     }
 
-    & + .table__actions__item {
-        margin-bottom: .8rem;
+    &.table__actions__item--block {
+        display: block;
+        margin: 0 0 .4rem;
     }
 }

--- a/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
@@ -82,17 +82,15 @@
                 <!-- Actions -->
                 <td class="table__actions">
                     {% if adminlist.canEdit(item) %}
-                        <a href="{{ path(adminlist.getEditUrlFor(item)["path"], adminlist.getEditUrlFor(item)[("params")] ) }}" class="link--text table__actions__item">
+                        <a href="{{ path(adminlist.getEditUrlFor(item)["path"], adminlist.getEditUrlFor(item)[("params")] ) }}" class="link--text table__actions__item" title="Edit">
                             <i class="fa fa-pencil-square-o"></i>
-                            Edit
                         </a>
                     {% endif %}
 
                     {% if adminlist.canDelete(item) %}
                         {% include 'KunstmaanAdminListBundle:AdminListTwigExtension:sure-modal.html.twig' %}
-                        <a href="#" data-toggle="modal" data-target="#sure-modal-{{ item.id }}" class="link--text link--danger table__actions__item">
+                        <a href="#" data-toggle="modal" data-target="#sure-modal-{{ item.id }}" class="link--text link--danger table__actions__item" title="Delete">
                             <i class="fa fa-trash-o"></i>
-                            Delete
                         </a>
                     {% endif %}
 
@@ -103,11 +101,10 @@
                             {% else %}
                                 {% set url = itemAction.getUrlFor(item) %}
                                 {% if url %}
-                                    <a href="{{ path(url["path"], url[("params")]) }}" class="link--text table__actions__item">
+                                    <a href="{{ path(url["path"], url[("params")]) }}" class="link--text table__actions__item" title="{{ itemAction.getLabelFor(item) }}">
                                         {% if itemAction.getIconFor(item) is not null %}
                                             <i class="fa fa-{{ itemAction.getIconFor(item) }}"></i>
                                         {% endif %}
-                                        {{ itemAction.getLabelFor(item) }}
                                     </a>
                                 {% endif %}
                             {% endif %}

--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
@@ -186,12 +186,12 @@
                 <td>{{ nodeVersion.updated | date('Y-m-d H:i:s') }}</td>
                 <td>{{ nodeVersion.owner }}</td>
                 <td class="table__actions">
-                <a href="{{ path('_slug_preview', { 'url': nodeTranslation.url, 'version': nodeVersion.id }) }}" target="_blank" class="link--text table__actions__item">
+                <a href="{{ path('_slug_preview', { 'url': nodeTranslation.url, 'version': nodeVersion.id }) }}" target="_blank" class="link--text table__actions__item table__actions__item--block">
                     <i class="fa fa-eye"></i>
                     Preview
                 </a>
                 {% if (draftNodeVersion is null or nodeVersion.id != draftNodeVersion.id) and (publicVersion is null or nodeVersion.id != publicVersion.id) %}
-                    <a href="{{ path('KunstmaanNodeBundle_nodes_revert', { 'id': node.id, 'version': nodeVersion.id }) }}" class="link--text table__actions__item">
+                    <a href="{{ path('KunstmaanNodeBundle_nodes_revert', { 'id': node.id, 'version': nodeVersion.id }) }}" class="link--text table__actions__item table__actions__item--block">
                     <i class="fa fa-refresh"></i>
                     Revert
                     </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #533 

Show only the icons of the actions. On hover, the label will be displayed. 
This way, there will be less whitespace in the tables.

Before:
![screen shot 2015-11-20 at 13 49 17](https://cloud.githubusercontent.com/assets/5577291/11300238/987559d0-8f8d-11e5-8f6f-9d2a1e2dfd2c.png)


Now:
![screen shot 2015-11-20 at 13 49 33](https://cloud.githubusercontent.com/assets/5577291/11300237/9703cd8e-8f8d-11e5-8255-2f5d810ec26d.png)
