### PR TITLE
[AdminBundle] Change admin template extends

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_ckeditor_configs.html.twig
@@ -46,4 +46,4 @@
     };
 </script>
 
-{% include "KunstmaanAdminBundle:Default:_ckeditor_configs_extra.html.twig" %}
+{% include "@KunstmaanAdminBundle/Resources/views/Default/_ckeditor_configs_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_css.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_css.html.twig
@@ -30,4 +30,4 @@
     }
 </style>
 
-{% include "KunstmaanAdminBundle:Default:_css_extra.html.twig" %}
+{% include "@KunstmaanAdminBundle/Resources/views/Default/_css_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -1,4 +1,4 @@
-{% include "@KunstmaanAdmin/Default/_ckeditor_configs.html.twig" %}
+{% include "@KunstmaanAdminBundle/Resources/views/Default/_ckeditor_configs.html.twig" %}
 
 <script>
     CKEDITOR_BASEPATH = '/bundles/kunstmaanadmin/default-theme/ckeditor/';
@@ -56,4 +56,4 @@
     <script src="{{ asset_url }}"></script>
 {% endjavascripts %}
 
-{% include "@KunstmaanAdmin/Default/_js_footer_extra.html.twig" %}
+{% include "@KunstmaanAdminBundle/Resources/views/Default/_js_footer_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
@@ -1,1 +1,1 @@
-{% include "@KunstmaanAdmin/Default/_js_header_extra.html.twig" %}
+{% include "@KunstmaanAdminBundle/Resources/views/Default/_js_header_extra.html.twig" %}

--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
@@ -15,7 +15,7 @@
     <!-- Sortable container -->
     <div id="parts-{{ pagepartadmin.context }}" class="js-sortable-container sortable-container" data-scope="{% spaceless %}{% for type in pagepartadmin.possiblePagePartTypes %}{{ type.class|replace({'\\':""})~' ' }}{% endfor %}{% endspaceless %}">
         {% for id, pagepart in pagepartadmin.pagepartmap %}
-            {% include '@KunstmaanPagePart/PagePartAdminTwigExtension/pagepart.html.twig' with { 'id': id, 'pagepartadmin': pagepartadmin, 'editmode': false} %}
+            {% include '@KunstmaanPagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig' with { 'id': id, 'pagepartadmin': pagepartadmin, 'editmode': false} %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #683

The overriding of resources only works when you refer to resources with the @KunstmaanAdminBundle/Resources/views/Default/_js_header_extra.html.twig method. If you refer to resources without using the @BundleName shortcut, they can't be overridden in this way.
