### PR TITLE
[FixturesBundle] Set Media folder name by internal name in fixtures

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
@@ -48,6 +48,11 @@ class MediaBuilder implements BuilderInterface
         }
 
         $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('rel' => $properties['folder']));
+
+        if (!$this->folder instanceof Folder) {
+            $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('internalName' => $properties['folder']));
+        }
+
         if (!$this->folder instanceof Folder) {
             throw new \Exception('Could not find the specified folder for media fixture ' . $fixture->getName());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This feature allows you to use the internal name of a Folder as reference for a Media item location.