### PR TITLE
[AdminBundle] Added up/down arrows on nested forms, fix rich editor when moving elements in DOM

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
@@ -8,7 +8,7 @@ kunstmaanbundles.pagepartEditor = function (window) {
         delete: []
     };
 
-    var init, addPagePart, editPagePart, deletePagePart, movePagePartUp, movePagePartDown, subscribeToEvent, unSubscribeToEvent, executeEvent;
+    var init, addPagePart, editPagePart, deletePagePart, movePagePartUp, movePagePartDown, subscribeToEvent, unSubscribeToEvent, executeEvent, reInit, updateDisplayOrder;
 
     init = function () {
         var $body = $('body');
@@ -184,6 +184,9 @@ kunstmaanbundles.pagepartEditor = function (window) {
 
         var currentPp = $('#' + targetId + '-pp-container');
         var previousPp = currentPp.prevAll('.sortable-item:first');
+        // ReInit the modules. This is needed for a known bug in CKEDITOR. When moving a element with a ckeditor in
+        // The DOM, the ckeditor needs to be reinitialized.
+        reInit(currentPp);
         if (previousPp.length) {
             $(previousPp).before(currentPp);
 
@@ -197,6 +200,9 @@ kunstmaanbundles.pagepartEditor = function (window) {
             easing: 'ease-in-out'
         });
 
+        // Update display order.
+        updateDisplayOrder(previousPp, currentPp);
+
         // Set Active Edit
         window.activeEdit = targetId;
     };
@@ -208,6 +214,9 @@ kunstmaanbundles.pagepartEditor = function (window) {
 
         var currentPp = $('#' + targetId + '-pp-container');
         var nextPp = currentPp.nextAll('.sortable-item:first');
+        // ReInit the modules. This is needed for a known bug in CKEDITOR. When moving a element with a ckeditor in
+        // The DOM, the ckeditor needs to be reinitialized.
+        reInit(currentPp);
         if (nextPp.length) {
             $(nextPp).after(currentPp);
 
@@ -220,6 +229,9 @@ kunstmaanbundles.pagepartEditor = function (window) {
             offset: -200,
             easing: 'ease-in-out'
         });
+
+        // Update display order.
+        updateDisplayOrder(currentPp, nextPp);
 
         // Set Active Edit
         window.activeEdit = targetId;
@@ -271,7 +283,7 @@ kunstmaanbundles.pagepartEditor = function (window) {
             resizeBtn.find('i').removeClass('fa-plus').addClass('fa-minus');
             resizeBtn.removeClass('pp__actions__action--resize-max');
         }
-    }
+    };
 
     // subsribe to an event.
     subscribeToEvent = function (eventName, callBack) {
@@ -292,6 +304,28 @@ kunstmaanbundles.pagepartEditor = function (window) {
         events[eventName].forEach(function (cb) {
             cb({target: target})
         })
+    };
+    reInit = function($el) {
+        $($el).find('*[data-reinit-js]').each(function() {
+            // Get modules from data attribute
+            var modules = $(this).data('reinit-js');
+
+            if (modules) {
+                for (var i = 0; i < modules.length; i++) {
+                    // Check if there really is a module with the given name and it if has a public reInit function
+                    if (typeof kunstmaanbundles[modules[i]] === 'object' && typeof kunstmaanbundles[modules[i]].reInit === 'function') {
+                        kunstmaanbundles[modules[i]].reInit();
+                    }
+                }
+            }
+        });
+    };
+    updateDisplayOrder = function($firstEl, $secondEl) {
+        $secondSortEl = $($secondEl).find('#' + $($secondEl).data('sortkey'));
+        $firstSortEl = $($firstEl).find('#' + $($firstEl).data('sortkey'));
+
+        $secondSortEl.val(parseInt($secondSortEl.val()) -1);
+        $firstSortEl.val(parseInt($firstSortEl.val()) +1);
     };
     return {
         init: init,

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
@@ -182,8 +182,8 @@ kunstmaanbundles.pagepartEditor = function (window) {
     movePagePartUp = function ($btn) {
         var targetId = $btn.data('target-id');
 
-        var currentPp = $('#' + targetId + '-pp-container');
-        var previousPp = currentPp.prevAll('.sortable-item:first');
+        $currentPp = $('#' + targetId + '-pp-container');
+        $previousPp = $currentPp.prevAll('.sortable-item:first');
         // ReInit the modules. This is needed for a known bug in CKEDITOR. When moving a element with a ckeditor in
         // The DOM, the ckeditor needs to be reinitialized.
         reInit(currentPp);
@@ -306,7 +306,7 @@ kunstmaanbundles.pagepartEditor = function (window) {
         })
     };
     reInit = function($el) {
-        $($el).find('*[data-reinit-js]').each(function() {
+        $el.find('*[data-reinit-js]').each(function() {
             // Get modules from data attribute
             var modules = $(this).data('reinit-js');
 

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_rich-editor.js
@@ -31,7 +31,7 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
         _collectEditorConfigs, _collectExternalPlugins, _customOkFunctionForTables;
 
     // First Init
-    init = reInit = function() {
+    init = function() {
         // These objects are declared global in _ckeditor_configs.html.twig
         _collectExternalPlugins(window.externalPlugins);
         _collectEditorConfigs(window.ckEditorConfigs);
@@ -41,6 +41,12 @@ kunstmaanbundles.richEditor = (function(window, undefined) {
                 enableRichEditor($(this));
             }
         });
+    };
+
+    // Needs extra destroy of existing rich editors.
+    reInit = function() {
+        destroyAllRichEditors();
+        init();
     };
 
     // PRIVATE

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -77,7 +77,10 @@
 {% block wysiwyg_widget %}
 {% spaceless %}
     {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' js-rich-editor rich-editor form-control')|trim }) %}
-    <textarea {{ block('widget_attributes') }}{% if attr['type'] is defined %} data-editor-mode="{{ attr['type'] }}"{% endif %} data-reinit-js='["richEditor"]' rows="10" cols="600">{{ value|raw }}</textarea>
+    {% if attr['maxlength'] is defined %}
+        {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' js-max-length-input')|trim }) %}
+    {% endif %}
+    <textarea {{ block('widget_attributes') }}{% if 'js-rich-editor' in attr.class %} data-reinit-js='["richEditor"]'{% endif %}{% if attr['type'] is defined %} data-editor-mode="{{ attr['type'] }}"{% endif %} rows="10" cols="600">{{ value|raw }}</textarea>
 {% endspaceless %}
 {% endblock wysiwyg_widget %}
 
@@ -165,7 +168,7 @@
 
                 {# Items #}
                 {% for obj in form %}
-                    <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
+                    <div id="{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}-pp-container" class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
                             {% if attr['nested_deletable'] is not defined or attr['nested_deletable'] != false %}
                                 data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
                             {% endif %}
@@ -177,6 +180,12 @@
                             {% endif %}
 
                             <div class="js-nested-form__item__header__actions nested-form__item__header__actions"></div>
+                            <button type="button" class="js-move-up-pp-btn btn--raise-on-hover pp__actions__action pp__actions__action--up" title="{{ 'pagepart.buttons.move_up'|trans }}" data-target-id="{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}">
+                                <i class="fa fa-chevron-up"></i>
+                            </button>
+                            <button type="button" class="js-move-down-pp-btn btn--raise-on-hover pp__actions__action pp__actions__action--down" title="{{ 'pagepart.buttons.move_down'|trans }}" data-target-id="{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}">
+                                <i class="fa fa-chevron-down"></i>
+                            </button>
                         </header>
 
                         {# View #}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #865 #216

Nested forms can now also be sorted by using the up and down arrow.

Also a fix for the rich editor. When moving a element around in the DOM by sorting it, the ckeditor gets disabled and the content is removed. This is a known bug in Ckeditor. I have fixed it by destroying all the rich editors and reinitialise them when moving them around.