### PR TITLE
[MediaBundle] Fix media chooser type selector when no type was passed

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -34,7 +34,7 @@ class ChooserController extends Controller
         $session  = $request->getSession();
         $folderId = false;
 
-        $type            = $request->get('type');
+        $type            = $request->get('type', 'all');
         $cKEditorFuncNum = $request->get('CKEditorFuncNum');
         $linkChooser     = $request->get('linkChooser');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When opening the media chooser with an empty `type` GET parameter, the type parameter from the previous request was used. So if the previous request had `type = image`, and the next request did not specify the type, only images could be selected.