### PR TITLE
[NodeBundle] Remove gedmo.listener.tree definition

### DIFF
--- a/UPGRADE-3.5.md
+++ b/UPGRADE-3.5.md
@@ -1,0 +1,17 @@
+# UPGRADE FROM 3.4 to 3.5
+
+## `gedmo.listener.tree` service was removed from KunstmaanNodeBundle (BC breaking)
+
+The service `gedmo.listener.tree` was removed from NodeBundle. To upgrade you need to place the service definition
+in your application config:
+
+```
+# app/config/config.yml
+services:
+    gedmo.listener.tree:
+        class: Gedmo\Tree\TreeListener
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+        calls:
+            - [ setAnnotationReader, [ @annotation_reader ] ]
+```

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -110,13 +110,6 @@ services:
             - [ setAclProvider, [ "@security.acl.provider" ] ]
             - [ setObjectIdentityRetrievalStrategy, [ "@security.acl.object_identity_retrieval_strategy" ] ]
 
-    gedmo.listener.tree:
-        class: Gedmo\Tree\TreeListener
-        tags:
-            - { name: doctrine.event_subscriber, connection: default }
-        calls:
-            - [ setAnnotationReader, [ @annotation_reader ] ]
-
     kunstmaan_node.doctrine_mapping.listener:
         class: Kunstmaan\NodeBundle\EventListener\MappingListener
         arguments: ["%fos_user.model.user.class%"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | none

Continuation of #779.

Remove `gedmo.listener.tree` definition from `NodeBundle`.