### PR TITLE
[MediaBundle, MediaBundle] Fix: the "property" option is deprecated since version 2.7 and will be removed in 3.0. Use "choice_label" instead

### DIFF
--- a/src/Kunstmaan/MediaBundle/Form/AbstractRemoteType.php
+++ b/src/Kunstmaan/MediaBundle/Form/AbstractRemoteType.php
@@ -82,7 +82,7 @@ abstract class AbstractRemoteType extends AbstractType
                         'entity',
                         array(
                             'class' => 'KunstmaanMediaBundle:Folder',
-                            'property' => 'optionLabel',
+                            'choice_label' => 'optionLabel',
                             'query_builder' => function (FolderRepository $er) {
                                 return $er->selectFolderQueryBuilder()
                                     ->andWhere('f.parent IS NOT NULL');

--- a/src/Kunstmaan/MediaBundle/Form/File/FileType.php
+++ b/src/Kunstmaan/MediaBundle/Form/File/FileType.php
@@ -95,7 +95,7 @@ class FileType extends AbstractType
                         'entity',
                         array(
                             'class' => 'KunstmaanMediaBundle:Folder',
-                            'property' => 'optionLabel',
+                            'choice_label' => 'optionLabel',
                             'query_builder' => function (FolderRepository $er) {
                                 return $er->selectFolderQueryBuilder()
                                     ->andWhere('f.parent IS NOT NULL');

--- a/src/Kunstmaan/MediaBundle/Form/FolderType.php
+++ b/src/Kunstmaan/MediaBundle/Form/FolderType.php
@@ -62,7 +62,7 @@ class FolderType extends AbstractType
                 'entity',
                 array(
                     'class' => 'KunstmaanMediaBundle:Folder',
-                    'property' => 'optionLabel',
+                    'choice_label' => 'optionLabel',
                     'required' => true,
                     'query_builder' => function (FolderRepository $er) use ($folder) {
                         return $er->selectFolderQueryBuilder($folder);

--- a/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
+++ b/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
@@ -76,7 +76,7 @@ class MenuItemAdminType extends AbstractType
             'entity',
             array(
                 'class'         => $menuItemclass,
-                'property'      => 'displayTitle',
+                'choice_label'  => 'displayTitle',
                 'query_builder' => function (EntityRepository $er) use (
                     $entityId,
                     $menu
@@ -122,7 +122,7 @@ class MenuItemAdminType extends AbstractType
             'entity',
             array(
                 'class'         => 'KunstmaanNodeBundle:NodeTranslation',
-                'property'  => 'title',
+                'choice_label'  => 'title',
                 'query_builder' => function (EntityRepository $er) use (
                     $locale,
                     $rootNode


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 