### PR TITLE
[FormBundle]: change bound to submitted

### DIFF
--- a/src/Kunstmaan/FormBundle/Resources/views/CheckboxPagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/CheckboxPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
 {% endif %}

--- a/src/Kunstmaan/FormBundle/Resources/views/ChoicePagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/ChoicePagePart/view.html.twig
@@ -1,4 +1,4 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
     {{ form_errors(frontendform['formwidget_'~resource.uniqueId]) }}
 {% endif %}

--- a/src/Kunstmaan/FormBundle/Resources/views/EmailPagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/EmailPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
 {% endif %}

--- a/src/Kunstmaan/FormBundle/Resources/views/FileUploadPagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/FileUploadPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
 {% endif %}

--- a/src/Kunstmaan/FormBundle/Resources/views/MultiLineTextPagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/MultiLineTextPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
 {% endif %}

--- a/src/Kunstmaan/FormBundle/Resources/views/SingleLineTextPagePart/view.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/SingleLineTextPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if frontendform is defined %}
-    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.bound } }) }}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

In symfony 3 the method bound is deprecated, we need to replace it with the submitted function.

