### PR TITLE
[NodeBundle]: rewrite implementation for templatelistener

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -10,6 +10,7 @@ use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Event\SlugEvent;
 use Kunstmaan\NodeBundle\Event\SlugSecurityEvent;
 use Kunstmaan\NodeBundle\Helper\RenderContext;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,7 +108,10 @@ class SlugController extends Controller
             throw $this->createNotFoundException('No page found for slug ' . $url);
         }
 
-        $request->attributes->set('_template', $view);
+        $template = new Template(array());
+        $template->setTemplate($view);
+
+        $request->attributes->set('_template', $template);
 
         return $renderContext->getArrayCopy();
     }

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\Templating\EngineInterface;
@@ -85,7 +86,11 @@ class RenderContextListener
             //set the rendercontext with all params as response, plus the template in the request attribs
             //the SensioFrameworkExtraBundle kernel.view will handle everything else
             $event->setControllerResult((array) $parameters);
-            $request->attributes->set('_template', $entity->getDefaultView());
+
+            $template = new Template(array());
+            $template->setTemplate($entity->getDefaultView());
+
+            $request->attributes->set('_template', $template);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

As of version https://github.com/sensiolabs/SensioFrameworkExtraBundle/releases/tag/v3.0.13 of the SensioFrameworkExtraBundle, the TemplateListener has been changed.

Normally we could do the following where $view is the name of your twig template file.

 $request->attributes->set('_template', $view);

In the latest version we have to provide a template object. Therefore I added:

 $template = new Template(array());
 $template->setTemplate($view);
 
 $request->attributes->set('_template', $template);

