### PR TITLE
[MultiDomainBundle] Use url locale to link extra parameters 

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
@@ -109,7 +109,7 @@ class KunstmaanMultiDomainExtension extends Extension
     {
         $localesExtra = array();
         foreach ($localeSettings as $key => $localeMapping) {
-            $localesExtra[$localeMapping['locale']] = array_key_exists('extra', $localeMapping) ? $localeMapping['extra'] : array();
+            $localesExtra[$localeMapping['uri_locale']] = array_key_exists('extra', $localeMapping) ? $localeMapping['extra'] : array();
         }
 
         return $localesExtra;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Because multiple url locales can have the same backend locale.