### PR TITLE
[MediaBundle] Update LiipImagineBundle to v1.4.3 with workaround

### DIFF
--- a/UPGRADE-3.5.md
+++ b/UPGRADE-3.5.md
@@ -24,3 +24,51 @@ More information about this change: http://symfony.com/blog/new-in-symfony-2-6-s
 
 You will only need to make changes when your code extends some functionality of the CMS that used the `security.context` service.
 
+
+## Upgrade LiipImagineBundle from v0.20.2 to v1.4.3
+
+It is not possible anymore to change the format of cached images with all versions that were released after v0.20.2 (see 
+https://github.com/liip/LiipImagineBundle/issues/584). There is an issue on the LiipImagineBundle roadmap to fix this, 
+but it will not be ready before the 2.0 release (see https://github.com/liip/LiipImagineBundle/issues/686). In the 
+meanwhile we extended some services to implement a quick workaround so we can a least update the bundle to a recent
+version. 
+
+You should change the `liip_imagine` configuration and the routing when updating:
+
+In your `config.yml` replace
+
+```
+liip_imagine:
+    cache_prefix: uploads/cache
+    driver: imagick
+    data_loader: filesystem
+    data_root: %kernel.root_dir%/../web
+    formats : ['jpg', 'jpeg','png', 'gif', 'bmp']
+```
+
+with
+
+```
+liip_imagine:
+    resolvers:
+        default:
+            web_path:
+                cache_prefix: uploads/cache
+    driver: imagick
+    data_loader: default
+```
+
+and in your `routing.yml`
+
+```
+_imagine:
+    resource: .
+    type:     imagine
+```
+
+with
+
+```
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+```

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -47,6 +47,14 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         if ($config['enable_pdf_preview'] === true) {
             $loader->load('pdf_preview.yml');
         }
+
+        $container->setParameter('liip_imagine.filter.loader.background.class', 'Kunstmaan\MediaBundle\Helper\Imagine\BackgroundFilterLoader');
+        $container->setParameter('liip_imagine.cache.manager.class', 'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager');
+        $container->setParameter('liip_imagine.cache.resolver.web_path.class', 'Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver');
+        $container->setParameter('liip_imagine.controller.class', 'Kunstmaan\MediaBundle\Helper\Imagine\ImagineController');
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('imagine.xml');
     }
 
     public function prepend(ContainerBuilder $container)
@@ -62,7 +70,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $twigConfig['globals']['mediamanager']        = "@kunstmaan_media.media_manager";
         $container->prependExtensionConfig('twig', $twigConfig);
 
-        $liipConfig = Yaml::parse(file_get_contents(__DIR__ . '/../Resources/config/liip_imagine.yml'));
+        $liipConfig = Yaml::parse(file_get_contents(__DIR__ . '/../Resources/config/imagine_filters.yml'));
         $container->prependExtensionConfig('liip_imagine', $liipConfig['liip_imagine']);
 
         $configs = $container->getExtensionConfig($this->getAlias());

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper\Imagine;
+
+use Imagine\Image\Box;
+use Imagine\Image\Color;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+
+/**
+ * This class can be removed when https://github.com/liip/LiipImagineBundle/issues/640 is fixed.
+ */
+class BackgroundFilterLoader extends \Liip\ImagineBundle\Imagine\Filter\Loader\BackgroundFilterLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ImageInterface $image, array $options = array())
+    {
+        $background = new Color(
+            isset($options['color']) ? $options['color'] : '#fff',
+            isset($options['transparency']) ? $options['transparency'] : 0
+        );
+        $topLeft = new Point(0, 0);
+        $size = $image->getSize();
+
+        if (isset($options['size'])) {
+            list($width, $height) = $options['size'];
+
+            $size = new Box($width, $height);
+            $topLeft = new Point(($width - $image->getSize()->getWidth()) / 2, ($height - $image->getSize()->getHeight()) / 2);
+        }
+
+        $canvas = $this->imagine->create($size, $background);
+
+        return $canvas->paste($image, $topLeft);
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper\Imagine;
+
+class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateUrl($path, $filter, array $runtimeConfig = array(), $resolver = null)
+    {
+        $filterConf = $this->filterConfig->get($filter);
+        $path = $this->changeFileExtension(ltrim($path, '/'), $filterConf['format']);
+
+        return parent::generateUrl($path, $filter, $runtimeConfig, $resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($path, $filter, $resolver = null)
+    {
+        $filterConf = $this->filterConfig->get($filter);
+        $path = $this->changeFileExtension($path, $filterConf['format']);
+
+        return parent::resolve($path, $filter, $resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBrowserPath($path, $filter, array $runtimeConfig = array(), $resolver = null)
+    {
+        $info = pathinfo($path);
+        $url = parent::getBrowserPath($path, $filter, $runtimeConfig, $resolver);
+        $newPath = parse_url($url, PHP_URL_PATH);
+        $newInfo = pathinfo($newPath);
+        if ($info['extension'] != $newInfo['extension']) {
+            $query = parse_url($url, PHP_URL_QUERY);
+            $url .= ($query ? '&' : '?') . 'originalExtension=' . $info['extension'];
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param string $path
+     * @param string $format
+     * @return string
+     */
+    private function changeFileExtension($path, $format)
+    {
+        if (!$format) {
+            return $path;
+        }
+
+        $info = pathinfo($path);
+        $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $format;
+
+        return $path;
+   }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/ImagineController.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/ImagineController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper\Imagine;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class ImagineController extends \Liip\ImagineBundle\Controller\ImagineController
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function filterAction(Request $request, $path, $filter)
+    {
+        if ($request->query->has('originalExtension')) {
+            $info = pathinfo($path);
+            $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $request->query->getAlpha('originalExtension');
+        }
+
+        return parent::filterAction($request, $path, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterRuntimeAction(Request $request, $hash, $path, $filter)
+    {
+        if ($request->query->has('originalExtension')) {
+            $info = pathinfo($path);
+            $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $request->query->getAlpha('originalExtension');
+        }
+
+        return parent::filterRuntimeAction($request, $hash, $path, $filter);
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper\Imagine;
+
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\RequestContext;
+
+class WebPathResolver extends \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver
+{
+    /**
+     * @var FilterConfiguration
+     */
+    protected $filterConfig;
+
+    /**
+     * @param Filesystem          $filesystem
+     * @param RequestContext      $requestContext
+     * @param string              $webRootDir
+     * @param string              $cachePrefix
+     * @param FilterConfiguration $filterConfig
+     */
+    public function __construct(Filesystem $filesystem, RequestContext $requestContext, $webRootDir, $cachePrefix = 'media/cache', FilterConfiguration $filterConfig)
+    {
+        parent::__construct($filesystem, $requestContext, $webRootDir, $cachePrefix);
+
+        $this->filterConfig = $filterConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFileUrl($path, $filter)
+    {
+        $filterConf = $this->filterConfig->get($filter);
+        $path = $this->changeFileExtension($path, $filterConf['format']);
+
+        return parent::getFileUrl($path, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($path, $filter)
+    {
+        return sprintf('%s/%s',
+            $this->getBaseUrl(),
+            $this->getFileUrl($path, $filter)
+        );
+    }
+
+    /**
+     * @param string $path
+     * @param string $format
+     * @return string
+     */
+    private function changeFileExtension($path, $format)
+    {
+        if (!$format) {
+            return $path;
+        }
+
+        $info = pathinfo($path);
+        $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $format;
+
+        return $path;
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Resources/config/imagine.xml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/imagine.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="liip_imagine.cache.resolver.prototype.web_path" class="%liip_imagine.cache.resolver.web_path.class%" public="true" abstract="true">
+            <argument type="service" id="filesystem" />
+            <argument type="service" id="router.request_context" />
+            <argument><!-- will be injected by WebPathResolverFactory --></argument>
+            <argument><!-- will be injected by WebPathResolverFactory --></argument>
+            <argument type="service" id="liip_imagine.filter.configuration" />
+        </service>
+    </services>
+</container>

--- a/src/Kunstmaan/MediaBundle/Resources/config/imagine_filters.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/imagine_filters.yml
@@ -1,8 +1,10 @@
 liip_imagine:
-    cache_prefix: uploads/cache
+    resolvers:
+        default:
+            web_path:
+                cache_prefix: uploads/cache
     driver: imagick
-    data_loader: kunstmaan_media_thumbloader
-    #cache: no_cache
+    data_loader: default
     filter_sets:
         media_list_thumbnail:
             quality: 75

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -11,14 +11,6 @@ parameters:
     kunstmaan_media.mimetype_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory'
 
 services:
-    liip_imagine.data.loader.stream.profile_photos:
-        class: '%liip_imagine.data.loader.stream.class%'
-        arguments:
-            - '@liip_imagine'
-            - ''
-        tags:
-            - { name: 'liip_imagine.data.loader', loader: 'kunstmaan_media_thumbloader' }
-
     kunstmaan_media.media_manager:
         class: '%kunstmaan_media.media_manager.class%'
         calls:

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -18,7 +18,7 @@
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",
         "stof/doctrine-extensions-bundle": "1.1.*@dev",
-        "liip/imagine-bundle": "v0.20.2",
+        "liip/imagine-bundle": "v1.4.3",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "sensio/framework-extra-bundle": ">=2.3.0,<4.0.0",
         "kunstmaan/admin-bundle": "~3.2",


### PR DESCRIPTION
Should be merged together with https://github.com/Kunstmaan/KunstmaanBundlesStandardEdition/pull/182

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #914 #228

The possibility to change the format of the cached images will be implemented in version 2.0 of the LiipImagineBundle. In the meanwhile we can upgrade by extending some logic.