### PR TITLE
[MediaBundle] Fixed uppercase extension (again)

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -224,7 +224,7 @@ class FileHandler extends AbstractMediaHandler
 
         $parts    = pathinfo($filename);
         $filename = $slugifier->slugify($parts['filename']);
-        $filename .= '.'.$parts['extension'];
+        $filename .= '.'.strtolower($parts['extension']);
 
         return sprintf(
             '%s/%s',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Well this will be the 2nd time we have fixed this issue.
Image thumbnailing fails for uppercase extensions.
The pull request #780 of @tentwofour removed our fix #725.

You probably want to fix this also in 3.2 and 3.3.