### PR TITLE
add github templates, move templates to .github folder

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contribute
+
+We follow most of the procedures for contributions from the [Symfony](http://symfony.com/doc/current/contributing/index.html) and [Sylius](http://sylius.org) project, as such much of this info will look familiar as it embodies current best practices.
+
+* [Reporting a bug or a security issue](./docs/07-01-reporting-issues.md)
+* [Submitting pull requests](./docs/07-02-pull-requests.md)
+* [Coding standards](./docs/07-03-coding-standards.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+| Q             | A
+| ------------- | ---
+| Bug fix?      | yes|no
+| New feature?  | yes|no
+| BC breaks?    | yes|no
+| Deprecations? | yes|no
+| Fixed tickets | comma separated list of tickets fixed by the PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-## Contribute
-
-We follow most of the procedures for contributions from the [Symfony](http://symfony.com/doc/current/contributing/index.html) and [Sylius](http://sylius.org) project, as such much of this info will look familiar as it embodies current best practices.
-
-* [Reporting a bug or a security issue](./docs/07-01-reporting-issues.md)
-* [Submitting pull requests](./docs/07-02-pull-requests.md)
-* [Coding standards](./docs/07-03-coding-standards.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Add the default github templates. (pull request template and issue template)
Move all github templates (including contributing guidelines) to a .github folder.