### PR TITLE
[FixturesBundle] Fix missing singe quote in yaml config

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
@@ -18,7 +18,7 @@ services:
     kunstmaan_fixtures.builder.pagepart:
         class: Kunstmaan\FixturesBundle\Builder\PagePartBuilder
         arguments:
-            - '@doctrine.orm.entity_manager
+            - '@doctrine.orm.entity_manager'
             - '@kunstmaan_fixtures.populator.populator'
         tags:
             - { name: kunstmaan_fixtures.builder, alias: PagePartBuilder }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Malformed inline YAML string ('@doctrine.orm.entity_manager) at line 21 (near "- '@doctrine.orm.entity_manager").