### PR TITLE
[AdminBundle] Added datepicker reinit for nested forms

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
@@ -172,6 +172,9 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
         // Init new colorpickers
         kunstmaanbundles.colorpicker.init();
 
+        // Init new datepickers
+        kunstmaanbundles.datepicker.reInit();
+
         // Init Ajax Modals
         kunstmaanbundles.ajaxModal.resetAjaxModals();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #857, #823

The datepicker plugin was not being initialized on nested forms that were dynamically added to a page. This fix calls the datepicker's reInit method to fix this.