### PR TITLE
[AdminBundle] Add reinit-js attribute on the wysiwyg textarea

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -66,7 +66,7 @@
     {% if attr['maxlength'] is defined %}
         {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' js-max-length-input')|trim }) %}
     {% endif %}
-    <textarea {{ block('widget_attributes') }}{% if attr['type'] is defined %} data-editor-mode="{{ attr['type'] }}"{% endif %} rows="10" cols="600">{{ value|raw }}</textarea>
+    <textarea {{ block('widget_attributes') }}{% if attr['type'] is defined %} data-editor-mode="{{ attr['type'] }}"{% endif %} data-reinit-js='["richEditor"]' rows="10" cols="600">{{ value|raw }}</textarea>
 {% endspaceless %}
 {% endblock wysiwyg_widget %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The ckeditor was not being initialized when a pagepart with type 'wysiwyg' was added to the page. This fix calls the ckeditor's reInit method to fix this.

Based on #849