### PR TITLE
[AdminBundle]: change fosuser template extends

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword.html.twig
@@ -1,4 +1,4 @@
-{% extends "@FOSUser/layout.html.twig" %}
+{% extends "@FOSUserBundle/Resources/views/layout.html.twig" %}
 
 {% block fos_user_content %}
     {% include "@KunstmaanAdmin/ChangePassword/changePassword_content.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Resetting/checkEmail.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Resetting/checkEmail.html.twig
@@ -1,4 +1,4 @@
-{% extends "@FOSUser/layout.html.twig" %}
+{% extends "@FOSUserBundle/Resources/views/layout.html.twig" %}
 
 {% block fos_user_content %}
     <div class="alert alert-success">

--- a/src/Kunstmaan/AdminBundle/Resources/views/Resetting/passwordAlreadyRequested.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Resetting/passwordAlreadyRequested.html.twig
@@ -1,4 +1,4 @@
-{% extends "@FOSUser/layout.html.twig" %}
+{% extends "@FOSUserBundle/Resources/views/layout.html.twig" %}
 
 {% block fos_user_content %}
     <div class="alert alert-error">

--- a/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
@@ -1,4 +1,4 @@
-{% extends "@FOSUser/layout.html.twig" %}
+{% extends "@FOSUserBundle/Resources/views/layout.html.twig" %}
 
 {% block fos_user_content %}
     <form action="{{ path("fos_user_security_check") }}" method="post">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets |  

The overriding of resources only works when you refer to resources with the @FOSUserBundle/Resources/config/routing/security.xml method. If you refer to resources without using the @BundleName shortcut, they can't be overridden in this way.