### PR TITLE
[All] Allow Symfony 2.8 and fix some deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 php:
   - 5.4
@@ -12,27 +12,32 @@ php:
   - 5.6
   - 7.0
 
-env:
-  - SYMFONY_VERSION="2.7.*"
-
 matrix:
-  fast_finish: false
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION="2.7.*"
   allow_failures:
     - php: 7.0
 
-before_script:
-    - composer selfupdate
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-    - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-    - composer require symfony/symfony:${SYMFONY_VERSION}
-    - wget https://scrutinizer-ci.com/ocular.phar
+before_install:
+  - phpenv config-rm xdebug.ini || true
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - composer selfupdate
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
+  - wget https://scrutinizer-ci.com/ocular.phar
 
-script:
-    - ./vendor/bin/phpunit --coverage-clover=coverage.clover || ./vendor/bin/phpunit --coverage-clover=coverage.clover
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+install: composer update --prefer-dist $COMPOSER_FLAGS
+
+before_script:
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+
+script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
+
+after_script: php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
+env:
+  global:
+    - SYMFONY_DEPRECATIONS_HELPER=16
+
 php:
   - 5.4
   - 5.5

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.5",
+        "symfony/symfony": "^2.5.3",
         "doctrine/orm": "~2.5.0",
         "doctrine/dbal": "~2.5.0",
         "doctrine/doctrine-bundle": "~1.4",
@@ -90,7 +90,6 @@
     "autoload": {
         "psr-4": {"Kunstmaan\\": "src/Kunstmaan/"}
     },
-    "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "^2.5.3",
+        "symfony/symfony": "^2.5.5",
         "doctrine/orm": "~2.5.0",
         "doctrine/dbal": "~2.5.0",
         "doctrine/doctrine-bundle": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.5,<2.8.0",
+        "symfony/symfony": "~2.5",
         "doctrine/orm": "~2.5.0",
         "doctrine/dbal": "~2.5.0",
         "doctrine/doctrine-bundle": "~1.4",
@@ -25,7 +25,7 @@
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
         "sensio/distribution-bundle": "~4.0",
-        "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
+        "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
 
         "friendsofsymfony/user-bundle": "2.0.*@dev",
@@ -57,6 +57,7 @@
         "behat/mink-selenium2-driver": "*",
         "behat/mink-goutte-driver": "*",
         "behat/mink-sahi-driver": "*",
+        "symfony/phpunit-bridge": "~2.7",
         "phpunit/phpunit": "~4.4",
         "fzaninotto/faker": "~1.5",
         "nelmio/alice": "~1.6"

--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -1,11 +1,11 @@
 parameters:
-    kunstmaan_admin.consoleexception.class: "Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener"
+    kunstmaan_admin.consoleexception.class: 'Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener'
 
 
 services:
     kunstmaan_admin.consolelogger.listener:
-        class: %kunstmaan_admin.consoleexception.class%
+        class: '%kunstmaan_admin.consoleexception.class%'
         arguments:
-            logger: "@logger"
+            logger: '@logger'
         tags:
             - { name: kernel.event_listener, event: console.exception }

--- a/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
@@ -1,15 +1,15 @@
 KunstmaanAdminBundle_default:
-    resource: "@KunstmaanAdminBundle/Controller/DefaultController.php"
+    resource: '@KunstmaanAdminBundle/Controller/DefaultController.php'
     type:     annotation
     prefix:   /admin  
 
 KunstmaanAdminBundle_modules:
-    resource: "@KunstmaanAdminBundle/Controller/ModulesController.php"
+    resource: '@KunstmaanAdminBundle/Controller/ModulesController.php'
     type:     annotation
     prefix:   /admin/modules
         
 KunstmaanAdminBundle_settings:
-    resource: "@KunstmaanAdminBundle/Controller/SettingsController.php"
+    resource: '@KunstmaanAdminBundle/Controller/SettingsController.php'
     type:     annotation
     prefix:   /admin/settings      
 
@@ -36,11 +36,11 @@ fos_user_security_logout:
     defaults: { _controller: FOSUserBundle:Security:logout }
 
 fos_user_profile:
-    resource: "@FOSUserBundle/Resources/config/routing/profile.xml"
+    resource: '@FOSUserBundle/Resources/config/routing/profile.xml'
     prefix: /admin/profile
 
 fos_user_resetting:
-    resource: "@FOSUserBundle/Resources/config/routing/resetting.xml"
+    resource: '@FOSUserBundle/Resources/config/routing/resetting.xml'
     prefix: /admin/resetting
 
 fos_user_change_password:

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -15,11 +15,11 @@ parameters:
 
 services:
     kunstmaan_admin.menubuilder:
-        class: "%kunstmaan_admin.menubuilder.class%"
-        arguments: ["@service_container"]
+        class: '%kunstmaan_admin.menubuilder.class%'
+        arguments: ['@service_container']
 
     kunstmaan_admin.admin_panel:
-        class: "%kunstmaan_admin.admin_panel.class%"
+        class: '%kunstmaan_admin.admin_panel.class%'
 
     kunstmaan_admin.menu.adaptor.modules:
         class: Kunstmaan\AdminBundle\Helper\Menu\ModulesMenuAdaptor
@@ -28,31 +28,31 @@ services:
 
     kunstmaan_admin.menu.adaptor.settings:
         class: Kunstmaan\AdminBundle\Helper\Menu\SettingsMenuAdaptor
-        arguments: ["@service_container"]
+        arguments: ['@service_container']
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
     kunstmaan_admin.login.listener:
-        class: "%kunstmaan_admin.login.listener.class%"
-        arguments: ["@kunstmaan_admin.logger", "@kunstmaan_admin.versionchecker"]
+        class: '%kunstmaan_admin.login.listener.class%'
+        arguments: ['@kunstmaan_admin.logger', '@kunstmaan_admin.versionchecker']
         tags:
             - { name: 'kernel.event_listener', event: 'security.interactive_login' }
 
     kunstmaan_admin.admin_locale.listener:
-        class: "%kunstmaan_admin.admin_locale.listener.class%"
-        arguments: ["@security.context", "@translator", "%kunstmaan_admin.default_admin_locale%", "%kunstmaan_admin.firewall.provider_key%"]
+        class: '%kunstmaan_admin.admin_locale.listener.class%'
+        arguments: ['@security.context', '@translator', '%kunstmaan_admin.default_admin_locale%', '%kunstmaan_admin.firewall.provider_key%']
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.request', method: 'onKernelRequest' }
 
     kunstmaan_admin.menu.twig.extension:
         class: Kunstmaan\AdminBundle\Twig\MenuTwigExtension
-        arguments: ["@kunstmaan_admin.menubuilder", "@kunstmaan_admin.admin_panel"]
+        arguments: ['@kunstmaan_admin.menubuilder', '@kunstmaan_admin.admin_panel']
         tags:
             -  { name: 'twig.extension' }
 
     kunstmaan_admin.localeswitcher.twig.extension:
         class: Kunstmaan\AdminBundle\Twig\LocaleSwitcherTwigExtension
-        arguments: ["@kunstmaan_admin.domain_configuration"]
+        arguments: ['@kunstmaan_admin.domain_configuration']
         tags:
             -  { name: 'twig.extension' }
 
@@ -63,7 +63,7 @@ services:
 
     kunstmaan_admin.formtools.twig.extension:
         class: Kunstmaan\AdminBundle\Twig\FormToolsExtension
-        arguments: ["@kunstmaan_admin.form.helper"]
+        arguments: ['@kunstmaan_admin.form.helper']
         tags:
             - { name: 'twig.extension' }
 
@@ -73,42 +73,42 @@ services:
             -  { name: 'twig.extension' }
 
     kunstmaan_admin.acl.helper:
-        class: "%kunstmaan_admin.acl.helper.class%"
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@security.role_hierarchy"]
+        class: '%kunstmaan_admin.acl.helper.class%'
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@security.role_hierarchy']
 
     kunstmaan_admin.acl.native.helper:
-        class: "%kunstmaan_admin.acl.native.helper.class%"
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@security.role_hierarchy"]
+        class: '%kunstmaan_admin.acl.native.helper.class%'
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@security.role_hierarchy']
 
     kunstmaan_admin.permissionadmin:
         class: Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@security.acl.provider", "@security.acl.object_identity_retrieval_strategy", "@event_dispatcher", "@kunstmaan_utilities.shell", "@kernel"]
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@security.acl.provider', '@security.acl.object_identity_retrieval_strategy', '@event_dispatcher', '@kunstmaan_utilities.shell', '@kernel']
 
     kunstmaan_admin.clone.helper:
         class: Kunstmaan\AdminBundle\Helper\CloneHelper
-        arguments: ["@doctrine.orm.entity_manager", "@event_dispatcher"]
+        arguments: ['@doctrine.orm.entity_manager', '@event_dispatcher']
 
     kunstmaan_admin.clone.listener:
-        class: "%kunstmaan_admin.clone.listener.class%"
+        class: '%kunstmaan_admin.clone.listener.class%'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.onDeepCloneAndSave, method: onDeepCloneAndSave }
 
     kunstmaan_admin.logger.processor.user:
         class: Kunstmaan\AdminBundle\Helper\UserProcessor
-        arguments: [ "@service_container" ]
+        arguments: [ '@service_container' ]
         tags:
             - { name: monolog.processor, method: processRecord }
             - { name: kunstmaan_admin.logger.processor, method: processRecord }
 
     kunstmaan_admin.logger.handler:
         class: Monolog\Handler\RotatingFileHandler
-        arguments: ["%kernel.logs_dir%/kunstmaan_%kernel.environment%.log", 10]
+        arguments: ['%kernel.logs_dir%/kunstmaan_%kernel.environment%.log', 10]
 
     kunstmaan_admin.logger:
         class: Symfony\Bridge\Monolog\Logger
         arguments: [kunstmaan]
         calls:
-            - [pushHandler, ["@kunstmaan_admin.logger.handler"]]
+            - [pushHandler, ['@kunstmaan_admin.logger.handler']]
 
     kunstmaan_admin.form.helper:
         class: Kunstmaan\AdminBundle\Helper\FormHelper
@@ -120,15 +120,15 @@ services:
 
     kunstmaan_admin.permission_creator:
         class: Kunstmaan\AdminBundle\Helper\Creators\ACLPermissionCreator
-        arguments: ["@security.acl.provider", "@security.acl.object_identity_retrieval_strategy"]
+        arguments: ['@security.acl.provider', '@security.acl.object_identity_retrieval_strategy']
 
     kunstmaan_admin.versionchecker:
         class: Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker
-        arguments: ["@service_container", "@kunstmaan_admin.cache"]
+        arguments: ['@service_container', '@kunstmaan_admin.cache']
 
     kunstmaan_admin.cache:
         class: Doctrine\Common\Cache\FilesystemCache
-        arguments: ["%kernel.cache_dir%/fcache"]
+        arguments: ['%kernel.cache_dir%/fcache']
 
     kunstmaan_admin.form.type.color:
         class: Kunstmaan\AdminBundle\Form\ColorType
@@ -137,7 +137,7 @@ services:
 
     kunstmaan_admin.doctrine_mapping.listener:
         class: Kunstmaan\AdminBundle\EventListener\MappingListener
-        arguments: ["%fos_user.model.user.class%"]
+        arguments: ['%fos_user.model.user.class%']
         tags:
             - { name: doctrine.event_listener, event: loadClassMetadata }
 
@@ -147,8 +147,8 @@ services:
             - { name: form.type, alias: range }
 
     kunstmaan_admin.session_security:
-        class: "%kunstmaan_admin.session_security.class%"
-        arguments: ["%kunstmaan_admin.session_security.ip_check%", "%kunstmaan_admin.session_security.user_agent_check%", "@logger"]
+        class: '%kunstmaan_admin.session_security.class%'
+        arguments: ['%kunstmaan_admin.session_security.ip_check%', '%kunstmaan_admin.session_security.user_agent_check%', '@logger']
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -1000 }
@@ -159,23 +159,23 @@ services:
             - { name: form.type, alias: wysiwyg }
 
     kunstmaan_admin.password_resetting.listener:
-        class: "%kunstmaan_admin.password_resetting.listener.class%"
+        class: '%kunstmaan_admin.password_resetting.listener.class%'
         arguments: ['@fos_user.user_manager']
         tags:
             - { name: kernel.event_listener, event: fos_user.change_password.edit.completed, method: onPasswordResettingSuccess }
 
     kunstmaan_admin.password_check.listener:
-        class: "%kunstmaan_admin.password_check.listener.class%"
+        class: '%kunstmaan_admin.password_check.listener.class%'
         arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session']
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 1 }
 
     kunstmaan_admin.admin_panel.adaptor:
         class: Kunstmaan\AdminBundle\Helper\AdminPanel\DefaultAdminPanelAdaptor
-        arguments: ["@security.context"]
+        arguments: ['@security.context']
         tags:
             -  { name: 'kunstmaan_admin.admin_panel.adaptor' }
 
     kunstmaan_admin.domain_configuration:
-        class: "%kunstmaan_admin.domain_configuration.class%"
-        arguments: ["@service_container"]
+        class: '%kunstmaan_admin.domain_configuration.class%'
+        arguments: ['@service_container']

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.5,<2.8.0",
+        "symfony/symfony": "~2.5",
         "doctrine/orm": "~2.2,>=2.2.3",
         "friendsofsymfony/user-bundle": "2.0.*@dev",
         "knplabs/knp-menu-bundle": "~2.0",
@@ -31,9 +31,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\AdminBundle": "" }
+        "psr-4": { "Kunstmaan\\AdminBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/AdminBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -6,13 +6,13 @@ services:
         class: Kunstmaan\AdminListBundle\AdminList\AdminListFactory
 
     kunstmaan_adminlist.service.export:
-        class:  %kunstmaan_adminlist.service.export.class%
+        class:  '%kunstmaan_adminlist.service.export.class%'
         calls:
-            -  [ setRenderer, [ "@templating" ] ]
+            -  [ setRenderer, [ '@templating' ] ]
 
     kunstmaan_adminlist.twig.extension:
         class: Kunstmaan\AdminListBundle\Twig\AdminListTwigExtension
         tags:
             -  { name: twig.extension }
         arguments:
-            -  @service_container
+            -  '@service_container'

--- a/src/Kunstmaan/AdminListBundle/composer.json
+++ b/src/Kunstmaan/AdminListBundle/composer.json
@@ -27,9 +27,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\AdminListBundle": "" }
+        "psr-4": { "Kunstmaan\\AdminListBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/AdminListBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -22,9 +22,8 @@
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\ArticleBundle": "" }
+        "psr-4": { "Kunstmaan\\ArticleBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/ArticleBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Kunstmaan/BehatBundle/composer.json
+++ b/src/Kunstmaan/BehatBundle/composer.json
@@ -26,9 +26,8 @@
         "phpunit/phpunit": "~3.7"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\BehatBundle": "" }
+        "psr-0": { "Kunstmaan\\BehatBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/BehatBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Kunstmaan/DashboardBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/routing.yml
@@ -1,14 +1,14 @@
 kunstmaan_dashboard:
-    resource: "@KunstmaanDashboardBundle/Controller/DashboardController.php"
+    resource: '@KunstmaanDashboardBundle/Controller/DashboardController.php'
     type:     annotation
     prefix:   /admin/dashboard
 
 kunstmaan_dashboard_googleanalytics:
-    resource: "@KunstmaanDashboardBundle/Controller/GoogleAnalyticsController.php"
+    resource: '@KunstmaanDashboardBundle/Controller/GoogleAnalyticsController.php'
     type:     annotation
     prefix:   /admin/dashboard/widget/googleanalytics
 
 kunstmaan_dashboard_googleanalytics_AJAX:
-    resource: "@KunstmaanDashboardBundle/Controller/GoogleAnalyticsAJAXController.php"
+    resource: '@KunstmaanDashboardBundle/Controller/GoogleAnalyticsAJAXController.php'
     type:     annotation
     prefix:   /admin/dashboard/ajax/

--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -11,38 +11,37 @@ services:
 
     kunstmaan_dashboard.widget.googleanalytics:
         class: Kunstmaan\DashboardBundle\Widget\DashboardWidget
-        arguments: [%kunstmaan_dashboard.widget.googleanalytics.command%, %kunstmaan_dashboard.widget.googleanalytics.controller%, '@service_container']
+        arguments: ['%kunstmaan_dashboard.widget.googleanalytics.command%', '%kunstmaan_dashboard.widget.googleanalytics.controller%', '@service_container']
         tags:
             - { name: kunstmaan_dashboard.widget, priority: 1 }
 
     # google client
     kunstmaan_dashboard.googleclient:
-        class: "%kunstmaan_dashboard.googleclient.class%"
+        class: '%kunstmaan_dashboard.googleclient.class%'
         calls:
-          - [ "setApplicationName", [ "%google.api.app_name%" ] ]
-          - [ "setClientId", [ "%google.api.client_id%" ] ]
-          - [ "setClientSecret", [ "%google.api.client_secret%" ] ]
-          - [ "setDeveloperKey", [ "%google.api.dev_key%" ] ]
-          - [ "setScopes", [ 'https://www.googleapis.com/auth/analytics.readonly' ] ]
-          - [ "setUseObjects", [ true ] ]
+          - [ 'setApplicationName', [ '%google.api.app_name%' ] ]
+          - [ 'setClientId', [ '%google.api.client_id%' ] ]
+          - [ 'setClientSecret', [ '%google.api.client_secret%' ] ]
+          - [ 'setDeveloperKey', [ '%google.api.dev_key%' ] ]
+          - [ 'setScopes', [ 'https://www.googleapis.com/auth/analytics.readonly' ] ]
+          - [ 'setUseObjects', [ true ] ]
 
     # client helper
     kunstmaan_dashboard.helper.google.client:
-        class: "Kunstmaan\DashboardBundle\Helper\Google\ClientHelper"
-        arguments: ["@kunstmaan_dashboard.googleclient", "@router", "KunstmaanDashboardBundle_setToken"]
+        class: 'Kunstmaan\DashboardBundle\Helper\Google\ClientHelper'
+        arguments: ['@kunstmaan_dashboard.googleclient', '@router', 'KunstmaanDashboardBundle_setToken']
 
     # service helper
     kunstmaan_dashboard.helper.google.analytics.service:
-        class: "Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper"
-        arguments: ["@kunstmaan_dashboard.helper.google.client"]
+        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper'
+        arguments: ['@kunstmaan_dashboard.helper.google.client']
 
     # config helper
     kunstmaan_dashboard.helper.google.analytics.config:
-        class: "Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper"
-        arguments: ["@kunstmaan_dashboard.helper.google.analytics.service", "@doctrine.orm.entity_manager"]
+        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper'
+        arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@doctrine.orm.entity_manager']
 
     # query helper
     kunstmaan_dashboard.helper.google.analytics.query:
-        class: "Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper"
-        arguments: ["@kunstmaan_dashboard.helper.google.analytics.service", "@kunstmaan_dashboard.helper.google.analytics.config"]
-
+        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper'
+        arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@kunstmaan_dashboard.helper.google.analytics.config']

--- a/src/Kunstmaan/DashboardBundle/composer.json
+++ b/src/Kunstmaan/DashboardBundle/composer.json
@@ -15,16 +15,13 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/orm": "^2.2.3",
         "alchemy/google-plus-api-client": "~0.6.5"
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": {
-            "Kunstmaan\\DashboardBundle": ""
-        }
+        "psr-4": { "Kunstmaan\\DashboardBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/DashboardBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/FixturesBundle/composer.json
+++ b/src/Kunstmaan/FixturesBundle/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/symfony": "~2.3",
-    "doctrine/orm": "~2.2,>=2.2.3",
+    "doctrine/orm": "^2.2.3",
     "doctrine/doctrine-bundle": "~1.2",
     "doctrine/doctrine-fixtures-bundle": "~2.2.0"
   },

--- a/src/Kunstmaan/FormBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanFormBundle_formsubmissions:
-    resource: "@KunstmaanFormBundle/Controller/FormSubmissionsController.php"
+    resource: '@KunstmaanFormBundle/Controller/FormSubmissionsController.php'
     type:     annotation
     prefix:   /admin/formsubmissions

--- a/src/Kunstmaan/FormBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/services.yml
@@ -9,15 +9,15 @@ services:
             -  { name: kunstmaan_admin.menu.adaptor }
 
     kunstmaan_form.form_mailer:
-        class: %kunstmaan_form.form_mailer.class%
-        arguments: [@mailer, @templating, @service_container]
+        class: '%kunstmaan_form.form_mailer.class%'
+        arguments: ['@mailer', '@templating', '@service_container']
 
     kunstmaan_form.form_handler:
         class: %kunstmaan_form.form_handler.class%
-        arguments: [@service_container]
+        arguments: ['@service_container']
 
     kunstmaan_form.configure_sub_actions_menu_listener:
         class: Kunstmaan\FormBundle\EventListener\ConfigureActionsMenuListener
-        arguments: ["@doctrine.orm.entity_manager", "@router"]
+        arguments: ['@doctrine.orm.entity_manager', '@router']
         tags:
             - { name: 'kernel.event_listener', event: 'kunstmaan_node.configureSubActionMenu', method: 'onSubActionMenuConfigure' }

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -27,9 +27,8 @@
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\FormBundle": "" }
+        "psr-4": { "Kunstmaan\\FormBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/FormBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "sensio/generator-bundle": ">=2.5.0",
+        "doctrine/orm": "^2.2.3",
+        "sensio/generator-bundle": "~2.5|~3.0",
         "fzaninotto/faker": "~1.4.0",
         "kunstmaan/utilities-bundle": "~3.2"
     },
@@ -31,9 +31,8 @@
         "kunstmaan/pagepart-bundle": "~3.2"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\GeneratorBundle": "" }
+        "psr-4": { "Kunstmaan\\GeneratorBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/GeneratorBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/LanguageChooserBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/LanguageChooserBundle/Resources/config/services.yml
@@ -1,19 +1,19 @@
 services:
     kunstmaan_languagechooser.languagechooserrouter:
         class: Kunstmaan\LanguageChooserBundle\Router\LanguageChooserRouter
-        arguments: ["@service_container"]
+        arguments: ['@service_container']
         tags:
             - { name: router, priority: 100 }
 
     twig.extension.your_extension_name:
         class: Kunstmaan\LanguageChooserBundle\Twig\Extension\LanguageChooserExtension
         calls:
-             - [setLanguageChooserLanguages, [%kunstmaan_language_chooser.languagechooserlocales%]]
+             - [setLanguageChooserLanguages, ['%kunstmaan_language_chooser.languagechooserlocales%']]
         tags:
             - { name: twig.extension }
 
     kunstmaan_languagechooser.url_locale_guesser:
         class: Kunstmaan\LanguageChooserBundle\LocaleGuesser\UrlLocaleGuesser
-        arguments: ["@lunetics_locale.validator.meta"]
+        arguments: ['@lunetics_locale.validator.meta']
         tags:
             - { name: lunetics_locale.guesser, alias: kuma_url_guesser }

--- a/src/Kunstmaan/LanguageChooserBundle/composer.json
+++ b/src/Kunstmaan/LanguageChooserBundle/composer.json
@@ -16,12 +16,11 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "lunetics/locale-bundle": "*"
+        "lunetics/locale-bundle": "~2.0"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\LanguageChooserBundle": "" }
+        "psr-4": { "Kunstmaan\\LanguageChooserBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/LanguageChooserBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/LeadGenerationBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/LeadGenerationBundle/Resources/config/routing.yml
@@ -1,13 +1,13 @@
 kunstmaanleadgenerationbundle_popups_admin_list:
-    resource: @KunstmaanLeadGenerationBundle/Controller/PopupsAdminListController.php
+    resource: '@KunstmaanLeadGenerationBundle/Controller/PopupsAdminListController.php'
     type:     annotation
     prefix:   /admin/popups/
     requirements:
-         _locale: %requiredlocales%
+         _locale: '%requiredlocales%'
 
 kunstmaanleadgenerationbundle_rules_admin_list:
-    resource: @KunstmaanLeadGenerationBundle/Controller/RulesAdminListController.php
+    resource: '@KunstmaanLeadGenerationBundle/Controller/RulesAdminListController.php'
     type:     annotation
     prefix:   /admin/popups/
     requirements:
-         _locale: %requiredlocales%
+         _locale: '%requiredlocales%'

--- a/src/Kunstmaan/LeadGenerationBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/LeadGenerationBundle/Resources/config/services.yml
@@ -5,32 +5,32 @@ parameters:
 
 services:
     kunstmaan_lead_generation.popup.manager:
-        class: %kunstmaan_lead_generation.popup.manager.class%
-        arguments: ["@doctrine.orm.entity_manager"]
+        class: '%kunstmaan_lead_generation.popup.manager.class%'
+        arguments: ['@doctrine.orm.entity_manager']
 
     kunstmaan_lead_generation.popup.twig.extension:
-        class: %kunstmaan_lead_generation.popup.twig.extension.class%
+        class: '%kunstmaan_lead_generation.popup.twig.extension.class%'
         arguments:
-            - "@kunstmaan_lead_generation.popup.manager"
-            - "@service_container"
-            - "%kunstmaan_lead_generation.popup_types%"
-            - "%kunstmaan_lead_generation.debug%"
+            - '@kunstmaan_lead_generation.popup.manager'
+            - '@service_container'
+            - '%kunstmaan_lead_generation.popup_types%'
+            - '%kunstmaan_lead_generation.debug%'
         tags:
             - { name: twig.extension }
 
     kunstmaan_lead_generation.menu.adaptor:
-        class: %kunstmaan_lead_generation.menu.adaptor.class%
+        class: '%kunstmaan_lead_generation.menu.adaptor.class%'
         tags:
             - { name: kunstmaan_admin.menu.adaptor }
 
     kunstmaan_lead_generation.rule.form.localewhitelistrule:
         class: Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleWhiteListAdminType
-        arguments: ["@kunstmaan_admin.domain_configuration"]
+        arguments: ['@kunstmaan_admin.domain_configuration']
 
     kunstmaan_lead_generation.rule.form.localeblacklistrule:
         class: Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleBlackListAdminType
-        arguments: ["@kunstmaan_admin.domain_configuration"]
+        arguments: ['@kunstmaan_admin.domain_configuration']
 
     kunstmaan_lead_generation.rule.service.localeruleservice:
         class: Kunstmaan\LeadGenerationBundle\Service\Rule\LocaleRuleService
-        arguments: ["@request_stack"]
+        arguments: ['@request_stack']

--- a/src/Kunstmaan/LiveReloadBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/LiveReloadBundle/Resources/config/services.yml
@@ -5,17 +5,17 @@ parameters:
 
 services:
     kunstmaan_live_reload.http_client:
-        class: "%kunstmaan_live_reload.http_client.class%"
-        arguments: ["http://%kunstmaan_live_reload.host%:%kunstmaan_live_reload.port%/"]
+        class: '%kunstmaan_live_reload.http_client.class%'
+        arguments: ['http://%kunstmaan_live_reload.host%:%kunstmaan_live_reload.port%/']
         public: false
 
     kunstmaan_live_reload.script_injector:
-        class: "%kunstmaan_live_reload.script_injector.class%"
-        arguments: ["@kunstmaan_live_reload.http_client", "%kunstmaan_live_reload.check_server_presence%"]
+        class: '%kunstmaan_live_reload.script_injector.class%'
+        arguments: ['@kunstmaan_live_reload.http_client', '%kunstmaan_live_reload.check_server_presence%']
         tags:
             - { name: kernel.event_subscriber }
 
     kunstmaan_live_reload.disable_cache:
-        class: "%kunstmaan_live_reload.disable_cache.class%"
+        class: '%kunstmaan_live_reload.disable_cache.class%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Kunstmaan/LiveReloadBundle/composer.json
+++ b/src/Kunstmaan/LiveReloadBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-	"symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.3",
         "guzzle/guzzle": "3.8.*"
     },
     "minimum-stability": "dev",

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -8,37 +8,37 @@ parameters:
 
 services:
     kunstmaan_media.media_handlers.remote_slide:
-        class: "%kunstmaan_media.media_handler.remote_slide.class%"
+        class: '%kunstmaan_media.media_handler.remote_slide.class%'
         arguments: [1]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }
 
     kunstmaan_media.media_handlers.remote_video:
-        class: "%kunstmaan_media.media_handler.remote_video.class%"
-        arguments: [1, "%kunstmaan_media.remote_video%"]
+        class: '%kunstmaan_media.media_handler.remote_video.class%'
+        arguments: [1, '%kunstmaan_media.remote_video%']
         tags:
             -  { name: 'kunstmaan_media.media_handler' }
 
     kunstmaan_media.media_handlers.remote_audio:
-        class: "%kunstmaan_media.media_handler.remote_audio.class%"
-        arguments: [1, "%kunstmaan_media.soundcloud_api_key%"]
+        class: '%kunstmaan_media.media_handler.remote_audio.class%'
+        arguments: [1, '%kunstmaan_media.soundcloud_api_key%']
         tags:
             -  { name: 'kunstmaan_media.media_handler' }
 
     kunstmaan_media.media_handlers.image:
-        class: "%kunstmaan_media.media_handler.image.class%"
-        arguments: [1, "@kunstmaan_media.mimetype_guesser.factory", "%aviary_api_key%"]
+        class: '%kunstmaan_media.media_handler.image.class%'
+        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '%aviary_api_key%']
         calls:
-            - [ setMediaPath, [ "%kernel.root_dir%" ] ]
-            - [ setBlacklistedExtensions, [ "%kunstmaan_media.blacklisted_extensions%" ] ]
+            - [ setMediaPath, [ '%kernel.root_dir%' ] ]
+            - [ setBlacklistedExtensions, [ '%kunstmaan_media.blacklisted_extensions%' ] ]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }
 
     kunstmaan_media.media_handlers.file:
-        class: "%kunstmaan_media.media_handler.file.class%"
-        arguments: [0, "@kunstmaan_media.mimetype_guesser.factory"]
+        class: '%kunstmaan_media.media_handler.file.class%'
+        arguments: [0, '@kunstmaan_media.mimetype_guesser.factory']
         calls:
-            - [ setMediaPath, [ "%kernel.root_dir%" ] ]
-            - [ setBlacklistedExtensions, [ "%kunstmaan_media.blacklisted_extensions%" ] ]
+            - [ setMediaPath, [ '%kernel.root_dir%' ] ]
+            - [ setBlacklistedExtensions, [ '%kunstmaan_media.blacklisted_extensions%' ] ]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }

--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -4,22 +4,22 @@ parameters:
 
 services:
     kunstmaan_media.imagick:
-        class: "Imagick"
+        class: 'Imagick'
 
     kunstmaan_media.pdf_transformer:
-        class: "%kunstmaan_media.pdf_transformer.class%"
-        arguments: ["@kunstmaan_media.imagick"]
+        class: '%kunstmaan_media.pdf_transformer.class%'
+        arguments: ['@kunstmaan_media.imagick']
 
     kunstmaan_media.command.createpdfpreview:
         class: Kunstmaan\MediaBundle\Command\CreatePdfPreviewCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]
 
     kunstmaan_media.media_handlers.pdf:
-        class: "%kunstmaan_media.media_handler.pdf.class%"
-        arguments: [1, "@kunstmaan_media.mimetype_guesser.factory"]
+        class: '%kunstmaan_media.media_handler.pdf.class%'
+        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory']
         calls:
-            - [ setMediaPath, [ "%kernel.root_dir%" ] ]
-            - [ setPdfTransformer, [ "@kunstmaan_media.pdf_transformer" ]]
+            - [ setMediaPath, [ '%kernel.root_dir%' ] ]
+            - [ setPdfTransformer, [ '@kunstmaan_media.pdf_transformer' ]]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }

--- a/src/Kunstmaan/MediaBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/routing.yml
@@ -1,24 +1,24 @@
 KunstmaanMediaBundle_media:
-    resource: "@KunstmaanMediaBundle/Controller/MediaController.php"
+    resource: '@KunstmaanMediaBundle/Controller/MediaController.php'
     type:     annotation
     prefix:   /admin/media
         
 KunstmaanMediaBundle_aviary:
-    resource: "@KunstmaanMediaBundle/Controller/AviaryController.php"
+    resource: '@KunstmaanMediaBundle/Controller/AviaryController.php'
     type:     annotation
     prefix:   /
         
 KunstmaanMediaBundle_media_chooser:
-    resource: "@KunstmaanMediaBundle/Controller/ChooserController.php"
+    resource: '@KunstmaanMediaBundle/Controller/ChooserController.php'
     type:     annotation
     prefix:   /admin/media
         
 KunstmaanMediaBundle_media_folder:
-    resource: "@KunstmaanMediaBundle/Controller/FolderController.php"
+    resource: '@KunstmaanMediaBundle/Controller/FolderController.php'
     type:     annotation
     prefix:   /admin/media/folder
 
 KunstmaanMediaBundle_icon_font:
-    resource: "@KunstmaanMediaBundle/Controller/IconFontController.php"
+    resource: '@KunstmaanMediaBundle/Controller/IconFontController.php'
     type:     annotation
     prefix:   /admin/media/icon-font

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -12,21 +12,21 @@ parameters:
 
 services:
     liip_imagine.data.loader.stream.profile_photos:
-        class: "%liip_imagine.data.loader.stream.class%"
+        class: '%liip_imagine.data.loader.stream.class%'
         arguments:
-            - "@liip_imagine"
+            - '@liip_imagine'
             - ''
         tags:
             - { name: 'liip_imagine.data.loader', loader: 'kunstmaan_media_thumbloader' }
 
     kunstmaan_media.media_manager:
-        class: "%kunstmaan_media.media_manager.class%"
+        class: '%kunstmaan_media.media_manager.class%'
         calls:
-            - [ setDefaultHandler, [ "@kunstmaan_media.media_handlers.file" ] ]
+            - [ setDefaultHandler, [ '@kunstmaan_media.media_handlers.file' ] ]
 
     kunstmaan_media.listener.doctrine:
-        class: "%kunstmaan_media.listener.doctrine.class%"
-        arguments: ["@kunstmaan_media.media_manager"]
+        class: '%kunstmaan_media.listener.doctrine.class%'
+        arguments: ['@kunstmaan_media.media_manager']
         tags:
             - { name: 'doctrine.event_listener', event: 'prePersist' }
             - { name: 'doctrine.event_listener', event: 'preUpdate' }
@@ -35,59 +35,59 @@ services:
             - { name: 'doctrine.event_listener', event: 'preRemove' }
 
     form.type.media:
-        class: "%kunstmaan_media.form.type.media.class%"
+        class: '%kunstmaan_media.form.type.media.class%'
         arguments:
-            - "@kunstmaan_media.media_manager"
-            - "@doctrine.orm.entity_manager"
+            - '@kunstmaan_media.media_manager'
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: form.type, alias: media }
 
     form.type.iconfont:
-        class: "%kunstmaan_media.form.type.iconfont.class%"
-        arguments: ["@kunstmaan_media.icon_font_manager"]
+        class: '%kunstmaan_media.form.type.iconfont.class%'
+        arguments: ['@kunstmaan_media.icon_font_manager']
         tags:
             - { name: form.type, alias: iconfont }
 
     kunstmaan_media.icon_font_manager:
-        class: "%kunstmaan_media.icon_font_manager.class%"
+        class: '%kunstmaan_media.icon_font_manager.class%'
         calls:
-            - [ setDefaultLoader, [ "@kunstmaan_media.icon_font.default_loader" ] ]
+            - [ setDefaultLoader, [ '@kunstmaan_media.icon_font.default_loader' ] ]
 
     kunstmaan_media.icon_font.default_loader:
-        class: "%kunstmaan_media.icon_font.default_loader.class%"
-        arguments: ["@kernel"]
+        class: '%kunstmaan_media.icon_font.default_loader.class%'
+        arguments: ['@kernel']
         tags:
             -  { name: 'kunstmaan_media.icon_font.loader' }
 
     kunstmaan_media.media_creator_service:
-        class: "%kunstmaan_media.media_creator_service.class%"
-        arguments: ["@service_container"]
+        class: '%kunstmaan_media.media_creator_service.class%'
+        arguments: ['@service_container']
 
     kunstmaan_media.repository.folder:
         class:            Kunstmaan\MediaBundle\Repository\FolderRepository
-        factory_service:  "doctrine.orm.entity_manager"
+        factory_service:  'doctrine.orm.entity_manager'
         factory_method:   getRepository
-        arguments:        ["KunstmaanMediaBundle:Folder"]
+        arguments:        ['KunstmaanMediaBundle:Folder']
 
     kunstmaan_media.menu.adaptor:
-        class: "%kunstmaan_media.menu.adaptor.class%"
-        arguments: ["@kunstmaan_media.repository.folder"]
+        class: '%kunstmaan_media.menu.adaptor.class%'
+        arguments: ['@kunstmaan_media.repository.folder']
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
     kunstmaan_media.folder_manager:
-        class: "%kunstmaan_media.folder_manager.class%"
-        arguments: ["@kunstmaan_media.repository.folder"]
+        class: '%kunstmaan_media.folder_manager.class%'
+        arguments: ['@kunstmaan_media.repository.folder']
 
     kunstmaan_media.mimetype_guesser.factory:
-        class: "%kunstmaan_media.mimetype_guesser.factory.class%"
+        class: '%kunstmaan_media.mimetype_guesser.factory.class%'
 
     kunstmaan_media.command.migratename:
         class: Kunstmaan\MediaBundle\Command\MigrateNameCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]
 
     kunstmaan_media.command.rebuildfoldertree:
         class: Kunstmaan\MediaBundle\Command\RebuildFolderTreeCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]

--- a/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MediaBundle\Tests\Validator\Constraints;
 use Kunstmaan\MediaBundle\Entity\Media as MediaObject;
 use Kunstmaan\MediaBundle\Validator\Constraints\Media;
 use Kunstmaan\MediaBundle\Validator\Constraints\MediaValidator;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\ExecutionContextInterface;
 use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
 
@@ -114,5 +115,10 @@ class MediaValidatorTest extends AbstractConstraintValidatorTest
             ['minHeight', 200, 'The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.', ['{{ height }}' => 100, '{{ min_height }}' => 200], Media::TOO_LOW_ERROR],
             ['maxHeight', 50, 'The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.', ['{{ height }}' => 100, '{{ max_height }}' => 50], Media::TOO_HIGH_ERROR],
         ];
+    }
+
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
     }
 }

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
@@ -34,7 +34,7 @@ class MediaValidator extends ConstraintValidator
 
             if (false === $this->validateMimeType($value, $mimeTypes)) {
 
-                $this->buildViolation($constraint->mimeTypesMessage)
+                $this->context->buildViolation($constraint->mimeTypesMessage)
                     ->setParameter('{{ type }}', $this->formatValue($mimeType))
                     ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
                     ->setCode(Media::INVALID_MIME_TYPE_ERROR)
@@ -88,7 +88,7 @@ class MediaValidator extends ConstraintValidator
             }
 
             if ($height < $constraint->minHeight) {
-                $this->buildViolation($constraint->minHeightMessage)
+                $this->context->buildViolation($constraint->minHeightMessage)
                     ->setParameter('{{ height }}', $height)
                     ->setParameter('{{ min_height }}', $constraint->minHeight)
                     ->setCode(Media::TOO_LOW_ERROR)
@@ -109,7 +109,7 @@ class MediaValidator extends ConstraintValidator
             }
 
             if ($height > $constraint->maxHeight) {
-                $this->buildViolation($constraint->maxHeightMessage)
+                $this->context->buildViolation($constraint->maxHeightMessage)
                     ->setParameter('{{ height }}', $height)
                     ->setParameter('{{ max_height }}', $constraint->maxHeight)
                     ->setCode(Media::TOO_HIGH_ERROR)
@@ -130,7 +130,7 @@ class MediaValidator extends ConstraintValidator
             }
 
             if ($width < $constraint->minWidth) {
-                $this->buildViolation($constraint->minWidthMessage)
+                $this->context->buildViolation($constraint->minWidthMessage)
                     ->setParameter('{{ width }}', $width)
                     ->setParameter('{{ min_width }}', $constraint->minWidth)
                     ->setCode(Media::TOO_NARROW_ERROR)
@@ -151,7 +151,7 @@ class MediaValidator extends ConstraintValidator
             }
 
             if ($width > $constraint->maxWidth) {
-                $this->buildViolation($constraint->maxWidthMessage)
+                $this->context->buildViolation($constraint->maxWidthMessage)
                     ->setParameter('{{ width }}', $width)
                     ->setParameter('{{ max_width }}', $constraint->maxWidth)
                     ->setCode(Media::TOO_WIDE_ERROR)

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "^2.5.3",
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "^2.5.3",
+        "symfony/symfony": "^2.5.5",
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",

--- a/src/Kunstmaan/MediaPagePartBundle/composer.json
+++ b/src/Kunstmaan/MediaPagePartBundle/composer.json
@@ -21,9 +21,8 @@
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\MediaPagePartBundle": "" }
+        "psr-4": { "Kunstmaan\\MediaPagePartBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/MediaPagePartBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/MenuBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/routing.yml
@@ -1,9 +1,9 @@
 kunstmaanmenubundle_menu_admin_list:
-    resource: @KunstmaanMenuBundle/Controller/MenuAdminListController.php
+    resource: '@KunstmaanMenuBundle/Controller/MenuAdminListController.php'
     type:     annotation
     prefix:   /admin/menu/
 
 kunstmaanmenubundle_menuitem_admin_list:
-    resource: @KunstmaanMenuBundle/Controller/MenuItemAdminListController.php
+    resource: '@KunstmaanMenuBundle/Controller/MenuItemAdminListController.php'
     type:     annotation
     prefix:   /admin/menu/

--- a/src/Kunstmaan/MenuBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/services.yml
@@ -7,34 +7,34 @@ parameters:
 
 services:
     kunstmaan_menu.menu.adaptor:
-        class: %kunstmaan_menu.menu.adaptor.class%
-        arguments: ["%kunstmaan_menu.menus%"]
+        class: '%kunstmaan_menu.menu.adaptor.class%'
+        arguments: ['%kunstmaan_menu.menus%']
         tags:
             - { name: kunstmaan_admin.menu.adaptor }
 
 
     kunstmaan_menu.menu.service:
-        class: %kunstmaan_menu.menu.service.class%
+        class: '%kunstmaan_menu.menu.service.class%'
         arguments:
-            - "%kunstmaan_menu.menus%"
-            - "@kunstmaan_admin.domain_configuration"
-            - "@doctrine.orm.entity_manager"
+            - '%kunstmaan_menu.menus%'
+            - '@kunstmaan_admin.domain_configuration'
+            - '@doctrine.orm.entity_manager'
 
     kunstmaan_menu.menu.render_service:
-        class: %kunstmaan_menu.menu.render_service.class%
+        class: '%kunstmaan_menu.menu.render_service.class%'
         arguments:
-            - "@router"
+            - '@router'
 
     kunstmaan_menu.menu.repository:
-        class:            %kunstmaan_menu.menu.repository.class%
-        factory_service:  "doctrine.orm.entity_manager"
+        class:            '%kunstmaan_menu.menu.repository.class%'
+        factory_service:  'doctrine.orm.entity_manager'
         factory_method:   getRepository
-        arguments:        ["%kunstmaan_menu.entity.menuitem.class%"]
+        arguments:        ['%kunstmaan_menu.entity.menuitem.class%']
 
     kunstmaan_menu.menu.twig.extension:
-        class: %kunstmaan_menu.menu.twig.extension.class%
+        class: '%kunstmaan_menu.menu.twig.extension.class%'
         arguments:
-            - "@kunstmaan_menu.menu.repository"
-            - "@kunstmaan_menu.menu.render_service"
+            - '@kunstmaan_menu.menu.repository'
+            - '@kunstmaan_menu.menu.render_service'
         tags:
             - { name: twig.extension }

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 kunstmaanmultidomainbundle_site_switch:
-    resource: @KunstmaanMultiDomainBundle/Controller/SiteSwitchController.php
+    resource: '@KunstmaanMultiDomainBundle/Controller/SiteSwitchController.php'
     type:     annotation
     prefix:   /admin/multi-domain

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -10,13 +10,13 @@ services:
 
     kunstmaan_multi_domain.twig.extension:
         class: Kunstmaan\MultiDomainBundle\Twig\MultiDomainTwigExtension
-        arguments: ["@kunstmaan_admin.domain_configuration"]
+        arguments: ['@kunstmaan_admin.domain_configuration']
         tags:
               -  { name: 'twig.extension' }
 
     kunstmaan_multi_domain.host_override_listener:
         class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
-        arguments: ["@session", "@kunstmaan_admin.domain_configuration"]
+        arguments: ['@session', '@kunstmaan_admin.domain_configuration']
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -6,6 +6,7 @@ use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Router\SlugRouter;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Class DomainBasedLocaleRouter
@@ -17,13 +18,13 @@ class DomainBasedLocaleRouter extends SlugRouter
     /**
      * Generate an url for a supplied route
      *
-     * @param string $name       The path
-     * @param array  $parameters The route parameters
-     * @param bool   $absolute   Absolute url or not
+     * @param string   $name          The path
+     * @param array    $parameters    The route parameters
+     * @param int|bool $referenceType The type of reference to be generated (one of the UrlGeneratorInterface constants)
      *
      * @return null|string
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         if ('_slug' === $name) {
             if ($this->isMultiLanguage() && $this->isMultiDomainHost()) {
@@ -36,7 +37,7 @@ class DomainBasedLocaleRouter extends SlugRouter
             }
         }
 
-        return parent::generate($name, $parameters, $absolute);
+        return parent::generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Router/DomainBasedLocaleRouterTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Router/DomainBasedLocaleRouterTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MultiDomainBundle\Tests\Router;
 use Kunstmaan\MultiDomainBundle\Router\DomainBasedLocaleRouter;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class DomainBasedLocaleRouterTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,10 +36,10 @@ class DomainBasedLocaleRouterTest extends \PHPUnit_Framework_TestCase
         $request   = $this->getRequest();
         $container = $this->getContainer($request);
         $object    = new DomainBasedLocaleRouter($container);
-        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en_GB'), true);
+        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en_GB'), UrlGeneratorInterface::ABSOLUTE_URL);
         $this->assertEquals('http://multilangdomain.tld/en/some-uri', $url);
 
-        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en_GB'), false);
+        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en_GB'), UrlGeneratorInterface::ABSOLUTE_PATH);
         $this->assertEquals('/en/some-uri', $url);
     }
 
@@ -54,10 +55,10 @@ class DomainBasedLocaleRouterTest extends \PHPUnit_Framework_TestCase
         $request->setLocale('nl_BE');
         $container = $this->getContainer($request);
         $object    = new DomainBasedLocaleRouter($container);
-        $url       = $object->generate('_slug', array('url' => 'some-uri'), true);
+        $url       = $object->generate('_slug', array('url' => 'some-uri'), UrlGeneratorInterface::ABSOLUTE_URL);
         $this->assertEquals('http://multilangdomain.tld/nl/some-uri', $url);
 
-        $url = $object->generate('_slug', array('url' => 'some-uri'), false);
+        $url = $object->generate('_slug', array('url' => 'some-uri'), UrlGeneratorInterface::ABSOLUTE_PATH);
         $this->assertEquals('/nl/some-uri', $url);
     }
 

--- a/src/Kunstmaan/NodeBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/routing.yml
@@ -1,9 +1,9 @@
 KunstmaanNodeBundle_widgets:
-    resource: "@KunstmaanNodeBundle/Controller/WidgetsController.php"
+    resource: '@KunstmaanNodeBundle/Controller/WidgetsController.php'
     type:     annotation
     prefix:   /admin/nodewidgets
 
 KunstmaanNodeBundle_nodes:
-    resource: "@KunstmaanNodeBundle/Controller/NodeAdminController.php"
+    resource: '@KunstmaanNodeBundle/Controller/NodeAdminController.php'
     type:     annotation
     prefix:   /admin/nodes

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -6,9 +6,9 @@ parameters:
 services:
     kunstmaan_node.nodetranslation.listener:
         class: Kunstmaan\NodeBundle\EventListener\NodeTranslationListener
-        arguments: ["@session", "@kunstmaan_admin.logger" , "@kunstmaan_utilities.slugifier", "@kunstmaan_admin.domain_configuration"]
+        arguments: ['@session', '@kunstmaan_admin.logger' , '@kunstmaan_utilities.slugifier', '@kunstmaan_admin.domain_configuration']
         calls:
-            - [ "setRequestStack", [@request_stack] ]
+            - [ 'setRequestStack', ['@request_stack'] ]
         tags:
             - { name: 'doctrine.event_listener', event: 'onFlush', method: 'onFlush' }
             - { name: 'doctrine.event_listener', event: 'postFlush', method: 'postFlush' }
@@ -17,7 +17,7 @@ services:
 
     kunstmaan_node.menu.adaptor.pages:
         class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor
-        arguments: ["@doctrine.orm.entity_manager", "@kunstmaan_admin.acl.native.helper", "@kunstmaan_node.pages_configuration", "@kunstmaan_admin.domain_configuration"]
+        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.acl.native.helper', '@kunstmaan_node.pages_configuration', '@kunstmaan_admin.domain_configuration']
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
@@ -28,23 +28,23 @@ services:
 
     kunstmaan_node.form.type.slug:
         class: Kunstmaan\NodeBundle\Form\Type\SlugType
-        arguments: ["@kunstmaan_utilities.slugifier"]
+        arguments: ['@kunstmaan_utilities.slugifier']
         tags:
             - { name: 'form.type', alias: 'slug' }
 
     kunstmaan_node.admin_node.publisher:
         class: Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@event_dispatcher", "@kunstmaan_admin.clone.helper"]
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@event_dispatcher', '@kunstmaan_admin.clone.helper']
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ["@knp_menu.factory", "@doctrine.orm.entity_manager", "@router", "@event_dispatcher", "@security.context", "@kunstmaan_node.pages_configuration" ]
+        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.context', '@kunstmaan_node.pages_configuration' ]
 
     kunstmaan_node.menu.sub_actions:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
         factory_service: kunstmaan_node.actions_menu_builder
         factory_method: createSubActionsMenu
-        arguments: ["@request"]
+        arguments: ['@request']
         scope: request # needed as we have the request as a dependency here
         tags:
             - { name: 'knp_menu.menu', alias: 'sub_actions' } # The alias is what is used to retrieve the menu
@@ -53,7 +53,7 @@ services:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
         factory_service: kunstmaan_node.actions_menu_builder
         factory_method: createActionsMenu
-        arguments: ["@request"]
+        arguments: ['@request']
         scope: request # needed as we have the request as a dependency here
         tags:
             - { name: 'knp_menu.menu', alias: 'actions' } # The alias is what is used to retrieve the menu
@@ -62,7 +62,7 @@ services:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
         factory_service: kunstmaan_node.actions_menu_builder
         factory_method: createTopActionsMenu
-        arguments: ["@request"]
+        arguments: ['@request']
         scope: request # needed as we have the request as a dependency here
         tags:
             - { name: 'knp_menu.menu', alias: 'top_actions' } # The alias is what is used to retrieve the menu
@@ -74,77 +74,77 @@ services:
 
     kunstmaan_node.edit_node.listener:
         class: Kunstmaan\NodeBundle\EventListener\NodeListener
-        arguments: ["@security.context", "@kunstmaan_admin.permissionadmin", "@security.acl.permission.map"]
+        arguments: ['@security.context', '@kunstmaan_admin.permissionadmin', '@security.acl.permission.map']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
     kunstmaan_node.log_page_events.subscriber:
         class: Kunstmaan\NodeBundle\EventListener\LogPageEventsSubscriber
-        arguments: ["@kunstmaan_admin.logger", "@security.context"]
+        arguments: ['@kunstmaan_admin.logger', '@security.context']
         tags:
             - { name: kernel.event_subscriber }
 
     kunstmaan_node.slugrouter:
-        class: "%kunstmaan_node.slugrouter.class%"
-        arguments: ["@service_container"]
+        class: '%kunstmaan_node.slugrouter.class%'
+        arguments: ['@service_container']
         tags:
             - { name: router, priority: 0 }
 
     kunstmaan_node.pages_configuration.twig_extension:
         class: Kunstmaan\NodeBundle\Twig\PagesConfigurationTwigExtension
         public: false
-        arguments: [ "@kunstmaan_node.pages_configuration" ]
+        arguments: [ '@kunstmaan_node.pages_configuration' ]
         tags:
             - { name: twig.extension }
 
     kunstmaan_node.page_creator_service:
         class: Kunstmaan\NodeBundle\Helper\Services\PageCreatorService
         calls:
-            - [ setEntityManager, [ "@doctrine.orm.entity_manager" ] ]
-            - [ setACLPermissionCreatorService, [ "@kunstmaan_node.acl_permission_creator_service" ] ]
-            - [ setUserEntityClass, [ "%fos_user.model.user.class%" ] ]
+            - [ setEntityManager, [ '@doctrine.orm.entity_manager' ] ]
+            - [ setACLPermissionCreatorService, [ '@kunstmaan_node.acl_permission_creator_service' ] ]
+            - [ setUserEntityClass, [ '%fos_user.model.user.class%' ] ]
 
     kunstmaan_node.acl_permission_creator_service:
         class: Kunstmaan\NodeBundle\Helper\Services\ACLPermissionCreatorService
         calls:
-            - [ setAclProvider, [ "@security.acl.provider" ] ]
-            - [ setObjectIdentityRetrievalStrategy, [ "@security.acl.object_identity_retrieval_strategy" ] ]
+            - [ setAclProvider, [ '@security.acl.provider' ] ]
+            - [ setObjectIdentityRetrievalStrategy, [ '@security.acl.object_identity_retrieval_strategy' ] ]
 
     kunstmaan_node.doctrine_mapping.listener:
         class: Kunstmaan\NodeBundle\EventListener\MappingListener
-        arguments: ["%fos_user.model.user.class%"]
+        arguments: ['%fos_user.model.user.class%']
         tags:
             - { name: doctrine.event_listener, event: loadClassMetadata }
 
     kunstmaan_node.command.fixtimestamps:
         class: Kunstmaan\NodeBundle\Command\FixTimestampsCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]
 
     kunstmaan_node.slug.listener:
-        class: "%kunstmaan_node.sluglistener.class%"
-        arguments: ["@doctrine.orm.entity_manager","@controller_resolver", "@event_dispatcher"]
+        class: '%kunstmaan_node.sluglistener.class%'
+        arguments: ['@doctrine.orm.entity_manager','@controller_resolver', '@event_dispatcher']
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
 
     kunstmaan_node.slug.security.listener:
         class: Kunstmaan\NodeBundle\EventListener\SlugSecurityListener
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@kunstmaan_node.node_menu"]
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@kunstmaan_node.node_menu']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.slug.security, method: onSlugSecurityEvent }
 
     kunstmaan_node.render.context.listener:
         class: Kunstmaan\NodeBundle\EventListener\RenderContextListener
-        arguments: ["@templating", @doctrine.orm.entity_manager]
+        arguments: ['@templating', @doctrine.orm.entity_manager]
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
     kunstmaan_node.node_menu:
         class: Kunstmaan\NodeBundle\Helper\NodeMenu
-        arguments: ["@doctrine.orm.entity_manager", "@security.context", "@kunstmaan_admin.acl.helper", "@kunstmaan_admin.domain_configuration"]
+        arguments: ['@doctrine.orm.entity_manager', '@security.context', '@kunstmaan_admin.acl.helper', '@kunstmaan_admin.domain_configuration']
 
     kunstmaan_node.node.twig.extension:
         class: Kunstmaan\NodeBundle\Twig\NodeTwigExtension
-        arguments: ["@doctrine.orm.entity_manager", "@router", "@kunstmaan_node.node_menu", "@request_stack"]
+        arguments: ['@doctrine.orm.entity_manager', '@router', '@kunstmaan_node.node_menu', '@request_stack']
         tags:
             - { name: twig.extension }

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -118,22 +118,22 @@ class SlugRouter implements RouterInterface
     }
 
     /**
-     * Generate an url for a supplied route
+     * Generate an url for a supplied route.
      *
-     * @param string $name       The path
-     * @param array  $parameters The route parameters
-     * @param bool   $absolute   Absolute url or not
+     * @param string   $name          The path
+     * @param array    $parameters    The route parameters
+     * @param int|bool $referenceType The type of reference to be generated (one of the UrlGeneratorInterface constants)
      *
      * @return null|string
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = UrlGenerator::ABSOLUTE_PATH)
     {
         $this->urlGenerator = new UrlGenerator(
             $this->getRouteCollection(),
             $this->getContext()
         );
 
-        return $this->urlGenerator->generate($name, $parameters, $absolute);
+        return $this->urlGenerator->generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Tests/Router/SlugRouterTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/Router/SlugRouterTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\NodeBundle\Tests\Router;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Router\SlugRouter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SlugRouterTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,10 +47,10 @@ class SlugRouterTest extends \PHPUnit_Framework_TestCase
         $request   = $this->getRequest();
         $container = $this->getContainer($request, true);
         $object    = new SlugRouter($container);
-        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en'), true);
+        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en'), UrlGeneratorInterface::ABSOLUTE_URL);
         $this->assertEquals('http://domain.tld/en/some-uri', $url);
 
-        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en'), false);
+        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'en'), UrlGeneratorInterface::ABSOLUTE_PATH);
         $this->assertEquals('/en/some-uri', $url);
     }
 
@@ -63,10 +64,10 @@ class SlugRouterTest extends \PHPUnit_Framework_TestCase
         $request   = $this->getRequest();
         $container = $this->getContainer($request);
         $object    = new SlugRouter($container);
-        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'nl'), true);
+        $url       = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'nl'), UrlGeneratorInterface::ABSOLUTE_URL);
         $this->assertEquals('http://domain.tld/some-uri', $url);
 
-        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'nl'), false);
+        $url = $object->generate('_slug', array('url' => 'some-uri', '_locale' => 'nl'), UrlGeneratorInterface::ABSOLUTE_PATH);
         $this->assertEquals('/some-uri', $url);
     }
 

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -24,9 +24,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\NodeBundle": "" }
+        "psr-4": { "Kunstmaan\\NodeBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/NodeBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 parameters:
     kunstmaan_node_search.search_configuration.node.class: Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration
-    kunstmaan_node_search.indexname: "nodeindex"
-    kunstmaan_node_search.indextype: "page"
+    kunstmaan_node_search.indexname: 'nodeindex'
+    kunstmaan_node_search.indextype: 'page'
     kunstmaan_node_search.search.node.class: Kunstmaan\NodeSearchBundle\Search\NodeSearcher
     kunstmaan_node_search.search_service.class: Kunstmaan\NodeSearchBundle\Services\SearchService
 
@@ -10,37 +10,37 @@ services:
         class: Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher
         abstract: true
         calls:
-            - [ setSearch, ["@kunstmaan_search.search"]]
+            - [ setSearch, ['@kunstmaan_search.search']]
 
     kunstmaan_node_search.search.node:
         class: %kunstmaan_node_search.search.node.class%
         parent: kunstmaan_node_search.search.abstract_elastica_searcher
         calls:
-            - [ setIndexName, ["%kunstmaan_node_search.indexname%"]]
-            - [ setIndexType, ["%kunstmaan_node_search.indextype%"]]
-            - [ setSecurityContext, ["@security.context"]]
-            - [ setDomainConfiguration, ["@kunstmaan_admin.domain_configuration"]]
+            - [ setIndexName, ['%kunstmaan_node_search.indexname%']]
+            - [ setIndexType, ['%kunstmaan_node_search.indextype%']]
+            - [ setSecurityContext, ['@security.context']]
+            - [ setDomainConfiguration, ['@kunstmaan_admin.domain_configuration']]
 
     kunstmaan_node_search.service.indexable_pageparts:
         class: Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     kunstmaan_node_search.twig.extension:
         class: Kunstmaan\NodeSearchBundle\Twig\KunstmaanNodeSearchTwigExtension
-        arguments: ["@doctrine.orm.entity_manager", "@kunstmaan_node_search.service.indexable_pageparts"]
+        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_node_search.service.indexable_pageparts']
         tags:
             - { name: twig.extension }
 
     kunstmaan_node_search.search_configuration.node:
         class: %kunstmaan_node_search.search_configuration.node.class%
-        arguments: ["@service_container", "@kunstmaan_search.search", "%kunstmaan_node_search.indexname%", "%kunstmaan_node_search.indextype%"]
+        arguments: ['@service_container', '@kunstmaan_search.search', '%kunstmaan_node_search.indexname%', '%kunstmaan_node_search.indextype%']
         calls:
-            - [ setAclProvider, ["@security.acl.provider"]]
-            - [ setIndexablePagePartsService, ["@kunstmaan_node_search.service.indexable_pageparts"]]
+            - [ setAclProvider, ['@security.acl.provider']]
+            - [ setIndexablePagePartsService, ['@kunstmaan_node_search.service.indexable_pageparts']]
         tags:
             - { name: kunstmaan_search.search_configuration, alias: Node }
 
     kunstmaan_node_search.search.service:
         class: %kunstmaan_node_search.search_service.class%
-        arguments: ["@service_container", "@request"]
+        arguments: ['@service_container', '@request']
         scope: request

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
@@ -3,8 +3,8 @@ parameters:
 
 services:
     kunstmaan_node_search.node_index_update.listener:
-        class: %kunstmaan_node_search.node_index_update.listener.class%
-        arguments: ["@service_container"]
+        class: '%kunstmaan_node_search.node_index_update.listener.class%'
+        arguments: ['@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.postPublish,   method: onPostPublish }
             - { name: kernel.event_listener, event: kunstmaan_node.postPersist,   method: onPostPersist }

--- a/src/Kunstmaan/PagePartBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/PagePartBundle/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 KunstmaanMediaBundle_pagepartadmin:
-    resource: "@KunstmaanPagePartBundle/Controller/PagePartAdminController.php"
+    resource: '@KunstmaanPagePartBundle/Controller/PagePartAdminController.php'
     type:     annotation
     prefix:   /admin
 

--- a/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
 #    kunstmaan_k_page_part.example:
 #        class: %kunstmaan_k_page_part.example.class%
-#        arguments: [@service_id, "plain_value", %parameter%]
+#        arguments: [@service_id, 'plain_value', %parameter%]
     kunstmaan_pagepart.pageparts:
         class: Kunstmaan\PagePartBundle\PagePartAdmin\Builder
 
@@ -20,31 +20,31 @@ services:
     kunstmaan_pageparts.twig.extension:
         class: Kunstmaan\PagePartBundle\Twig\Extension\PagePartTwigExtension
         arguments:
-            - "@doctrine.orm.entity_manager"
+            - '@doctrine.orm.entity_manager'
         tags:
             - { name: twig.extension }
             
     kunstmaan_pagetemplate.twig.extension:
         class: Kunstmaan\PagePartBundle\Twig\Extension\PageTemplateTwigExtension
         arguments:
-            - "@doctrine.orm.entity_manager"
-            - "@kernel"
+            - '@doctrine.orm.entity_manager'
+            - '@kernel'
         tags:
             - { name: twig.extension }
 
     kunstmaan_pageparts.pagepart_creator_service:
             class: Kunstmaan\PagePartBundle\Helper\Services\PagePartCreatorService
             calls:
-                - [ setEntityManager, [ "@doctrine.orm.entity_manager" ] ]
+                - [ setEntityManager, [ '@doctrine.orm.entity_manager' ] ]
 
     kunstmaan_pageparts.edit_node.listener:
         class: Kunstmaan\PagePartBundle\EventListener\NodeListener
-        arguments: ["@doctrine.orm.entity_manager", "@kernel", "@form.factory", "@kunstmaan_pagepartadmin.factory"]
+        arguments: ['@doctrine.orm.entity_manager', '@kernel', '@form.factory', '@kunstmaan_pagepartadmin.factory']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
     kunstmaan_pageparts.clone.listener:
         class: Kunstmaan\PagePartBundle\EventListener\CloneListener
-        arguments: ["@doctrine.orm.entity_manager", "@kernel"]
+        arguments: ['@doctrine.orm.entity_manager', '@kernel']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }

--- a/src/Kunstmaan/PagePartBundle/composer.json
+++ b/src/Kunstmaan/PagePartBundle/composer.json
@@ -22,9 +22,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\PagePartBundle": "" }
+        "psr-4": { "Kunstmaan\\PagePartBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/PagePartBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/RedirectBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanRedirectBundle_redirect_adminlist:
-    resource: @KunstmaanRedirectBundle/Controller/RedirectAdminListController.php
+    resource: '@KunstmaanRedirectBundle/Controller/RedirectAdminListController.php'
     type:     annotation
     prefix:   /admin/settings/redirect/

--- a/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
@@ -5,18 +5,18 @@ parameters:
 
 services:
     kunstmaan_redirect.menu.adaptor:
-        class: "%kunstmaan_redirect.menu.adaptor.class%"
+        class: '%kunstmaan_redirect.menu.adaptor.class%'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
     kunstmaan_redirect.repositories.redirect:
-        class:            "%kunstmaan_redirect.redirect_repository.class%"
-        factory_service:  "doctrine.orm.entity_manager"
+        class:            '%kunstmaan_redirect.redirect_repository.class%'
+        factory_service:  'doctrine.orm.entity_manager'
         factory_method:   getRepository
-        arguments:        ["%kunstmaan_redirect.redirect.class%"]
+        arguments:        ['%kunstmaan_redirect.redirect.class%']
 
     kunstmaan_redirect.redirectrouter:
         class: Kunstmaan\RedirectBundle\Router\RedirectRouter
-        arguments: ["@kunstmaan_redirect.repositories.redirect", "@kunstmaan_admin.domain_configuration"]
+        arguments: ['@kunstmaan_redirect.repositories.redirect', '@kunstmaan_admin.domain_configuration']
         tags:
             - { name: router, priority: 1 }

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -23,9 +23,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\RedirectBundle": "" }
+        "psr-4": { "Kunstmaan\\RedirectBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/RedirectBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/SearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SearchBundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 parameters:
-    kunstmaan_search.hostname: "localhost"
+    kunstmaan_search.hostname: 'localhost'
     kunstmaan_search.port: 9200
-    kunstmaan_search.search_provider: "Elastica"
+    kunstmaan_search.search_provider: 'Elastica'
     kunstmaan_search.search_configuration_chain.class: Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain
     kunstmaan_search.search_provider_chain.class: Kunstmaan\SearchBundle\Provider\SearchProviderChain
     kunstmaan_search.search.class: Kunstmaan\SearchBundle\Search\Search
@@ -10,38 +10,38 @@ parameters:
 
 services:
     kunstmaan_search.search:
-        class: "%kunstmaan_search.search.class%"
-        arguments: ["@kunstmaan_search.search_provider_chain", "%searchindexprefix%", "%kunstmaan_search.search_provider%"]
+        class: '%kunstmaan_search.search.class%'
+        arguments: ['@kunstmaan_search.search_provider_chain', '%searchindexprefix%', '%kunstmaan_search.search_provider%']
 
     kunstmaan_search.search.factory.analysis:
-        class: "%kunstmaan_search.search.factory.analysis.class%"
+        class: '%kunstmaan_search.search.factory.analysis.class%'
 
     # Providers
     kunstmaan_search.search_provider_chain:
-        class: "%kunstmaan_search.search_provider_chain.class%"
+        class: '%kunstmaan_search.search_provider_chain.class%'
 
     kunstmaan_search.search_provider.elastica:
-        class: "%kunstmaan_search.search_provider.elastica.class%"
+        class: '%kunstmaan_search.search_provider.elastica.class%'
         calls:
-            - [ addNode, [%kunstmaan_search.hostname%, %kunstmaan_search.port%] ]
+            - [ addNode, ['%kunstmaan_search.hostname%', '%kunstmaan_search.port%'] ]
         tags:
             - { name: kunstmaan_search.search_provider, alias: Elastica }
 
     # Configurations
     kunstmaan_search.search_configuration_chain:
-        class: "%kunstmaan_search.search_configuration_chain.class%"
+        class: '%kunstmaan_search.search_configuration_chain.class%'
 
     kunstmaan_search.command.setup:
         class: Kunstmaan\SearchBundle\Command\SetupIndexCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]
 
     kunstmaan_search.command.delete:
         class: Kunstmaan\SearchBundle\Command\DeleteIndexCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]
 
     kunstmaan_search.command.populate:
         class: Kunstmaan\SearchBundle\Command\PopulateIndexCommand
         calls:
-            - [setContainer, ["@service_container"] ]
+            - [setContainer, ['@service_container'] ]

--- a/src/Kunstmaan/SeoBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanSeoBundle_settings:
-    resource: "@KunstmaanSeoBundle/Controller/Admin/SettingsController.php"
+    resource: '@KunstmaanSeoBundle/Controller/Admin/SettingsController.php'
     prefix:   /admin/settings/robots
     type:     annotation

--- a/src/Kunstmaan/SeoBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/services.yml
@@ -1,9 +1,9 @@
 services:
     kunstmaan_seo.twig.extension:
         class: Kunstmaan\SeoBundle\Twig\SeoTwigExtension
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
         calls:
-            - [setWebsiteTitle, [%websitetitle%]]
+            - [setWebsiteTitle, ['%websitetitle%']]
         tags:
             - { name: twig.extension }
 
@@ -18,24 +18,24 @@ services:
         tags:
             - { name: twig.extension }
         calls:
-            - [ setAccountID, [ "%google.analytics.account_id%" ] ]
-            - [ setOrderPreparer, [ "@kunstmaan_seo.google_analytics.order_preparer" ] ]
-            - [ setOrderConverter, [ "@kunstmaan_seo.google_analytics.order_converter" ] ]
+            - [ setAccountID, [ '%google.analytics.account_id%' ] ]
+            - [ setOrderPreparer, [ '@kunstmaan_seo.google_analytics.order_preparer' ] ]
+            - [ setOrderConverter, [ '@kunstmaan_seo.google_analytics.order_converter' ] ]
 
     kunstmaan_seo.node.listener:
         class: Kunstmaan\SeoBundle\EventListener\NodeListener
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
     kunstmaan_seo.clone.listener:
         class: Kunstmaan\SeoBundle\EventListener\CloneListener
-        arguments: ["@doctrine.orm.entity_manager", "@kunstmaan_admin.clone.helper"]
+        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.clone.helper']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }
 
     kunstmaanseobundle.seo_management_menu_adaptor:
         class: Kunstmaan\SeoBundle\Helper\Menu\SeoManagementMenuAdaptor
-        arguments: ["@security.context"]
+        arguments: ['@security.context']
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }

--- a/src/Kunstmaan/SeoBundle/composer.json
+++ b/src/Kunstmaan/SeoBundle/composer.json
@@ -23,9 +23,8 @@
         "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\SeoBundle": "" }
+        "psr-4": { "Kunstmaan\\SeoBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/SeoBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/SitemapBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/SitemapBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanSitemapBundle_sitemap:
-    resource: "@KunstmaanSitemapBundle/Controller/SitemapController.php"
+    resource: '@KunstmaanSitemapBundle/Controller/SitemapController.php'
     type:     annotation
     prefix:   /

--- a/src/Kunstmaan/SitemapBundle/composer.json
+++ b/src/Kunstmaan/SitemapBundle/composer.json
@@ -21,9 +21,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\SitemapBundle": "" }
+        "psr-4": { "Kunstmaan\\SitemapBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/SitemapBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/TaggingBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/TaggingBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanTaggingBundle_admin_tag:
-    resource: @KunstmaanTaggingBundle/Controller/TagAdminListController.php
+    resource: '@KunstmaanTaggingBundle/Controller/TagAdminListController.php'
     type:     annotation
     prefix:   /admin/tags/

--- a/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
@@ -3,11 +3,11 @@ parameters:
 services:
     kuma_tagging.tag_manager:
         class: Kunstmaan\TaggingBundle\Entity\TagManager
-        arguments: ["@doctrine.orm.entity_manager", "Kunstmaan\TaggingBundle\Entity\Tag", "Kunstmaan\TaggingBundle\Entity\Tagging"]
+        arguments: ['@doctrine.orm.entity_manager', 'Kunstmaan\TaggingBundle\Entity\Tag', 'Kunstmaan\TaggingBundle\Entity\Tagging']
 
     kuma_tagging.listener:
         class: Kunstmaan\TaggingBundle\EventListener\TagsListener
-        arguments: ["@service_container"]
+        arguments: ['@service_container']
         tags:
             - { name: doctrine.event_listener, event: postUpdate }
             - { name: doctrine.event_listener, event: postPersist }
@@ -16,13 +16,13 @@ services:
 
     kuma_tagging.clone.listener:
         class: Kunstmaan\TaggingBundle\EventListener\CloneListener
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }
 
     kuma_tagging.index_node.listener:
         class: Kunstmaan\TaggingBundle\EventListener\IndexNodeEventListener
-        arguments: ["@service_container"]
+        arguments: ['@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node_search.onIndexNode, method: onIndexNode }
 
@@ -33,6 +33,6 @@ services:
 
     form.type.tags:
         class: Kunstmaan\TaggingBundle\Form\TagsAdminType
-        arguments: ["@kuma_tagging.tag_manager"]
+        arguments: ['@kuma_tagging.tag_manager']
         tags:
             - { name: form.type, alias: kunstmaan_taggingbundle_tags }

--- a/src/Kunstmaan/TaggingBundle/composer.json
+++ b/src/Kunstmaan/TaggingBundle/composer.json
@@ -22,9 +22,8 @@
         "kunstmaan/node-bundle": "~3.2"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\TaggingBundle": "" }
+        "psr-4": { "Kunstmaan\\TaggingBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/TaggingBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -75,8 +75,8 @@ class KunstmaanTranslatorExtension extends Extension
         $translator = $container->getDefinition('kunstmaan_translator.service.translator.translator');
 
         $dirs = array();
-        if (class_exists('Symfony\Component\Validator\Validator')) {
-            $r = new \ReflectionClass('Symfony\Component\Validator\Validator');
+        if (class_exists('Symfony\Component\Validator\Validation')) {
+            $r = new \ReflectionClass('Symfony\Component\Validator\Validation');
 
             $dirs[] = dirname($r->getFilename()).'/Resources/translations';
         }

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/repositories.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/repositories.yml
@@ -1,10 +1,10 @@
 services:
 #    kunstmaan_translator_list.example:
-#        class: %kunstmaan_translater_list.example.class%
-#        arguments: [@service_id, "plain_value", %parameter%]
+#        class: '%kunstmaan_translater_list.example.class%'
+#        arguments: ['@service_id', 'plain_value', '%parameter%']
 
     kunstmaan_translator.repository.translation:
-        factory_service: "doctrine.orm.default_entity_manager"
-        factory_method: "getRepository"
-        class: "Kunstmaan\TranslatorBundle\Repository\TranslationRepository"
-        arguments: ["Kunstmaan\TranslatorBundle\Entity\Translation"]
+        factory_service: 'doctrine.orm.default_entity_manager'
+        factory_method: 'getRepository'
+        class: 'Kunstmaan\TranslatorBundle\Repository\TranslationRepository'
+        arguments: ['Kunstmaan\TranslatorBundle\Entity\Translation']

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/routing.yml
@@ -1,10 +1,10 @@
 KunstmaanTranslatorBundle_translations:
-    resource: "@KunstmaanTranslatorBundle/Controller/TranslatorController.php"
+    resource: '@KunstmaanTranslatorBundle/Controller/TranslatorController.php'
     type:     annotation
     prefix:   /admin/settings/translations
 
 KunstmaanTranslatorBundle_translations_commands:
-    resource: "@KunstmaanTranslatorBundle/Controller/TranslatorCommandController.php"
+    resource: '@KunstmaanTranslatorBundle/Controller/TranslatorCommandController.php'
     type:     annotation
     prefix:   /admin/settings/translations
 

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -5,95 +5,95 @@ services:
     kunstmaan.data_collector.translator:
         class: Kunstmaan\TranslatorBundle\Component\HttpKernel\DataCollector\TranslatorDataCollector
         tags:
-            - { name: data_collector, template: "KunstmaanTranslatorBundle:DataCollector:translator", id: "translator", priority: "1" }
+            - { name: data_collector, template: 'KunstmaanTranslatorBundle:DataCollector:translator', id: 'translator', priority: '1' }
 
     kunstmaan_translator.menu.adaptor:
-        class: "%kunstmaan_translator.menu.adaptor.class%"
+        class: '%kunstmaan_translator.menu.adaptor.class%'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
     kunstmaan_translator.service.abstract_command_handler:
         abstract: true
-        class: "Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler'
         calls:
-            - [setManagedLocales, [%kuma_translator.managed_locales%]]
-            - [setKernel, [@kernel]]
+            - [setManagedLocales, ['%kuma_translator.managed_locales%']]
+            - [setKernel, ['@kernel']]
 
     kunstmaan_translator.service.importer.command_handler:
         parent: kunstmaan_translator.service.abstract_command_handler
-        class: "Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler'
         calls:
-            - [setTranslationFileExplorer, [@kunstmaan_translator.service.file_explorer]]
-            - [setImporter, [@kunstmaan_translator.service.importer.importer]]
+            - [setTranslationFileExplorer, ['@kunstmaan_translator.service.file_explorer']]
+            - [setImporter, ['@kunstmaan_translator.service.importer.importer']]
 
     kunstmaan_translator.service.exporter.command_handler:
         parent: kunstmaan_translator.service.abstract_command_handler
-        class: "Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler'
         calls:
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
-            - [setExporter, [@kunstmaan_translator.service.exporter.exporter]]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setExporter, ['@kunstmaan_translator.service.exporter.exporter']]
 
     kunstmaan_translator.service.exporter.exporter:
-        class: "Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter'
 
     kunstmaan_translator.service.exporter.yaml:
-        class: "Kunstmaan\TranslatorBundle\Service\Command\Exporter\YamlFileExporter"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\YamlFileExporter'
         tags:
             - { name: 'translation.exporter', alias: 'yml' }
 
     kunstmaan_translator.service.file_explorer:
-        class: "Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer"
+        class: 'Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer'
         calls:
-            - [setFileFormats, [%kuma_translator.file_formats%]]
+            - [setFileFormats, ['%kuma_translator.file_formats%']]
 
     kunstmaan_translator.service.importer.importer:
-        class: "Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer'
         calls:
-            - [setTranslationGroupManager, [@kunstmaan_translator.service.group_manager]] # default, maken via config var
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
+            - [setTranslationGroupManager, ['@kunstmaan_translator.service.group_manager']] # default, maken via config var
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 
     kunstmaan_translator.service.group_manager:
-        class: "Kunstmaan\TranslatorBundle\Service\TranslationGroupManager"
+        class: 'Kunstmaan\TranslatorBundle\Service\TranslationGroupManager'
         calls:
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 
     kunstmaan_translator.service.translator.loader:
         class: Kunstmaan\TranslatorBundle\Service\Translator\Loader
         tags:
             - { name: 'translation.loader', alias: 'database' }
         calls:
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 
     kunstmaan_translator.service.translator.resource_cacher:
         class: Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher
         calls:
-            - [setDebug, [%kuma_translator.debug%]]
-            - [setCacheDir, [%kuma_translator.cache_dir%]]
-            - [setLogger, [@logger]]
+            - [setDebug, ['%kuma_translator.debug%']]
+            - [setCacheDir, ['%kuma_translator.cache_dir%']]
+            - [setLogger, ['@logger']]
 
     kunstmaan_translator.service.translator.cache_validator:
         class: Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator
         calls:
-            - [setCacheDir, [%kuma_translator.cache_dir%]]
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
+            - [setCacheDir, ['%kuma_translator.cache_dir%']]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 
     kunstmaan_translator.service.translator.translator:
         class: Kunstmaan\TranslatorBundle\Service\Translator\Translator
         arguments:
-            - @service_container
-            - @translator.selector
+            - '@service_container'
+            - '@translator.selector'
             - {}
-            - { cache_dir : %kuma_translator.cache_dir%, debug: %kuma_translator.debug% }
-            - [@session]
+            - { cache_dir: '%kuma_translator.cache_dir%', debug: '%kuma_translator.debug%' }
+            - ['@session']
         calls:
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
-            - [setResourceCacher, [@kunstmaan_translator.service.translator.resource_cacher]]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setResourceCacher, ['@kunstmaan_translator.service.translator.resource_cacher']]
 
     kunstmaan_translator.service.migrations.migrations:
-        class: "Kunstmaan\TranslatorBundle\Service\Migrations\MigrationsService"
+        class: 'Kunstmaan\TranslatorBundle\Service\Migrations\MigrationsService'
         calls:
-            - [setTranslationRepository, [@kunstmaan_translator.repository.translation]]
-            - [setEntityManager, [@doctrine.orm.default_entity_manager]]
+            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setEntityManager, ['@doctrine.orm.default_entity_manager']]
 
     kunstmaan_translator.service.command.diff:
-        class: "Kunstmaan\TranslatorBundle\Service\Command\DiffCommand"
+        class: 'Kunstmaan\TranslatorBundle\Service\Command\DiffCommand'

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": "~2.3",
-        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/orm": "^2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
@@ -36,9 +36,8 @@
         "doctrine/doctrine-fixtures-bundle": "~2.2.0"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\TranslatorBundle": "" }
+        "psr-4": { "Kunstmaan\\TranslatorBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/TranslatorBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
@@ -1,15 +1,15 @@
 KunstmaanUserManagementBundle_user_settings:
-    resource: "@KunstmaanUserManagementBundle/Controller/UsersController.php"
+    resource: '@KunstmaanUserManagementBundle/Controller/UsersController.php'
     type:     annotation
     prefix:   /admin/settings/users
 
 KunstmaanUserManagementBundle_group_settings:
-    resource: "@KunstmaanUserManagementBundle/Controller/GroupsController.php"
+    resource: '@KunstmaanUserManagementBundle/Controller/GroupsController.php'
     type:     annotation
     prefix:   /admin/settings/groups
 
 KunstmaanUserManagementBundle_role_settings:
-    resource: "@KunstmaanUserManagementBundle/Controller/RolesController.php"
+    resource: '@KunstmaanUserManagementBundle/Controller/RolesController.php'
     type:     annotation
     prefix:   /admin/settings/roles
 

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 
 services:
     kunstmaan_user_management.menu.adaptor:
-        class: "%kunstmaan_user_management.menu.adaptor.class%"
-        arguments: ["@security.context"]
+        class: '%kunstmaan_user_management.menu.adaptor.class%'
+        arguments: ['@security.context']
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor', priority: 100 }

--- a/src/Kunstmaan/UserManagementBundle/composer.json
+++ b/src/Kunstmaan/UserManagementBundle/composer.json
@@ -21,9 +21,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "Kunstmaan\\UserManagementBundle": "" }
+        "psr-4": { "Kunstmaan\\UserManagementBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/UserManagementBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/UtilitiesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/UtilitiesBundle/Resources/config/services.yml
@@ -6,18 +6,18 @@ parameters:
 
 services:
     kunstmaan_utilities.shell:
-        class: "%kunstmaan_utilities.shell.class%"
+        class: '%kunstmaan_utilities.shell.class%'
 
     kunstmaan_utilities.cipher:
-        class: "%kunstmaan_utilities.cipher.class%"
-        arguments: ["%kunstmaan_utilities.cipher.secret%"]
+        class: '%kunstmaan_utilities.cipher.class%'
+        arguments: ['%kunstmaan_utilities.cipher.secret%']
 
     kunstmaan_utilities.slugifier:
-        class: "%kunstmaan_utilities.slugifier.class%"
+        class: '%kunstmaan_utilities.slugifier.class%'
 
     kunstmaan_utilities.twig.extension:
         class: Kunstmaan\UtilitiesBundle\Twig\UtilitiesTwigExtension
-        arguments: [ "@kunstmaan_utilities.slugifier" ]
+        arguments: ['@kunstmaan_utilities.slugifier']
         tags:
             - { name: twig.extension }
 

--- a/src/Kunstmaan/UtilitiesBundle/composer.json
+++ b/src/Kunstmaan/UtilitiesBundle/composer.json
@@ -22,9 +22,8 @@
         "ekino/newrelic-bundle": "To use the UrlTransactionNamingStrategy"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\UtilitiesBundle": "" }
+        "psr-4": { "Kunstmaan\\UtilitiesBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/UtilitiesBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"

--- a/src/Kunstmaan/VotingBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/VotingBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanVotingBundle_default:
-    resource: "@KunstmaanVotingBundle/Controller/VotingController.php"
+    resource: '@KunstmaanVotingBundle/Controller/VotingController.php'
     type:     annotation
     prefix:   /

--- a/src/Kunstmaan/VotingBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/VotingBundle/Resources/config/services.yml
@@ -4,69 +4,69 @@ parameters:
 services:
 #    kunstmaan_voting_list.example:
 #        class: %kunstmaan_voting_list.example.class%
-#        arguments: [@service_id, "plain_value", %parameter%]
+#        arguments: [@service_id, 'plain_value', %parameter%]
 
     ## UP VOTE
 
     kunstmaan_voting.upvote:
         class: Kunstmaan\VotingBundle\EventListener\UpDown\UpVoteEventListener
-        arguments: ["@doctrine.orm.entity_manager", "@service_container"]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.upVote, method: onUpVote }
 
     kunstmaan_voting.helper.upvote:
         class: Kunstmaan\VotingBundle\Helper\UpDown\UpVoteHelper
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     ## Down VOTE
 
     kunstmaan_voting.downvote:
         class: Kunstmaan\VotingBundle\EventListener\UpDown\DownVoteEventListener
-        arguments: ["@doctrine.orm.entity_manager", "@service_container"]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.downVote, method: onDownVote }
 
     kunstmaan_voting.helper.downvote:
         class: Kunstmaan\VotingBundle\Helper\UpDown\DownVoteHelper
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     ## FACEBOOK LIKE
 
     kunstmaan_voting.facebooklike:
         class: Kunstmaan\VotingBundle\EventListener\Facebook\FacebookLikeEventListener
-        arguments: ["@doctrine.orm.entity_manager", "@service_container"]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.facebookLike, method: onFacebookLike }
 
     kunstmaan_voting.helper.facebook.like:
         class: Kunstmaan\VotingBundle\Helper\Facebook\FacebookLikeHelper
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     ## FACEBOOK SEND
 
     kunstmaan_voting.facebooksend:
         class: Kunstmaan\VotingBundle\EventListener\Facebook\FacebookSendEventListener
-        arguments: ["@doctrine.orm.entity_manager", "@service_container"]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.facebookSend, method: onFacebookSend }
 
     kunstmaan_voting.helper.facebook.send:
         class: Kunstmaan\VotingBundle\Helper\Facebook\FacebookSendHelper
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     ## LINKEDIN SHARE
 
     kunstmaan_voting.linkedinshare:
         class: Kunstmaan\VotingBundle\EventListener\LinkedIn\LinkedInShareEventListener
-        arguments: ["@doctrine.orm.entity_manager", "@service_container"]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.linkedInShare, method: onLinkedInShare }
 
     kunstmaan_voting.helper.linkedin.share:
         class: Kunstmaan\VotingBundle\Helper\LinkedIn\LinkedInShareHelper
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']
 
     # SERVICES
     kunstmaan_voting.services.repository_resolver:
         class: Kunstmaan\VotingBundle\Services\RepositoryResolver
-        arguments: ["@doctrine.orm.entity_manager"]
+        arguments: ['@doctrine.orm.entity_manager']

--- a/src/Kunstmaan/VotingBundle/composer.json
+++ b/src/Kunstmaan/VotingBundle/composer.json
@@ -20,9 +20,8 @@
         "doctrine/doctrine-fixtures-bundle": "~2.2.0"
     },
     "autoload": {
-        "psr-0": { "Kunstmaan\\VotingBundle": "" }
+        "psr-4": { "Kunstmaan\\VotingBundle\\": "" }
     },
-    "target-dir": "Kunstmaan/VotingBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

 * If a bundle works on 2.7, it works on 2.8 too, no reason to not allow installing this bundle with Symfony 2.8.
 * Improve Travis setup to run tests quicker and test more
 * Removed some deprecated feature usages (the ones that don't require BC layers)

Is there any roadmap for Symfony 3 support? E.g. support both Symfony 2 and 3 with a BC layer like [the one in SonataCoreBundle](https://github.com/sonata-project/SonataCoreBundle/blob/master/Form/FormHelper.php) or do you only support 2.8 and 3.0 (which would be possible without BC layers), etc. ?