### PR TITLE
[AdminBundle] Make sure folder is always a property

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Menu/MenuItem.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Menu/MenuItem.php
@@ -53,6 +53,11 @@ class MenuItem
     private $offline = false;
 
     /**
+     * @var boolean
+     */
+    private $folder = false;
+
+    /**
      * @var MenuItem[]
      */
     private $children = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

This fixes a bug introduced in this commit: https://github.com/Kunstmaan/KunstmaanBundlesCMS/commit/7e60d159e029b7055f07088e975fc2493e705370. When the folder is not explicitly set on the MenuItem, the property will not be present. The is the case on the Settings page in the admin, which causes an error.