### PR TITLE
[NodeBundle] only use `$request->attributes` to get `NodeTranslation`

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -41,7 +41,7 @@ class SlugController extends Controller
         $locale = $request->getLocale();
 
         /* @var NodeTranslation $nodeTranslation */
-        $nodeTranslation = $request->get('_nodeTranslation');
+        $nodeTranslation = $request->attributes->get('_nodeTranslation');
 
         // If no node translation -> 404
         if (!$nodeTranslation) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Only use `$request->attributes` to get `NodeTranslation`, since user provided value (via GET or POST) will break the site.