### PR TITLE
[AllBundles]: Change deprecated form functions

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
@@ -61,7 +61,7 @@ class DefaultController extends Controller
         if (is_null($dashboardConfiguration)) {
             $dashboardConfiguration = new DashboardConfiguration();
         }
-        $form = $this->createForm(new DashboardConfigurationType(), $dashboardConfiguration);
+        $form = $this->createForm(DashboardConfigurationType::class, $dashboardConfiguration);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
@@ -72,7 +72,7 @@ abstract class AbstractNewsletterController extends Controller
 
     protected function getSubscriptionFormType()
     {
-        return new NewsletterSubscriptionType();
+        return NewsletterSubscriptionType::class;
     }
 
     protected function getIndexTemplate()

--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -115,7 +115,7 @@ class ChooserController extends Controller
 
         $sub = new Folder();
         $sub->setParent($folder);
-        $subForm  = $this->createForm(new FolderType($sub), $sub);
+        $subForm  = $this->createForm(FolderType::class, $sub, array('folder' => $sub));
 
         $linkChooserLink = null;
         if (!empty($linkChooser)) {

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -56,8 +56,8 @@ class FolderController extends Controller
 
         $sub = new Folder();
         $sub->setParent($folder);
-        $subForm  = $this->createForm(new FolderType($sub), $sub);
-        $editForm = $this->createForm(new FolderType($folder), $folder);
+        $subForm  = $this->createForm(FolderType::class, $sub, array('folder' => $sub));
+        $editForm = $this->createForm(FolderType::class, $folder, array('folder' => $folder));
 
         if ($request->isMethod('POST')) {
             $editForm->handleRequest($request);
@@ -151,7 +151,7 @@ class FolderController extends Controller
         $parent = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
         $folder = new Folder();
         $folder->setParent($parent);
-        $form = $this->createForm(new FolderType(), $folder);
+        $form = $this->createForm(FolderType::class, $folder);
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
             if ($form->isValid()) {

--- a/src/Kunstmaan/MediaBundle/Form/FolderType.php
+++ b/src/Kunstmaan/MediaBundle/Form/FolderType.php
@@ -17,19 +17,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class FolderType extends AbstractType
 {
     /**
-     * @var Folder
-     */
-    public $folder;
-
-    /**
-     * @param Folder $folder The folder
-     */
-    public function __construct(Folder $folder = null)
-    {
-        $this->folder = $folder;
-    }
-
-    /**
      * Builds the form.
      *
      * This method is called for each type in the hierarchy starting form the
@@ -44,7 +31,7 @@ class FolderType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $folder = $this->folder;
+        $folder = $options['folder'];
         $builder
             ->add('name')
             ->add(
@@ -101,6 +88,7 @@ class FolderType extends AbstractType
         $resolver->setDefaults(
             array(
                 'data_class' => 'Kunstmaan\MediaBundle\Entity\Folder',
+                'folder' => null
             )
         );
     }

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -41,7 +41,7 @@ class SettingsController extends BaseSettingsController
             $isSaved = false;
         }
 
-        $form = $this->createForm(new RobotsType(), $robot, array(
+        $form = $this->createForm(RobotsType::class, $robot, array(
             'action' => $this->generateUrl('KunstmaanSeoBundle_settings_robots')
         ));
         if ($request->isMethod('POST')) {

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -85,7 +85,7 @@ class TranslatorController extends AdminListController
             $translation->addText($locale, '');
         }
 
-        $form = $this->createForm(new TranslationAdminType('add'), $translation);
+        $form = $this->createForm(TranslationAdminType::class, $translation, array('intention' => 'add'));
         if ('POST' == $request->getMethod()) {
             $form->handleRequest($request);
 
@@ -162,7 +162,7 @@ class TranslatorController extends AdminListController
             }
         }
 
-        $form = $this->createForm(new TranslationAdminType('edit'), $translation);
+        $form = $this->createForm(TranslationAdminType::class, $translation, array('intention' => 'edit'));
 
         if ('POST' == $request->getMethod()) {
             $form->handleRequest($request);

--- a/src/Kunstmaan/TranslatorBundle/Form/TranslationAdminType.php
+++ b/src/Kunstmaan/TranslatorBundle/Form/TranslationAdminType.php
@@ -11,28 +11,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class TranslationAdminType extends AbstractType
 {
     /**
-     * @var string
-     */
-    private $intention;
-
-    /**
-     * Constructor
-     *
-     * @param string $intention
-     */
-    public function __construct($intention = 'add')
-    {
-        $this->intention = $intention;
-    }
-
-    /**
      * @param FormBuilderInterface $builder
      * @param array $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $intention = $options['intention'];
         $options = array();
-        if ($this->intention == 'edit') {
+        if ($intention == 'edit') {
             $options = array('read_only' => true);
         }
 
@@ -61,6 +47,7 @@ class TranslationAdminType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => '\Kunstmaan\TranslatorBundle\Model\Translation',
+            'intention' => null
         ));
     }
 }

--- a/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
@@ -64,7 +64,7 @@ class GroupsController extends BaseSettingsController
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
         $group = new Group();
-        $form = $this->createForm(new GroupType(), $group);
+        $form = $this->createForm(GroupType::class, $group);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
@@ -102,7 +102,7 @@ class GroupsController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
         /* @var Group $group */
         $group = $em->getRepository('KunstmaanAdminBundle:Group')->find($id);
-        $form = $this->createForm(new GroupType(), $group);
+        $form = $this->createForm(GroupType::class, $group);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -60,7 +60,7 @@ class RolesController extends BaseSettingsController
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
         $role = new Role('');
-        $form = $this->createForm(new RoleType(), $role);
+        $form = $this->createForm(RoleType::class, $role);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
@@ -99,7 +99,7 @@ class RolesController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
         /* @var Role $role */
         $role = $em->getRepository('KunstmaanAdminBundle:Role')->find($id);
-        $form = $this->createForm(new RoleType(), $role);
+        $form = $this->createForm(RoleType::class, $role);
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

Passing type instances to Form::add(), FormBuilder::add() and the FormFactory::create*() methods is deprecated