### PR TITLE
[MediaBundle] Added extensionless file upload

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -167,9 +167,14 @@ class FileHandler extends AbstractMediaHandler
         }
         if ($content instanceof UploadedFile) {
             $pathInfo = pathinfo($content->getClientOriginalName());
-            $media->setOriginalFilename($this->slugifier->slugify($pathInfo['filename']).'.'.$pathInfo['extension']);
-            $name = $media->getName();
-            if (empty($name)) {
+
+            if(isset($pathInfo['extension'])){
+                $originalFileName = sprintf('%s.%s', $this->slugifier->slugify($pathInfo['filename']), $pathInfo['extension']);
+            } else {
+                $originalFileName = $this->slugifier->slugify($pathInfo['filename']);
+            }
+            $media->setOriginalFilename($originalFileName);
+            if (empty($media->getName())) {
                 $media->setName($media->getOriginalFilename());
             }
         }
@@ -237,7 +242,10 @@ class FileHandler extends AbstractMediaHandler
 
         $parts    = pathinfo($filename);
         $filename = $this->slugifier->slugify($parts['filename']);
-        $filename .= '.'.strtolower($parts['extension']);
+        if(isset($parts['extension'])){
+            $filename .= '.'.strtolower($parts['extension']);
+        }
+
 
         return sprintf(
             '%s/%s',

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
@@ -35,11 +35,12 @@ class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
         $url = parent::getBrowserPath($path, $filter, $runtimeConfig, $resolver);
         $newPath = parse_url($url, PHP_URL_PATH);
         $newInfo = pathinfo($newPath);
-        if ($info['extension'] != $newInfo['extension']) {
-            $query = parse_url($url, PHP_URL_QUERY);
-            $url .= ($query ? '&' : '?') . 'originalExtension=' . $info['extension'];
+        if(isset($info['extension']) && isset($newInfo['extension'])){
+            if ($info['extension'] != $newInfo['extension']) {
+                $query = parse_url($url, PHP_URL_QUERY);
+                $url .= ($query ? '&' : '?') . 'originalExtension=' . $info['extension'];
+            }
         }
-
         return $url;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no

Users should be able to upload extension-less files in case when exporting a media file without extension.
As there is no visual error handling for this, we should just check for it inside the backend and allow it.
