### PR TITLE
[GeneratorBundle] Spaceless fix

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/layout.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Layout/layout.html.twig
@@ -29,6 +29,7 @@
     {# CSS #}
     {% include '<%= shortBundleName %>/Layout/_css.html.twig' %}
 </head>
+{% endspaceless %}
 
 <body id="sidebar-toggle-container" class="sidebar-toggle-container{% block extra_body_classes %}{% endblock %}" {% block extra_body_attributes %}{% endblock %}>
 <% if demosite %>
@@ -87,4 +88,3 @@
 <% endif %>
 </body>
 </html>
-{% endspaceless %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The original version ignore the user created content! Eg: the user owner create a text page part with the following content:

```
<strong>Strong</strong> <u>underline</u> <em>other text</em>
```

The full page `{% spaceless %}` causes wrong "spaceless" output:

```
Strongunderlineother text
```

Other problem from twig documentation ( http://twig.sensiolabs.org/doc/tags/spaceless.html ):

> If you want to create a tag that actually removes all extra whitespace in an HTML string, be warned that this is not as easy as it seems to be (think of textarea or pre tags for instance). Using a third-party library like Tidy is probably a better idea.

The full layout "spacelessing" is a wrong way.