### PR TITLE
[NodeBundle] Hide page status indicator if it's a StructureNode page

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
@@ -39,7 +39,7 @@
             <small class="app__content__header__title__small app__content__header__title__small--offline">
                 Offline / Draft version (Go to <a href="{{ path('KunstmaanNodeBundle_nodes_edit', { 'id': node.id}) }}">public version</a>)
             </small>
-        {% else %}
+        {% elseif not is_structure_node(page) %}
             <small class="app__content__header__title__small {% if nodeTranslation.online %}app__content__header__title__small--online{% else %}app__content__header__title__small--offline{% endif %}">
                 {% if nodeTranslation.online %}
                     Online / Public version

--- a/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\PageInterface;
+use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Kunstmaan\NodeBundle\Helper\NodeMenu;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -88,6 +89,10 @@ class NodeTwigExtension extends Twig_Extension
             new \Twig_SimpleFunction(
                 'get_node_menu',
                 array($this, 'getNodeMenu')
+            ),
+            new \Twig_SimpleFunction(
+                'is_structure_node',
+                array($this, 'isStructureNode')
             ),
         );
     }
@@ -194,6 +199,11 @@ class NodeTwigExtension extends Twig_Extension
         $this->nodeMenu->setIncludeHiddenFromNav($includeHiddenFromNav);
 
         return $this->nodeMenu;
+    }
+
+    public function isStructureNode($page)
+    {
+        return $page instanceof StructureNode;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

Hide page status & indicator on structureNode pages