### PR TITLE
[AllBundles] Deprecated "empty_value" option when using choice as form type. Replace it with "placeholder"

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/UserType.php
+++ b/src/Kunstmaan/AdminBundle/Form/UserType.php
@@ -70,7 +70,7 @@ class UserType extends AbstractType implements RoleDependentUserFormInterface
                     'choices'     => $languages,
                     'label'       => 'settings.user.adminlang',
                     'required'    => true,
-                    'empty_value' => false
+                    'placeholder' => false
                 ));
 
         if ($this->canEditAllFields) {

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -27,8 +27,8 @@
 {% spaceless %}
     {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' form-control')|trim }) %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
-        {% if empty_value is not none %}
-            <option value="" {% if required and value is empty %}selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+        {% if placeholder is not none %}
+            <option value="" {% if required and value is empty %}selected="selected"{% endif %}>{{ placeholder|trans({}, translation_domain) }}</option>
         {% endif %}
         {% if preferred_choices|length > 0 %}
             {% set options = preferred_choices %}

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
@@ -119,7 +119,7 @@ class ChoicePagePart extends AbstractFormPagePart
                 'expanded'    => $this->getExpanded(),
                 'multiple'    => $this->getMultiple(),
                 'choices'     => $choices,
-                'empty_value' => $this->getEmptyValue(),
+                'placeholder' => $this->getEmptyValue(),
                 'constraints' => $constraints,
             )
         );

--- a/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
@@ -19,7 +19,7 @@ class ChoiceFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'expanded', 'multiple', 'choices', 'empty_value', 'constraints'), null);
+        $keys = array_fill_keys(array('label', 'required', 'expanded', 'multiple', 'choices', 'placeholder', 'constraints'), null);
         $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function($v) { return isset($v); });
         $fieldOptions['empty_data'] = null;
 
@@ -39,7 +39,7 @@ class ChoiceFormSubmissionType extends AbstractType
         $resolver->setDefaults(array(
                 'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\ChoiceFormSubmissionField',
                 'choices' => array(),
-                'empty_value' => null,
+                'placeholder' => null,
                 'expanded' => null,
                 'multiple' => null,
         ));

--- a/src/Kunstmaan/FormBundle/Form/ChoicePagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoicePagePartAdminType.php
@@ -26,7 +26,7 @@ class ChoicePagePartAdminType extends AbstractType
             ->add('expanded', 'checkbox', array('required' => false))
             ->add('multiple', 'checkbox', array('required' => false))
             ->add('choices', 'textarea', array('required' => false))
-            ->add('empty_value', 'text', array('required' => false));
+            ->add('placeholder', 'text', array('required' => false));
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Resources/doc/FormBundle.md
+++ b/src/Kunstmaan/FormBundle/Resources/doc/FormBundle.md
@@ -25,7 +25,7 @@ The choice page part can be used to add single or multiple choice form elements 
 * **expanded**: If set to true, radio buttons or checkboxes will be rendered (depending on the multiple value). If false, a select element will be rendered.
 * **multiple**: If true, the user will be able to select multiple options (as opposed to choosing just one option). Depending on the value of the expanded option, this will render either a select tag or checkboxes if true and a select tag or radio buttons if false. The returned value will be an array.
 * **choices**: The list of possible options the user can choose from. The choices can be entered separated by a new line.
-* **empty value**: This option determines whether or not a special "empty" option (e.g. "Choose an option") will appear at the top of a select widget. This option only applies if both the expanded and multiple options are set to false.
+* **placeholder**: This option determines whether or not a special "empty" option (e.g. "Choose an option") will appear at the top of a select widget. This option only applies if both the expanded and multiple options are set to false.
 
 #### FileUploadPagePart
 The file upload page part adds the possibility to upload files. When adding a this kind of page part there are a few configuration options available:

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/BikeAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/BikeAdminType.php
@@ -23,7 +23,7 @@ class BikeAdminType extends AbstractType
     {
 	$builder->add('type', 'choice', array(
 	    'choices' => array_combine(Bike::$types, Bike::$types),
-	    'empty_value' => false,
+	    'placeholder' => false,
 	    'required' => true
 	));
 	$builder->add('brand', 'text', array(

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
@@ -49,7 +49,7 @@ class ServicePagePartAdminType extends \Symfony\Component\Form\AbstractType
 	));
 	$builder->add('imagePosition', 'choice', array(
 	    'choices' => array_combine(ServicePagePart::$imagePositions, ServicePagePart::$imagePositions),
-	    'empty_value' => false,
+	    'placeholder' => false,
 	    'required' => true
 	));
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
@@ -74,8 +74,8 @@
     <div {{ block('widget_container_attributes') }} class="form-widget--select">
         <i class="icon icon--triangle-down select__icon"></i>
         <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %} class="form-control form-control--select">
-            {% if empty_value is not none %}
-                <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+            {% if placeholder is not none %}
+                <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder|trans({}, translation_domain) }}</option>
             {% endif %}
             {% if preferred_choices|length > 0 %}
                 {% set options = preferred_choices %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ButtonPagePart/ButtonPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ButtonPagePart/ButtonPagePartAdminType.php
@@ -38,17 +38,17 @@ class {{ pagepart }}AdminType extends AbstractType
 	));
 	$builder->add('type', 'choice', array(
 	    'choices' => array_combine({{ pagepart }}::$types, {{ pagepart }}::$types),
-	    'empty_value' => false,
+	    'placeholder' => false,
 	    'required' => true
 	));
 	$builder->add('size', 'choice', array(
 	    'choices' => array_combine({{ pagepart }}::$sizes, {{ pagepart }}::$sizes),
-	    'empty_value' => false,
+	    'placeholder' => false,
 	    'required' => true
 	));
 	$builder->add('position', 'choice', array(
 	    'choices' => array_combine({{ pagepart }}::$positions, {{ pagepart }}::$positions),
-	    'empty_value' => false,
+	    'placeholder' => false,
 	    'required' => true
 	));
     }

--- a/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
+++ b/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
@@ -110,7 +110,7 @@ class MenuItemAdminType extends AbstractType
                     MenuItem::$types,
                     MenuItem::$types
                 ),
-                'empty_value' => false,
+                'placeholder' => false,
                 'required'    => true
             )
         );

--- a/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
@@ -33,7 +33,7 @@ class NodeMenuTabTranslationAdminType extends AbstractType
         }
         $builder->add('weight', 'choice', array(
             'choices'     => array_combine(range(-50, 50), range(-50, 50)),
-            'empty_value' => false,
+            'placeholder' => false,
             'required'    => false,
             'attr'        => array('title' => 'Used to reorder the pages.')
         ));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 