### PR TITLE
[SeoBundle] Readded meta keywords

### DIFF
--- a/src/Kunstmaan/SeoBundle/Entity/Seo.php
+++ b/src/Kunstmaan/SeoBundle/Entity/Seo.php
@@ -40,6 +40,13 @@ class Seo extends AbstractEntity
     /**
      * @var string
      *
+     * @ORM\Column(name="meta_keywords", type="string", nullable=true)
+     */
+    protected $metaKeywords;
+
+    /**
+     * @var string
+     *
      * @ORM\Column(name="meta_author", type="string", nullable=true)
      */
     protected $metaAuthor;
@@ -235,6 +242,22 @@ class Seo extends AbstractEntity
         $this->metaDescription = $meta;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMetaKeywords()
+    {
+        return $this->metaKeywords;
+    }
+
+    /**
+     * @param string $meta
+     */
+    public function setMetaKeywords($meta)
+    {
+        $this->metaKeywords = $meta;
     }
 
     /**

--- a/src/Kunstmaan/SeoBundle/Form/SeoType.php
+++ b/src/Kunstmaan/SeoBundle/Form/SeoType.php
@@ -34,7 +34,8 @@ class SeoType extends AbstractType
                 'info_text' => 'The title tag is often used on search engine results pages. It should be less than 55 characters.'
             )
         ))
-        ->add('metaDescription', null, array('label' => 'Meta description', 'max_length' => 155));
+        ->add('metaDescription', null, array('label' => 'Meta description', 'max_length' => 155))
+        ->add('metaKeywords', null, array('label' => 'Meta keywords'));
 
         $builder->add('metaRobots', 'choice', array(
             'choices'   => array(

--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -2,6 +2,9 @@
 {% if seo.getMetaDescription() %}
     <meta name="description" content="{{ seo.getMetaDescription() }}">
 {% endif %}
+{% if seo.getMetaKeywords() %}
+    <meta name="keywords" content="{{ seo.getMetaKeywords() }}">
+{% endif %}
 {% if seo.getMetaAuthor() %}
     <meta name="author" content="{{ seo.getMetaAuthor() }}">
 {% endif %}

--- a/src/Kunstmaan/SeoBundle/Tests/Entity/SeoTest.php
+++ b/src/Kunstmaan/SeoBundle/Tests/Entity/SeoTest.php
@@ -53,6 +53,16 @@ class SeoTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Kunstmaan\SeoBundle\Entity\Seo::getMetaKeywords
+     * @covers Kunstmaan\SeoBundle\Entity\Seo::setMetaKeywords
+     */
+    public function testGetSetMetaKeywords()
+    {
+        $this->object->setMetaKeywords('Meta Keywords');
+        $this->assertEquals('Meta Keywords', $this->object->getMetaKeywords());
+    }
+
+    /**
      * @covers Kunstmaan\SeoBundle\Entity\Seo::getMetaRobots
      * @covers Kunstmaan\SeoBundle\Entity\Seo::setMetaRobots
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #803

See the discussion in #803. 
We had to readd the keywords because some customers still use it. 
Up to you to merge the pull request back or not.
