### PR TITLE
[WIP] [AdminBundle] Auto Google SignIn with Guard

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/OAuthController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/OAuthController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Controller;
+
+
+class OAuthController
+{
+    public function checkAction()
+    {
+        throw new \RuntimeException('You must configure the check path to be handled by the firewall using guard component in your security firewall configuration.');
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -54,6 +54,15 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('google_signin')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultFalse()->end()
+                        ->scalarNode('client_id')->isRequired()->end()
+                        ->scalarNode('client_secret')->isRequired()->end()
+                        ->scalarNode('hosted_domain')->isRequired()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -50,6 +50,11 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_admin.session_security.ip_check', $config['session_security']['ip_check']);
         $container->setParameter('kunstmaan_admin.session_security.user_agent_check', $config['session_security']['user_agent_check']);
 
+        $container->setParameter('kunstmaan_admin.google_signin.enabled', $config['google_signin']['enabled']);
+        $container->setParameter('kunstmaan_admin.google_signin.client_id', $config['google_signin']['client_id']);
+        $container->setParameter('kunstmaan_admin.google_signin.client_secret', $config['google_signin']['client_secret']);
+        $container->setParameter('kunstmaan_admin.google_signin.hosted_domain', $config['google_signin']['hosted_domain']);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 

--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -36,6 +36,11 @@ abstract class BaseUser extends AbstractUser
     protected $passwordChanged;
 
     /**
+     * @ORM\Column(name="google_id", type="string", length=255, nullable=true)
+     */
+    protected $googleId;
+
+    /**
      * Construct a new user
      */
     public function __construct()
@@ -144,6 +149,22 @@ abstract class BaseUser extends AbstractUser
         $this->passwordChanged = $passwordChanged;
 
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getGoogleId()
+    {
+        return $this->googleId;
+    }
+
+    /**
+     * @param mixed $googleId
+     */
+    public function setGoogleId($googleId)
+    {
+        $this->googleId = $googleId;
     }
 
     /**

--- a/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
@@ -47,3 +47,10 @@ fos_user_change_password:
     path: /admin/profile/change-password
     defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
     methods: [GET, POST]
+
+##########################
+## Google OAuth Sign In ##
+##########################
+KunstmaanAdminBundle_oauth_signin:
+    path: /admin/google_signin_check
+    defaults: { _controller: KunstmaanAdminBundle:OAuth:check }

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -179,3 +179,21 @@ services:
     kunstmaan_admin.domain_configuration:
         class: '%kunstmaan_admin.domain_configuration.class%'
         arguments: ['@service_container']
+
+    kunstmaan_admin.oauth_authenticator:
+        class: Kunstmaan\AdminBundle\Security\OAuthAuthenticator
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@router'
+            - '%kunstmaan_admin.google_signin.client_id%'
+            - '%kunstmaan_admin.google_signin.client_secret%'
+            - '%kunstmaan_admin.google_signin.hosted_domain%'
+
+    kunstmaan_admin.google_signin.twig.extension:
+        class: Kunstmaan\AdminBundle\Twig\GoogleSignInTwigExtension
+        arguments:
+            - '%kunstmaan_admin.google_signin.enabled%'
+            - '%kunstmaan_admin.google_signin.client_id%'
+            - '%kunstmaan_admin.google_signin.hosted_domain%'
+        tags:
+            - { name: twig.extension }

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_google_oauth.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_google_oauth.js
@@ -1,0 +1,68 @@
+var kunstmaanbundles = kunstmaanbundles || {};
+
+kunstmaanbundles.googleOAuth = (function($, window, undefined) {
+    //functions
+    var init,
+        attachSignin,
+        onSignIn,
+        onFailure,
+        onSignOut;
+
+    var auth2,
+        $input;
+
+    init = function(){
+        $input = $('#google_id_token');
+        if ($input.length) {
+            gapi.load('auth2', function() {
+                auth2 = gapi.auth2.init({
+                    client_id: $input.data('clientid'),
+                    scope: 'profile email',
+                    hosted_domain: $input.data('hosteddomain')
+                });
+
+                attachSignin(document.getElementById('app_oauth_signin'));
+            });
+
+            $('#app__logout').click(function(e){
+                e.preventDefault();
+                onSignOut();
+                window.location = $(this).attr('href');
+            });
+        }
+    };
+
+    attachSignin = function(element) {
+        auth2.attachClickHandler(element, {},
+            function(googleUser) {
+                onSignIn(googleUser);
+            },
+            function(error) {
+                onFailure();
+            });
+    };
+
+    onSignIn = function(googleUser){
+        var id_token = googleUser.getAuthResponse().id_token;
+        var $form = $('#app__login__form');
+        var path = $input.data('url');
+        $input.val(id_token);
+        $form.attr('action', path);
+        $form.submit();
+    };
+
+    onFailure = function(){
+        //TODO: Make error nicer
+        alert('It seems that you are not allowed to login with google on this website.');
+    };
+
+    onSignOut = function(){
+        auth2.signOut();
+    };
+
+    return {
+        init: init,
+        onSignIn: onSignIn
+    };
+
+})(jQuery, window);

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
@@ -40,6 +40,7 @@ kunstmaanbundles.app = (function($, window, undefined) {
         kunstmaanbundles.colorpicker.init();
         kunstmaanbundles.charactersLeft.init();
         kunstmaanbundles.rangeslider.init();
+        kunstmaanbundles.googleOAuth.init();
     };
 
 

--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/general/_login.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/general/_login.scss
@@ -109,3 +109,15 @@
         list-style: none;
     }
 }
+
+
+
+/* Google Sign in
+   ========================================================================== */
+#app_oauth_signin {
+    display: block;
+    width: 100%;
+    margin: 2rem 0 0;
+
+    text-align: center;
+}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -42,6 +42,7 @@
     "@KunstmaanAdminBundle/Resources/ui/js/_colorpicker.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_characters-left.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_input-range-slider.js"
+    "@KunstmaanAdminBundle/Resources/ui/js/_google_oauth.js"
     "@KunstmaanAdminBundle/Resources/ui/js/app.js"
     output="KunstmaanAdminBundleAssets/js/footer.min.js" filter="?uglifyjs2"
 %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -22,6 +22,8 @@
 
     <!-- JS -->
     {% include "@KunstmaanAdmin/Default/_js_header.html.twig" %}
+
+    <script src="https://apis.google.com/js/platform.js" async defer></script>
 </head>
 
 <body {% block extraparamsinbody %}{% endblock %} class="app {% block extrabodyclasses %}{% endblock %}" data-file-browse-url="{% if nodebundleisactive is defined and nodebundleisactive %}{{ path('KunstmaanNodeBundle_ckselecturl') }}{% endif %}" data-image-browse-url="{% if mediabundleisactive is defined %}{{ path('KunstmaanMediaBundle_chooser', {'type': 'image'}) }}{% endif %}">

--- a/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Security/login.html.twig
@@ -1,7 +1,10 @@
 {% extends "FOSUserBundle::layout.html.twig" %}
 
 {% block fos_user_content %}
-    <form action="{{ path("fos_user_security_check") }}" method="post">
+    <form id="app__login__form" action="{{ path("fos_user_security_check") }}" method="post">
+        {% if google_signin_enabled() %}
+        <input id="google_id_token" data-url="{{ path('KunstmaanAdminBundle_oauth_signin') }}" data-clientid="{{ google_signin_client_id() }}" data-hosteddomain="{{ google_signin_hosted_domain() }}" type="hidden" name="_google_id_token">
+        {% endif %}
         {% if error %}
             <div class="alert alert-danger">
                 Wrong password or email
@@ -38,4 +41,11 @@
             Log In
         </button>
     </form>
+
+    {% if google_signin_enabled() %}
+    <a href="#" id="app_oauth_signin">
+        <img src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png" alt="Google Sign in">
+    </a>
+    {% endif %}
+
 {% endblock fos_user_content %}

--- a/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
+++ b/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Security;
+
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Entity\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class OAuthAuthenticator extends AbstractGuardAuthenticator
+{
+    private $em;
+    private $router;
+    private $clientId;
+    private $clientSecret;
+    private $hostedDomain;
+
+    public function __construct(EntityManager $em, RouterInterface $router, $clientId, $clientSecret, $hostedDomain)
+    {
+        $this->em = $em;
+        $this->router = $router;
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->hostedDomain = $hostedDomain;
+    }
+
+    /**
+     * Returns a response that directs the user to authenticate.
+     *
+     * This is called when an anonymous request accesses a resource that
+     * requires authentication. The job of this method is to return some
+     * response that "helps" the user start into the authentication process.
+     *
+     * Examples:
+     *  A) For a form login, you might redirect to the login page
+     *      return new RedirectResponse('/login');
+     *  B) For an API token authentication system, you return a 401 response
+     *      return new Response('Auth header required', 401);
+     *
+     * @param Request $request The request that resulted in an AuthenticationException
+     * @param AuthenticationException $authException The exception that started the authentication process
+     *
+     * @return Response
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        return new RedirectResponse($this->router->generate('fos_user_security_login'));
+    }
+
+    /**
+     * Get the authentication credentials from the request and return them
+     * as any type (e.g. an associate array). If you return null, authentication
+     * will be skipped.
+     *
+     * Whatever value you return here will be passed to getUser() and checkCredentials()
+     *
+     * For example, for a form login, you might:
+     *
+     *      return array(
+     *          'username' => $request->request->get('_username'),
+     *          'password' => $request->request->get('_password'),
+     *      );
+     *
+     * Or for an API token that's on a header, you might use:
+     *
+     *      return array('api_key' => $request->headers->get('X-API-TOKEN'));
+     *
+     * @param Request $request
+     *
+     * @return mixed|null
+     */
+    public function getCredentials(Request $request)
+    {
+        if ($request->attributes->get('_route') != 'KunstmaanAdminBundle_oauth_signin' || !$request->request->has('_google_id_token')) {
+            return null;
+        }
+
+        $token = $request->request->get('_google_id_token');
+        return array(
+            'token' => $token,
+        );
+    }
+
+    /**
+     * Return a UserInterface object based on the credentials.
+     *
+     * The *credentials* are the return value from getCredentials()
+     *
+     * You may throw an AuthenticationException if you wish. If you return
+     * null, then a UsernameNotFoundException is thrown for you.
+     *
+     * @param mixed $credentials
+     * @param UserProviderInterface $userProvider
+     *
+     * @throws AuthenticationException
+     *
+     * @return UserInterface|null
+     */
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        $idToken = $credentials['token'];
+
+        $gc = new \Google_Client();
+        $gc->setClientId($this->clientId);
+        $gc->setClientSecret($this->clientSecret);
+        $ticket = $gc->verifyIdToken($idToken);
+        if (!$ticket instanceof \Google_LoginTicket) {
+            return null;
+        }
+        
+        $data = $ticket->getAttributes()['payload'];
+        $email = $data['email'];
+        $googleId = $data['sub'];
+
+        $user = $this->em->getRepository('KunstmaanAdminBundle:User')
+            ->findOneBy(array('googleId' => $googleId));
+
+        if (!$user instanceof User && preg_match('/'.$this->hostedDomain.'$/', $email)) {
+            $user = new User();
+            $user->setUsername($email);
+            $user->setEmail($email);
+            $user->setPlainPassword($googleId . $email . time());
+            $user->setEnabled(true);
+            $user->setLocked(false);
+            $user->setGoogleId($googleId);
+            $user->addRole('ROLE_SUPER_ADMIN');
+            $user->setAdminLocale('en');
+            $user->setPasswordChanged(true);
+
+            // Persist
+            $this->em->persist($user);
+            $this->em->flush();
+        }
+
+        return $user;
+    }
+
+    /**
+     * Returns true if the credentials are valid.
+     *
+     * If any value other than true is returned, authentication will
+     * fail. You may also throw an AuthenticationException if you wish
+     * to cause authentication to fail.
+     *
+     * The *credentials* are the return value from getCredentials()
+     *
+     * @param mixed $credentials
+     * @param UserInterface $user
+     *
+     * @return bool
+     *
+     * @throws AuthenticationException
+     */
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        return true;
+    }
+
+    /**
+     * Called when authentication executed, but failed (e.g. wrong username password).
+     *
+     * This should return the Response sent back to the user, like a
+     * RedirectResponse to the login page or a 403 response.
+     *
+     * If you return null, the request will continue, but the user will
+     * not be authenticated. This is probably not what you want to do.
+     *
+     * @param Request $request
+     * @param AuthenticationException $exception
+     *
+     * @return Response|null
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        return new RedirectResponse($this->router->generate('fos_user_security_login'));
+    }
+
+    /**
+     * Called when authentication executed and was successful!
+     *
+     * This should return the Response sent back to the user, like a
+     * RedirectResponse to the last page they visited.
+     *
+     * If you return null, the current request will continue, and the user
+     * will be authenticated. This makes sense, for example, with an API.
+     *
+     * @param Request $request
+     * @param TokenInterface $token
+     * @param string $providerKey The provider (i.e. firewall) key
+     *
+     * @return Response|null
+     */
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        return new RedirectResponse($this->router->generate('KunstmaanAdminBundle_homepage'));
+    }
+
+    /**
+     * Does this method support remember me cookies?
+     *
+     * Remember me cookie will be set if *all* of the following are met:
+     *  A) This method returns true
+     *  B) The remember_me key under your firewall is configured
+     *  C) The "remember me" functionality is activated. This is usually
+     *      done by having a _remember_me checkbox in your form, but
+     *      can be configured by the "always_remember_me" and "remember_me_parameter"
+     *      parameters under the "remember_me" firewall key
+     *
+     * @return bool
+     */
+    public function supportsRememberMe()
+    {
+        return false;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Twig/GoogleSignInTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/GoogleSignInTwigExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Twig;
+
+use Twig_Environment;
+use Twig_Extension;
+
+/**
+ * Class GoogleSignInTwigExtension
+ * @package Kunstmaan\AdminBundle\Twig
+ */
+class GoogleSignInTwigExtension extends Twig_Extension
+{
+    private $enabled;
+    private $clientId;
+    private $hostedDomain;
+
+    public function __construct($enabled, $clientId, $hostedDomain)
+    {
+        $this->enabled = $enabled;
+        $this->clientId = $clientId;
+        $this->hostedDomain = $hostedDomain;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('google_signin_enabled', array($this, 'isGoogleSignInEnabled')),
+            new \Twig_SimpleFunction('google_signin_client_id', array($this, 'getClientId')),
+            new \Twig_SimpleFunction('google_signin_hosted_domain', array($this, 'getHostedDomain'))
+        );
+    }
+
+    public function isGoogleSignInEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHostedDomain()
+    {
+        return $this->hostedDomain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'google_signin_twig_extension';
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Thanks to the hosted_domain option with Google SignIn you can now automatically login as an Admin with your email domain. You'll have to configure the ```google_signin``` in your ```config.yml``` options like this:

```yml
kunstmaan_admin:
    google_signin:
        enabled: true
        client_id: some_client_id.apps.googleusercontent.com
        client_secret: some_secret
        hosted_domain: kunstmaan.be
```

After that you only have to configure the ```guard``` component in the ```security.yml``` like so:
```yml
security:
    ...
    firewalls:
        main:
            pattern: .*
            guard:
                authenticators:
                    - kunstmaan_admin.oauth_authenticator
            form_login:
                login_path: fos_user_security_login
                check_path: fos_user_security_check
                provider: fos_userbundle
            ...
```

And then the login will look like this:

![screenshot 2016-03-05 13 45 12](https://cloud.githubusercontent.com/assets/360302/13547574/f1dc2d20-e2d8-11e5-8d6a-ecf8c62eb490.png)

