### PR TITLE
[AdminBundle]: symfony 2.7 syntax

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
+++ b/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
@@ -69,7 +69,7 @@ class TabPane
      */
     public function buildForm()
     {
-        $builder = $this->formFactory->createBuilder(FormType::class, null);
+        $builder = $this->formFactory->createBuilder('form', null);
 
         foreach ($this->tabs as $tab) {
             $tab->buildForm($builder);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Symfony 2.7 does not know the new symfony 2.8 form syntax. Revert it to correct 2.7 syntax.