### PR TITLE
[SearchBundle] Add basic auth support for Elasticsearch with shield plugin

### DIFF
--- a/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
+++ b/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
@@ -141,16 +141,24 @@ class ElasticaProvider implements SearchProviderInterface
 
     /**
      * @param string $host
-     * @param int    $port
+     * @param int $port
+     * @param string|null $username
+     * @param string|null $password
      */
-    public function addNode($host, $port)
+    public function addNode($host, $port, $username = null, $password = null)
     {
         foreach ($this->nodes as $node) {
             if ($node['host'] === $host && $node['port'] === $port) {
                 return;
             }
         }
-        $this->nodes[] = array('host' => $host, 'port' => $port);
+
+        $authHeader = null;
+        if (null !== $username && $password !== null) {
+            $authHeader = array('Authorization' => 'Basic ' . base64_encode($username . ':' . $password));
+        }
+
+        $this->nodes[] = array('host' => $host, 'port' => $port, 'headers' => $authHeader);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

To avoid BC breaks the username and password options are optional.
It's easy to add by overruling the default elastic search provider service.

```
kunstmaan_search.search_provider.elastica:
        class: '%kunstmaan_search.search_provider.elastica.class%'
        calls:
            - [ addNode, ['%kunstmaan_search.hostname%', '%kunstmaan_search.port%', '%kunstmaan_search.username%', '%kunstmaan_search.password%'] ]
        tags:
            - { name: kunstmaan_search.search_provider, alias: Elastica }
```

Password and username can be added as parameters.
