### PR TITLE
[AdminBundle] Added focus on sidebar search input when sidebar search is made visible

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_app-sidebar-search-focus.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_app-sidebar-search-focus.js
@@ -1,0 +1,27 @@
+var kunstmaanbundles = kunstmaanbundles || {};
+
+kunstmaanbundles.sidebarsearchfocus = (function(window, undefined) {
+
+    var init,
+    focus;
+
+    init = function() {
+        focus();
+    };
+
+    focus = function() {
+        var $toggleButton = $('.app__sidebar__search-toggle-btn'),
+            $searchInput = $('#app__sidebar__search');
+
+        $toggleButton.on('click touchstart mousedown', function(e) {
+            e.preventDefault();
+        }).on('touchend mouseup', function() {
+           $searchInput.focus();
+        });
+    };
+
+    return {
+        init: init
+    };
+
+})(window);

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
@@ -15,6 +15,7 @@ kunstmaanbundles.app = (function($, window, undefined) {
 
         kunstmaanbundles.sidebartoggle.init();
         kunstmaanbundles.sidebartree.init();
+        kunstmaanbundles.sidebarsearchfocus.init();
         kunstmaanbundles.filter.init();
         kunstmaanbundles.sortableTable.init();
         kunstmaanbundles.checkIfEdited.init();

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -19,6 +19,7 @@
     "@KunstmaanAdminBundle/Resources/ui/js/_app-loading.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-sidebar-tree.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-sidebar-toggle.js"
+    "@KunstmaanAdminBundle/Resources/ui/js/_app-sidebar-search-focus.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-main-actions.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-filter.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-sortable-table.js"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | |no
| Fixed tickets | 

This is done by the added js module. When search icon in sidebar is clicked, focus on input in the sidebar search is set on