### PR TITLE
[TranslatorBundle, VotingBundle] Deprecated request call

### DIFF
--- a/src/Kunstmaan/LanguageChooserBundle/Controller/LanguageChooserController.php
+++ b/src/Kunstmaan/LanguageChooserBundle/Controller/LanguageChooserController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\LanguageChooserBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -11,9 +12,10 @@ class LanguageChooserController extends Controller
     /**
      * Handles the language chooser
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @return Response the request response
      */
-    public function indexAction()
+    public function indexAction(Request $request)
     {
         $enableAutodetect = $this->container->getParameter('kunstmaan_language_chooser.autodetectlanguage');
         $enableSplashpage = $this->container->getParameter('kunstmaan_language_chooser.showlanguagechooser');
@@ -22,8 +24,6 @@ class LanguageChooserController extends Controller
 
         if ($enableAutodetect) {
             $localeGuesserManager   = $this->get('lunetics_locale.guesser_manager');
-
-            $request                = $this->getRequest();
 
             $locale = $localeGuesserManager->runLocaleGuessing($request);
 

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -9,6 +9,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * WidgetsController
@@ -19,11 +20,12 @@ class WidgetsController extends Controller
      * @Route("/ckselecturl", name="KunstmaanNodeBundle_ckselecturl")
      * @Template("KunstmaanNodeBundle:Widgets:selectLink.html.twig")
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @return array
      */
-    public function ckSelectLinkAction()
+    public function ckSelectLinkAction(Request $request)
     {
-        $params        = $this->getTemplateParameters();
+        $params        = $this->getTemplateParameters($request);
         $params['cke'] = true;
 
         return $params;
@@ -35,11 +37,12 @@ class WidgetsController extends Controller
      * @Route   ("/selecturl", name="KunstmaanNodeBundle_selecturl")
      * @Template("KunstmaanNodeBundle:Widgets:selectLink.html.twig")
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @return array
      */
-    public function selectLinkAction()
+    public function selectLinkAction(Request $request)
     {
-        $params        = $this->getTemplateParameters();
+        $params        = $this->getTemplateParameters($request);
         $params['cke'] = false;
 
         return $params;
@@ -49,13 +52,14 @@ class WidgetsController extends Controller
      * Get the parameters needed in the template. This is common for the
      * default link chooser and the cke link chooser.
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @return array
      */
-    private function getTemplateParameters()
+    private function getTemplateParameters(Request $request)
     {
         /* @var EntityManager $em */
         $em     = $this->getDoctrine()->getManager();
-        $locale = $this->getRequest()->getLocale();
+        $locale = $request->getLocale();
 
         $result = $em->getRepository('KunstmaanNodeBundle:Node')
             ->getAllMenuNodes(
@@ -80,7 +84,7 @@ class WidgetsController extends Controller
 
         if (array_key_exists('KunstmaanMediaBundle', $allBundles)) {
             $params          = array('linkChooser' => 1);
-            $cKEditorFuncNum = $this->getRequest()->get('CKEditorFuncNum');
+            $cKEditorFuncNum = $request->get('CKEditorFuncNum');
             if (!empty($cKEditorFuncNum)) {
                 $params['CKEditorFuncNum'] = $cKEditorFuncNum;
             }

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\TranslatorBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractAdminListConfigurator;
 use Kunstmaan\TranslatorBundle\AdminList\TranslationAdminListConfigurator;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
@@ -33,10 +34,11 @@ class TranslatorController extends AdminListController
     /**
      * @Route("/", name="KunstmaanTranslatorBundle_settings_translations")
      * @Template("KunstmaanTranslatorBundle:Translator:list.html.twig")
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function indexAction()
+    public function indexAction(Request $request)
     {
-        $request = $this->getRequest();
         $configurator = $this->getAdminListConfigurator();
 
         /* @var AdminList $adminList */
@@ -64,16 +66,16 @@ class TranslatorController extends AdminListController
      * @Method({"GET", "POST"})
      * @Template("KunstmaanTranslatorBundle:Translator:addTranslation.html.twig")
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $keyword
      * @param string $domain
      * @param string $locale
      * @return array|RedirectResponse
      */
-    public function addAction($keyword = '', $domain = '', $locale = '')
+    public function addAction(Request $request, $keyword = '', $domain = '', $locale = '')
     {
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
-        $request = $this->getRequest();
         $configurator = $this->getAdminListConfigurator();
         $translator = $this->get('translator');
 
@@ -127,14 +129,14 @@ class TranslatorController extends AdminListController
      * @Method({"GET", "POST"})
      * @Template("KunstmaanTranslatorBundle:Translator:editTranslation.html.twig")
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
      * @param $id
      * @throws \InvalidArgumentException
      * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function editAction($id)
+    public function editAction(Request $request, $id)
     {
         $em = $this->getDoctrine()->getManager();
-        $request = $this->getRequest();
         $configurator = $this->getAdminListConfigurator();
 
 

--- a/src/Kunstmaan/VotingBundle/Controller/VotingController.php
+++ b/src/Kunstmaan/VotingBundle/Controller/VotingController.php
@@ -20,12 +20,13 @@ class VotingController extends Controller
     /**
      * @Route("/voting-upvote", name="voting_upvote")
      * @Template("KunstmaanVotingBundle:UpDown:voted.html.twig")
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     public function upVoteAction(Request $request)
     {
         $reference = $request->get('reference');
         $value = $request->get('value');
-        $this->get('event_dispatcher')->dispatch(Events::VOTE_UP, new UpVoteEvent($this->getRequest(), $reference, $value));
+        $this->get('event_dispatcher')->dispatch(Events::VOTE_UP, new UpVoteEvent($request, $reference, $value));
 
         return;
     }
@@ -33,44 +34,48 @@ class VotingController extends Controller
     /**
      * @Route("/voting-downvote", name="voting_downvote")
      * @Template("KunstmaanVotingBundle:UpDown:voted.html.twig")
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     public function downVoteAction(Request $request)
     {
         $reference = $request->get('reference');
         $value = $request->get('value');
-        $this->get('event_dispatcher')->dispatch(Events::VOTE_DOWN, new DownVoteEvent($this->getRequest(), $reference, $value));
+        $this->get('event_dispatcher')->dispatch(Events::VOTE_DOWN, new DownVoteEvent($request, $reference, $value));
 
         return;
     }
 
     /**
      * @Route("/voting-facebooklike", name="voting_facebooklike")
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     public function facebookLikeAction(Request $request)
     {
         $response = $request->get('response');
         $value = $request->get('value');
-        $this->get('event_dispatcher')->dispatch(Events::FACEBOOK_LIKE, new FacebookLikeEvent($this->getRequest(), $response, $value));
+        $this->get('event_dispatcher')->dispatch(Events::FACEBOOK_LIKE, new FacebookLikeEvent($request, $response, $value));
     }
 
     /**
      * @Route("/voting-facebooksend", name="voting_facebooksend")
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     public function facebookSendAction(Request $request)
     {
         $response = $request->get('response');
         $value = $request->get('value');
-        $this->get('event_dispatcher')->dispatch(Events::FACEBOOK_SEND, new FacebookSendEvent($this->getRequest(), $response, $value));
+        $this->get('event_dispatcher')->dispatch(Events::FACEBOOK_SEND, new FacebookSendEvent($request, $response, $value));
     }
 
     /**
      * @Route("/voting-linkedinshare", name="voting_linkedinshare")
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
     public function linkedInShareAction(Request $request)
     {
         $reference = $request->get('reference');
         $value = $request->get('value');
-        $this->get('event_dispatcher')->dispatch(Events::LINKEDIN_SHARE, new LinkedInShareEvent($this->getRequest(), $reference, $value));
+        $this->get('event_dispatcher')->dispatch(Events::LINKEDIN_SHARE, new LinkedInShareEvent($request, $reference, $value));
     }
 
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Calling $this->getRequest() in a controller is deprecated. We have to inject the $request variable in the controller action.