### PR TITLE
[NodeBundle] View permission on node in adminlist

### DIFF
--- a/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
+++ b/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\DateFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\BooleanFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
@@ -13,6 +14,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionDefinition;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\ListAction\SimpleListAction;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * NodeAdminListConfigurator
@@ -40,6 +42,11 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     protected $showAddHomepage;
 
     /**
+     * @var AuthorizationCheckerInterface $authorizationChecker
+     */
+    protected $authorizationChecker;
+
+    /**
      * @param EntityManager                $em                  The entity
      *                                                          manager
      * @param AclHelper                    $aclHelper           The ACL helper
@@ -47,10 +54,11 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      *                                                          locale
      * @param string                       $permission          The permission
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper, $locale, $permission)
+    public function __construct(EntityManager $em, AclHelper $aclHelper, $locale, $permission, AuthorizationCheckerInterface $authorizationChecker)
     {
         parent::__construct($em, $aclHelper);
         $this->locale = $locale;
+        $this->authorizationChecker = $authorizationChecker;
         $this->setPermissionDefinition(
             new PermissionDefinition(
                 array($permission),
@@ -152,6 +160,11 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     public function canAdd()
     {
         return false;
+    }
+
+    public function canEdit($item)
+    {
+        return $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_EDIT, $item->getNode());
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeBundle\Controller;
 
 use DateTime;
 use Kunstmaan\AdminBundle\Entity\BaseUser;
+use Kunstmaan\AdminBundle\Entity\EntityInterface;
 use Kunstmaan\NodeBundle\Form\NodeMenuTabTranslationAdminType;
 use Kunstmaan\NodeBundle\Form\NodeMenuTabAdminType;
 use InvalidArgumentException;
@@ -104,8 +105,24 @@ class NodeAdminController extends Controller
             $this->em,
             $this->aclHelper,
             $this->locale,
-            PermissionMap::PERMISSION_EDIT
+            PermissionMap::PERMISSION_VIEW,
+            $this->authorizationChecker
+
         );
+
+        $locale = $this->locale;
+        $acl = $this->authorizationChecker;
+        $itemRoute = function (EntityInterface $item) use ($locale, $acl) {
+
+            if ($acl->isGranted(PermissionMap::PERMISSION_VIEW, $item->getNode())) {
+                return array(
+                    'path'   => '_slug_preview',
+                    'params' => ['_locale' => $locale, 'url' => $item->getUrl()]
+                );
+            }
+        };
+        $nodeAdminListConfigurator->addSimpleItemAction('Preview', $itemRoute, 'eye');
+
         $nodeAdminListConfigurator->setDomainConfiguration($this->get('kunstmaan_admin.domain_configuration'));
         $nodeAdminListConfigurator->setShowAddHomepage($this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN'));
 

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -97,7 +97,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
         } elseif (stripos($request->attributes->get('_route'), 'KunstmaanNodeBundle_nodes') === 0) {
             $treeNodes     = $this->getTreeNodes(
                 $request->getLocale(),
-                PermissionMap::PERMISSION_EDIT,
+                PermissionMap::PERMISSION_VIEW,
                 $this->aclNativeHelper,
                 true
             );


### PR DESCRIPTION
Does this count as a new feature maybe even a bc break ?

It can give some unexpected behaviour, when you update to this code, and previously had a page wich you only viewed and edited in the admin, but had not set any view permissions on, for any role,   this page will no longer be visible in your admin .... as you would now require the view permission to be able to see it in the admin.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no?
| BC breaks?    | no?
| Deprecations? | no
| Fixed tickets | https://github.com/Kunstmaan/KunstmaanBundlesCMS/issues/705