### PR TITLE
Update LiipImagineBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "lunetics/locale-bundle": "~2.4",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "stof/doctrine-extensions-bundle": "~1.1",
-        "liip/imagine-bundle": "v0.20.2",
+        "liip/imagine-bundle": "^1.0",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "symfony-cmf/routing-bundle": "~1.3",
         "ruflin/elastica": "~2.3",

--- a/src/Kunstmaan/MediaBundle/Resources/config/liip_imagine.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/liip_imagine.yml
@@ -1,7 +1,12 @@
 liip_imagine:
-    cache_prefix: uploads/cache
     driver: imagick
-    data_loader: kunstmaan_media_thumbloader
+    resolvers:
+        default:
+            web_path:
+                cache_prefix: uploads/cache
+    loaders:
+        kunstmaan_media_thumbloader:
+            filesystem: ~
     #cache: no_cache
     filter_sets:
         media_list_thumbnail:

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -12,7 +12,7 @@ parameters:
 
 services:
     liip_imagine.data.loader.stream.profile_photos:
-        class: "%liip_imagine.data.loader.stream.class%"
+        class: "%liip_imagine.binary.loader.stream.class%"
         arguments:
             - "@liip_imagine"
             - ''

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -18,7 +18,7 @@
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",
-        "liip/imagine-bundle": "v0.20.2",
+        "liip/imagine-bundle": "^1.0",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "sensio/framework-extra-bundle": ">=2.3.0,<4.0.0",
         "kunstmaan/admin-bundle": "~3.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

Update legacy LiipImagineBundle 0.20.2 to 1.0+.

We use this with version 1.3.1 in production for about 2 weeks and no problem occured so far.