### PR TITLE
[MediaBundle] Fixed image cache path

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
@@ -31,7 +31,8 @@ class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
      */
     public function getBrowserPath($path, $filter, array $runtimeConfig = array(), $resolver = null)
     {
-        $info = pathinfo($path);
+        $infoPath = parse_url($path, PHP_URL_PATH);
+        $info = pathinfo($infoPath);
         $url = parent::getBrowserPath($path, $filter, $runtimeConfig, $resolver);
         $newPath = parse_url($url, PHP_URL_PATH);
         $newInfo = pathinfo($newPath);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The assets version from app/config/config.yml will also be append to image urls. The extension will then be jpg?v1 which won't work for the cache resolver.

