### PR TITLE
[AdminBundle]: add custom AclVoter

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionMap.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionMap.php
@@ -3,11 +3,13 @@
 namespace Kunstmaan\AdminBundle\Helper\Security\Acl\Permission;
 
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMapInterface;
+use Symfony\Component\Security\Acl\Permission\MaskBuilderInterface;
+use Symfony\Component\Security\Acl\Permission\MaskBuilderRetrievalInterface;
 
 /**
  * PermissionMap which stores all the possible permissions, this is based on the BasicPermissionMap
  */
-class PermissionMap implements PermissionMapInterface
+class PermissionMap implements PermissionMapInterface, MaskBuilderRetrievalInterface
 {
 
     const PERMISSION_VIEW       = 'VIEW';
@@ -77,5 +79,15 @@ class PermissionMap implements PermissionMapInterface
     public function getPossiblePermissions()
     {
         return array_keys($this->map);
+    }
+
+    /**
+     * Returns a new instance of the MaskBuilder used in the permissionMap.
+     *
+     * @return MaskBuilderInterface
+     */
+    public function getMaskBuilder()
+    {
+        return new MaskBuilder();
     }
 }

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kunstmaan\AdminBundle\Helper\Security\Acl\Voter;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
+use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Model\AclProviderInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Acl\Voter\AclVoter as BaseAclVoter;
+
+/**
+ * This voter can be used as a base class for implementing your own permissions.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class AclVoter extends BaseAclVoter
+{
+
+    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
+    {
+       parent::__construct($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap, $logger, $allowIfObjectIdentityUnavailable);
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -84,6 +84,15 @@ services:
     kunstmaan_admin.security.acl.permission.map:
         class: '%kunstmaan_admin.security.acl.permission.map.class%'
 
+    kunstmaan_admin.security.acl.voter:
+        class: Kunstmaan\AdminBundle\Helper\Security\Acl\Voter\AclVoter
+        arguments: ['@security.acl.provider', '@security.acl.object_identity_retrieval_strategy', '@security.acl.security_identity_retrieval_strategy', '@kunstmaan_admin.security.acl.permission.map']
+        tags:
+            - { name: security.voter, priority: 255 }
+            - { name: monolog.logger, channel: security }
+        # small performance boost
+        public: false
+
     kunstmaan_admin.permissionadmin:
         class: Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin
         arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.acl.provider', '@security.acl.object_identity_retrieval_strategy', '@event_dispatcher', '@kunstmaan_utilities.shell', '@kernel']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When upgrading to symfony 3, the custom acl permission map does not get called anymore. Therefore our permissions like Publish and Unpublish don't work anymore.

By adding a AclVoter we can provide our own permission map as an extension. As of symfony 3 there is also now the class AbstractMaskBuilder and MaskBuilderRetrievalInterface. We can remove our own methods and just extend these classes.

