### PR TITLE
[AdminBundle] The "array" type hint was removed from the OptionsResolverInterface

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/UserType.php
+++ b/src/Kunstmaan/AdminBundle/Form/UserType.php
@@ -110,7 +110,7 @@ class UserType extends AbstractType implements RoleDependentUserFormInterface
         array('password_required' => false,
             'data_class' => 'Kunstmaan\AdminBundle\Entity\User',
         ));
-        $resolver->addAllowedValues(array('password_required' => array(true, false)));
+        $resolver->addAllowedValues('password_required', array(true, false));
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The "array" type hint was removed from the OptionsResolverInterface methods setRequired(), setAllowedValues(), addAllowedValues(), setAllowedTypes() and addAllowedTypes()