### PR TITLE
Fix FOSUserBundle extend

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
@@ -1,4 +1,4 @@
-{% extends "@FOSUserBundle/Resources/views/layout.html.twig" %}
+{% extends "FOSUserBundle::layout.html.twig" %}
 
 {% block fos_user_content %}
     <form action="{{ path("fos_user_security_check") }}" method="post">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

Admin login page doesn't seem to work on current dev-master with latest Symfony 2.8.x because of this extend.