### PR TITLE
[GeneratorBundle]: Upgrade error layout skeleton: Remove deleted js twig

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Error/layout.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Error/layout.html.twig
@@ -19,9 +19,6 @@
 
     {# CSS #}
     {% include '<%= bundle.getName() %>:Layout:_css.html.twig' %}
-
-    {# JS #}
-    {% include '<%= bundle.getName() %>:Layout:_js_header.html.twig' %}
 </head>
 
 <body class="{% block extra_body_classes %}<% if demosite %>emulate-pulldown<% endif %>{% endblock %}" {% block extra_body_attributes %}{% endblock %}>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Dries Beerten deleted the `_js_header.html.twig` file in `1f099dd8e40750f290982b8ae7fd3ca575e6a59b` commit, but didn't remove this file from `Error/layout` only `Layout/layout`.