### PR TITLE
[AdminBundle] Dynamic reinit modules when a pagepart is added

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_colorpicker.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_colorpicker.js
@@ -2,9 +2,9 @@ var kunstmaanbundles = kunstmaanbundles || {};
 
 kunstmaanbundles.colorpicker = (function(window, undefined) {
 
-    var init, initColorpicker;
+    var init, reInit, initColorpicker;
 
-    init = function() {
+    init = reInit = function() {
         $('.js-colorpicker').each(function() {
             if(!$(this).hasClass('js-colorpicker--enabled')) {
                 initColorpicker($(this));
@@ -21,7 +21,8 @@ kunstmaanbundles.colorpicker = (function(window, undefined) {
 
 
     return {
-        init: init
+        init: init,
+        reInit: reInit
     };
 
 }(window));

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_datepicker.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_datepicker.js
@@ -2,7 +2,7 @@ var kunstmaanbundles = kunstmaanbundles || {};
 
 kunstmaanbundles.datepicker = (function($, window, undefined) {
 
-    var init, reInitialise, _setDefaultDate, _initDatepicker;
+    var init, reInit, _setDefaultDate, _initDatepicker;
 
     var _today = window.moment(),
         _tomorrow = window.moment(_today).add(1, 'days');
@@ -20,7 +20,7 @@ kunstmaanbundles.datepicker = (function($, window, undefined) {
         });
     };
 
-    reInitialise = function(el) {
+    reInit = function(el) {
         if (el) {
             _initDatepicker($(el));
         } else {
@@ -95,7 +95,7 @@ kunstmaanbundles.datepicker = (function($, window, undefined) {
 
     return {
         init: init,
-        reInitialise: reInitialise
+        reInit: reInit
     };
 
 }(jQuery, window));

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
@@ -2,7 +2,7 @@ var kunstmaanbundles = kunstmaanbundles || {};
 
 kunstmaanbundles.nestedForm = (function(window, undefined) {
 
-    var init, setupForm,
+    var init, reInit, setupForm,
         addNewItem, delItem,
         addNewBtn, addDelBtn, showOrHideActions,
         updateSortkeys;
@@ -12,7 +12,7 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
     var delButtonHtml = '<button type="button" class="js-nested-form__del-btn btn--raise-on-hover nested-form__item__header__actions__action nested-form__item__header__actions__action--del"><i class="fa fa-trash-o"></i></button>';
 
 
-    init = function() {
+    init = reInit = function() {
         $('.js-nested-form').each(function() {
             var $form = $(this),
                 initialized = $form.data('initialized'),
@@ -223,7 +223,8 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
 
 
     return {
-        init: init
+        init: init,
+        reInit: reInit
     };
 
 }(window));

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
@@ -78,32 +78,37 @@ kunstmaanbundles.pagepartEditor = (function(window) {
                     elem = $select.closest('.js-sortable-item').after(data);
                 }
 
+                // Create a temporary node of the new PP
+                var $temp = $('<div>');
+                $temp.append(data);
+
+                // Check if some javascript needs to be reinitialised for this PP
+                $temp.find('*[data-reinit-js]').each(function() {
+                    // Get modules from data attribute
+                    var modules = $(this).data('reinit-js');
+
+                    if (modules) {
+                        for (var i = 0; i < modules.length; i++) {
+                            // Check if there really is a module with the given name and it if has a public reInit function
+                            if (typeof kunstmaanbundles[modules[i]] === 'object' && typeof kunstmaanbundles[modules[i]].reInit === 'function') {
+                                kunstmaanbundles[modules[i]].reInit();
+                            }
+                        }
+                    }
+                });
+
                 // Remove Loading
                 kunstmaanbundles.appLoading.removeLoading();
 
                 // Enable leave-page modal
                 kunstmaanbundles.checkIfEdited.edited();
 
-                // Enable new Rich Editors
-                kunstmaanbundles.richEditor.init();
-
-                // Init new tooltips
-                kunstmaanbundles.tooltip.init();
-
-                // Init new colorpickers
-                kunstmaanbundles.colorpicker.init();
-
                 // Reinit custom selects
                 kunstmaanbundles.advancedSelect.init();
 
-                // Reinit nested forms
-                kunstmaanbundles.nestedForm.init();
-
-                // Rest ajax-modals
+                // Reset ajax-modals
                 kunstmaanbundles.ajaxModal.resetAjaxModals();
 
-                // Reinitialise the datepickers
-                kunstmaanbundles.datepicker.reInitialise();
                 executeEvent('add')
             }
         });

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
@@ -26,12 +26,12 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
         }
     };
 
-    var init,
+    var init, reInit,
         enableRichEditor, destroyAllRichEditors, destroySpecificRichEditor,
         _collectEditorConfigs, _collectExternalPlugins, _customOkFunctionForTables;
 
     // First Init
-    init = function() {
+    init = reInit = function() {
         // These objects are declared global in _ckeditor_configs.html.twig
         _collectExternalPlugins(window.externalPlugins);
         _collectEditorConfigs(window.ckEditorConfigs);
@@ -283,6 +283,7 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
     // Returns
     return {
         init: init,
+        reInit: reInit,
         enableRichEditor: enableRichEditor,
         destroyAllRichEditors: destroyAllRichEditors,
         destroySpecificRichEditor: destroySpecificRichEditor

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_tooltip.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_tooltip.js
@@ -2,9 +2,9 @@ var kunstmaanbundles = kunstmaanbundles || {};
 
 kunstmaanbundles.tooltip = (function(window, undefined) {
 
-    var init, initTooltip;
+    var init, reInit, initTooltip;
 
-    init = function() {
+    init = reInit = function() {
         $('[data-toggle="tooltip"]').each(function() {
             if(!$(this).hasClass('js-tooltip--enabled')) {
                 initTooltip($(this));
@@ -21,7 +21,8 @@ kunstmaanbundles.tooltip = (function(window, undefined) {
 
 
     return {
-        init: init
+        init: init,
+        reInit: reInit
     };
 
 }(window));

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -1,7 +1,7 @@
 {# Widgets #}
 {% block color_widget %}
 {% spaceless %}
-    <div class="js-colorpicker input-group">
+    <div class="js-colorpicker input-group" data-reinit-js='["colorpicker"]'>
         <input {{ block('widget_attributes') }} class="form-control" value="{{ value }}"/>
         <span class="input-group-addon"><i></i></span>
     </div>
@@ -55,8 +55,8 @@
 
 {% block textarea_widget %}
 {% spaceless %}
-    {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' form-control' ~ (attr['maxlength'] is defined ? ' js-max-length-input' : ''))|trim }) %}
-    <textarea {{ block('widget_attributes') }} rows="5">{{ value }}</textarea>
+    {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' form-control ' ~ (attr['maxlength'] is defined ? ' js-max-length-input' : ''))|trim }) %}
+    <textarea {{ block('widget_attributes') }} rows="5"{% if 'js-rich-editor' in attr.class %} data-reinit-js='["richEditor"]'{% endif %}>{{ value }}</textarea>
 {% endspaceless %}
 {% endblock textarea_widget %}
 
@@ -150,7 +150,7 @@
                 {% set sortableField = attr['nested_sortable_field']|default('weight') %}
             {% endif %}
 
-            <div id="{{ form.vars.id }}__nested-form" class="js-nested-form nested-form{% if sortable %} js-sortable-container sortable-container nested-form--sortable{% endif %}" data-sortable="{% if sortable %}true{% else %}false{% endif %}" data-allow-new="{{ form.vars.allow_add|default('0') }}" data-allow-delete="{{ form.vars.allow_delete|default('0') }}" data-min-items="{{ attr['nested_form_min']|default('0') }}" data-max-items="{{ attr['nested_form_max']|default('false') }}" data-sortable="{{ attr['nested_sortable']|default('false') }}" {% if sortable %} data-sortkey="{{ form.vars.id }}___name___{{ sortableField }}"{% endif %}{% if form.vars.allow_add %} data-prototype="{{ form_widget(form.vars.prototype)|e }}"{% endif %} data-initialized="false" data-initializing="false">
+            <div id="{{ form.vars.id }}__nested-form" class="js-nested-form nested-form {% if sortable %} js-sortable-container sortable-container nested-form--sortable{% endif %}" data-sortable="{% if sortable %}true{% else %}false{% endif %}" data-allow-new="{{ form.vars.allow_add|default('0') }}" data-allow-delete="{{ form.vars.allow_delete|default('0') }}" data-min-items="{{ attr['nested_form_min']|default('0') }}" data-max-items="{{ attr['nested_form_max']|default('false') }}" data-sortable="{{ attr['nested_sortable']|default('false') }}" {% if sortable %} data-sortkey="{{ form.vars.id }}___name___{{ sortableField }}"{% endif %}{% if form.vars.allow_add %} data-prototype="{{ form_widget(form.vars.prototype)|e }}"{% endif %} data-initialized="false" data-initializing="false" data-reinit-js='["nestedForm"]'>
 
                 {# Items #}
                 {% for obj in form %}
@@ -186,7 +186,7 @@
         {% else %}
             {% if attr['info_text'] is defined %}
                 {# Info text #}
-                <div class="input-group">
+                <div class="input-group" data-reinit-js='["tooltip"]'>
                     {{ form_widget(form) }}
                     <span class="input-group-addon">
                         <strong class="input-group-addon--tooltip" data-toggle="tooltip" data-container="body" data-placement="top" title="{{ attr['info_text']|trans }}" id="{{ id }}_info_text">?</strong>
@@ -221,7 +221,7 @@
 {% block date_widget %}
     <div class="form--double-widget__col">
         {% use 'form_div_layout.html.twig' with date_widget as base_date_widget %}
-        <div class="js-datepicker" data-format="DD/MM/YYYY">
+        <div class="js-datepicker" data-format="DD/MM/YYYY" data-reinit-js='["datepicker"]'>
             {{ block('base_date_widget') }}
         </div>
     </div>
@@ -233,7 +233,7 @@
     <div class="form--double-widget__col">
         {% use 'form_div_layout.html.twig' with time_widget as base_time_widget %}
         {% set type = 'text' %}
-        <div class="js-datepicker" data-format="HH:mm">
+        <div class="js-datepicker" data-format="HH:mm" data-reinit-js='["datepicker"]'>
             {{ block('base_time_widget') }}
         </div>
     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

Each time a new pagepart was added to a page, several javascript modules got reinitialised, even when they had nothing to do with this pagepart.

This feature makes it possible to just reinitialise one or more specific modules. This way, it is also possible to reinitialise modules which aren't default in the bundles.

![screen shot 2015-11-30 at 11 04 40](https://cloud.githubusercontent.com/assets/5577291/11469204/05456c70-9755-11e5-9525-6db3d463e6af.png)
This is an example of how you can trigger a reinitialise. Give the element a 'js-reinit' class and in the data attribute 'data-reinit-js' you can set the modules that need to be reinitialised for this pagepart.
It is important that the module has a public reInit function, because this is the function that will get triggered when the pagepart is added to the page.