### PR TITLE
[FormBundle] fix btn pagepart dont submit in admin

### DIFF
--- a/src/Kunstmaan/FormBundle/Resources/views/SubmitButtonPagePart/view-admin.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/SubmitButtonPagePart/view-admin.html.twig
@@ -1,1 +1,1 @@
-<button class="btn">{{ resource.label }}</button>
+<button class="btn" disabled="disabled">{{ resource.label }}</button>


### PR DESCRIPTION
When this pagepart was beeing rendered in the admin, it was actually clickable and would submit the page ...  this PR disables the button in the admin view



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 