### PR TITLE
[Global] Add flash and modal translations

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Controller;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Kunstmaan\AdminBundle\Form\DashboardConfigurationType;
 use Kunstmaan\AdminBundle\Entity\DashboardConfiguration;
@@ -68,7 +69,10 @@ class DefaultController extends Controller
             if ($form->isValid()) {
                 $em->persist($dashboardConfiguration);
                 $em->flush($dashboardConfiguration);
-                $this->get('session')->getFlashBag()->add('success', 'The welcome page has been edited!');
+                $this->get('session')->getFlashBag()->add(
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_admin.edit.flash.success')
+                );
 
                 return new RedirectResponse($this->generateUrl('KunstmaanAdminBundle_homepage'));
             }

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -3,13 +3,13 @@
 namespace Kunstmaan\AdminBundle\EventListener;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Routing\RouterInterface as Router;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * PasswordCheckListener to check if the user has to change his password
@@ -37,17 +37,18 @@ class PasswordCheckListener
     private $session;
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     private $translator;
 
     /**
-     * @param AuthorizationCheckerInterface  $authorizationChecker
-     * @param TokenStorageInterface          $tokenStorage
-     * @param Router                         $router
-     * @param Session                        $session
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param TokenStorageInterface $tokenStorage
+     * @param Router $router
+     * @param Session $session
+     * @param TranslatorInterface $translator
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, Translator $translator)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, TranslatorInterface $translator)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\AdminBundle\EventListener;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Routing\RouterInterface as Router;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -35,17 +37,23 @@ class PasswordCheckListener
     private $session;
 
     /**
+     * @var Translator
+     */
+    private $translator;
+
+    /**
      * @param AuthorizationCheckerInterface  $authorizationChecker
      * @param TokenStorageInterface          $tokenStorage
      * @param Router                         $router
      * @param Session                        $session
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, Translator $translator)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
         $this->router = $router;
         $this->session = $session;
+        $this->translator = $translator;
     }
 
     /**
@@ -60,7 +68,10 @@ class PasswordCheckListener
                 $user = $this->tokenStorage->getToken()->getUser();
                 if ($user->isPasswordChanged() === false) {
                     $response = new RedirectResponse($this->router->generate('fos_user_change_password'));
-                    $this->session->getFlashBag()->add('error', 'Your password has not yet been changed');
+                    $this->session->getFlashBag()->add(
+                        FlashTypes::ERROR,
+                        $this->translator->trans('kuma_admin.password_check.flash.error')
+                    );
                     $event->setResponse($response);
                 }
             }

--- a/src/Kunstmaan/AdminBundle/FlashMessages/FlashTypes.php
+++ b/src/Kunstmaan/AdminBundle/FlashMessages/FlashTypes.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\FlashMessages;
+
+/**
+ * Class FlashTypes
+ *
+ * Enabled flash types.
+ *
+ * @package Kunstmaan\AdminBundle\FlashMessages
+ */
+class FlashTypes
+{
+    const SUCCESS = 'success';
+    const ERROR = 'error';
+    const WARNING = 'warning';
+
+    const INFO = 'info';
+    const DANGER = 'danger';
+}

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -166,7 +166,7 @@ services:
 
     kunstmaan_admin.password_check.listener:
         class: '%kunstmaan_admin.password_check.listener.class%'
-        arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session']
+        arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session', '@translator']
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 1 }
 

--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
@@ -88,12 +88,32 @@ errors:
         invalid: You are not able to login to Google OAuth, your domain name is probably not allowed.
 
 kuma_admin:
+    flash_type:
+        success: Success
+        warning: Warning
+        error:   Error
+        info:    Info
+        danger:  Danger
     dashboard:
         configuration:
             title:
                 label: Title
             content:
                 label: Content (raw html)
+    edit:
+        flash:
+            success: The welcome page has been edited!
+    password_check:
+        flash:
+            error: Your password has not yet been changed
+    ga_ajax_controller:
+        flash:
+            success: Succesfully saved!
+    media:
+        flash:
+            'deleted_success.%medianame%': Entry '%medianame%' has been deleted!
+            drop_success:       File was uploaded successfuly!
+            drop_unrecognized:  Could not recognize what you dropped!
 
 kuma_js:
     auto_collapse:

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/flashmessages.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/flashmessages.html.twig
@@ -4,7 +4,7 @@
             <button type="button" class="close" data-dismiss="alert">
                 <i class="fa fa-times"></i>
             </button>
-            <strong>{{ flashMessageType | capitalize }}:</strong> {{ flashMessage|trans }}
+            <strong>{{ 'kuma_admin.flash_type.' ~ flashMessageType | trans }}:</strong> {{ flashMessage|trans }}
         </div>
     {% endfor %}
 {% endfor %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/flashmessages.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/flashmessages.html.twig
@@ -4,7 +4,7 @@
             <button type="button" class="close" data-dismiss="alert">
                 <i class="fa fa-times"></i>
             </button>
-            <strong>{{ 'kuma_admin.flash_type.' ~ flashMessageType | trans }}:</strong> {{ flashMessage|trans }}
+            <strong>{{ ('kuma_admin.flash_type.' ~ flashMessageType) | trans }}:</strong> {{ flashMessage|trans }}
         </div>
     {% endfor %}
 {% endfor %}

--- a/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
+++ b/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Security;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,19 +20,19 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
 {
     /** @var RouterInterface */
     private $router;
-    
+
     /** @var Session */
     private $session;
-    
+
     /** @var DataCollectorTranslator */
     private $translator;
 
     /** @var OAuthUserCreator */
     private $oAuthUserCreator;
-    
+
     /** @var string */
     private $clientId;
-    
+
     /** @var string */
     private $clientSecret;
 
@@ -182,7 +183,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $this->session->getFlashBag()->add('error', $this->translator->trans('errors.oauth.invalid'));
+        $this->session->getFlashBag()->add(FlashTypes::ERROR, $this->translator->trans('errors.oauth.invalid'));
         return new RedirectResponse($this->router->generate('fos_user_security_login'));
     }
 

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Kunstmaan\DashboardBundle\Controller;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsGoal;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
@@ -216,8 +217,8 @@ class GoogleAnalyticsAJAXController extends Controller
         $em->flush();
 
         $this->get('session')->getFlashBag()->add(
-            'success',
-            'Succesfully saved!'
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_admin.ga_ajax_controller.flash.success')
         );
 
         return new JsonResponse();

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\MediaBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\MediaBundle\AdminList\MediaAdminListConfigurator;
 use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Form\FolderType;
@@ -70,7 +71,7 @@ class FolderController extends Controller
                 $em->getRepository('KunstmaanMediaBundle:Folder')->save($folder);
 
                 $this->get('session')->getFlashBag()->add(
-                    'success',
+                    FlashTypes::SUCCESS,
                     $this->get('translator')->trans('media.folder.show.success.text', array('%folder%' => $folder->getName()))
                 );
 
@@ -114,12 +115,12 @@ class FolderController extends Controller
 
         if (is_null($parentFolder)) {
             $this->get('session')->getFlashBag()->add(
-                'failure',
+                FlashTypes::ERROR,
                 $this->get('translator')->trans('media.folder.delete.failure.text', array('%folder%' => $folder->getName()))
             );
         } else {
             $em->getRepository('KunstmaanMediaBundle:Folder')->delete($folder);
-            $this->get('session')->getFlashBag()->add('success', $this->get('translator')->trans('media.folder.delete.success.text', array('%folder%' => $folder->getName())));
+            $this->get('session')->getFlashBag()->add(FlashTypes::SUCCESS, $this->get('translator')->trans('media.folder.delete.success.text', array('%folder%' => $folder->getName())));
             $folderId = $parentFolder->getId();
         }
         if (strpos($_SERVER['HTTP_REFERER'],'chooser')) {
@@ -163,7 +164,7 @@ class FolderController extends Controller
             if ($form->isValid()) {
                 $em->getRepository('KunstmaanMediaBundle:Folder')->save($folder);
                 $this->get('session')->getFlashBag()->add(
-                    'success',
+                    FlashTypes::SUCCESS,
                     $this->get('translator')->trans('media.folder.addsub.success.text', array('%folder%' => $folder->getName()))
                 );
                 if (strpos($_SERVER['HTTP_REFERER'],'chooser') !== false) {
@@ -226,7 +227,7 @@ class FolderController extends Controller
                 $em->getRepository('KunstmaanMediaBundle:Folder')->emptyFolder($folder, $alsoDeleteFolders);
 
                 $this->get('session')->getFlashBag()->add(
-                    'success',
+                    FlashTypes::SUCCESS,
                     $this->get('translator')->trans('media.folder.empty.success.text', array('%folder%' => $folder->getName()))
                 );
                 if (strpos($_SERVER['HTTP_REFERER'],'chooser') !== false) {

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Controller;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
@@ -91,7 +92,10 @@ class MediaController extends Controller
 
         $em->getRepository('KunstmaanMediaBundle:Media')->delete($media);
 
-        $this->get('session')->getFlashBag()->add('success', 'Entry \'' . $medianame . '\' has been deleted!');
+        $this->get('session')->getFlashBag()->add(
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_admin.media.flash.deleted_success.%medianame%', ['%medianame%' => $medianame])
+        );
 
         // If the redirect url is passed via the url we use it
         $redirectUrl = $request->query->get('redirectUrl');
@@ -303,8 +307,8 @@ class MediaController extends Controller
 
         if (array_key_exists('files', $_FILES) && $_FILES['files']['error'] === 0) {
             $drop = $request->files->get('files');
-	} else if ($request->files->get('file')) {
-	    $drop = $request->files->get('file');
+        } else if ($request->files->get('file')) {
+            $drop = $request->files->get('file');
         } else {
             $drop = $request->get('text');
         }
@@ -313,12 +317,15 @@ class MediaController extends Controller
             $media->setFolder($folder);
             $em->getRepository('KunstmaanMediaBundle:Media')->save($media);
 
-            return new Response(json_encode(array('status' => 'File was uploaded successfuly!')));
+            return new Response(json_encode(array('status' => $this->get('translator')->trans('kuma_admin.media.flash.drop_success'))));
         }
 
-	$request->getSession()->getFlashBag()->add('danger', 'Could not recognize what you dropped!');
+        $request->getSession()->getFlashBag()->add(
+            FlashTypes::DANGER,
+            $this->get('translator')->trans('kuma_admin.media.flash.drop_unrecognized')
+        );
 
-        return new Response(json_encode(array('status' => 'Could not recognize anything!')));
+        return new Response(json_encode(array('status' => $this->get('translator')->trans('kuma_admin.media.flash.drop_unrecognized'))));
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -2,7 +2,9 @@
 
 namespace Kunstmaan\MultiDomainBundle\EventListener;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -16,19 +18,27 @@ class HostOverrideListener
     protected $session;
 
     /**
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
      * @var DomainConfigurationInterface
      */
     protected $domainConfiguration;
 
     /**
      * @param Session                      $session
+     * @param Translator                   $translator
      * @param DomainConfigurationInterface $domainConfiguration
      */
     public function __construct(
         Session $session,
+        Translator $translator,
         DomainConfigurationInterface $domainConfiguration
     ) {
         $this->session             = $session;
+        $this->translator          = $translator;
         $this->domainConfiguration = $domainConfiguration;
     }
 
@@ -58,8 +68,8 @@ class HostOverrideListener
         if ($request->getHost() !== $this->domainConfiguration->getHost()) {
             // Add flash message for admin pages
             $this->session->getFlashBag()->add(
-                'warning',
-                'multi_domain.host_override_active'
+                FlashTypes::WARNING,
+                $this->translator->trans('multi_domain.host_override_active')
             );
         }
     }

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -4,11 +4,11 @@ namespace Kunstmaan\MultiDomainBundle\EventListener;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class HostOverrideListener
 {
@@ -18,7 +18,7 @@ class HostOverrideListener
     protected $session;
 
     /**
-     * @var Translator
+     * @var TranslatorInterface
      */
     protected $translator;
 
@@ -29,12 +29,12 @@ class HostOverrideListener
 
     /**
      * @param Session                      $session
-     * @param Translator                   $translator
+     * @param TranslatorInterface          $translator
      * @param DomainConfigurationInterface $domainConfiguration
      */
     public function __construct(
         Session $session,
-        Translator $translator,
+        TranslatorInterface $translator,
         DomainConfigurationInterface $domainConfiguration
     ) {
         $this->session             = $session;

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -16,7 +16,7 @@ services:
 
     kunstmaan_multi_domain.host_override_listener:
         class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
-        arguments: ['@session', '@kunstmaan_admin.domain_configuration']
+        arguments: ['@session', '@translator', '@kunstmaan_admin.domain_configuration']
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 

--- a/src/Kunstmaan/MultiDomainBundle/Tests/EventListener/HostOverrideListenerTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/EventListener/HostOverrideListenerTest.php
@@ -154,8 +154,11 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
         $domainConfiguration = $this->getMock('Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface');
         $domainConfiguration->method('getHost')
             ->willReturn('override-domain.tld');
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator->method('trans')
+            ->willReturnArgument(0);
 
-        $listener = new HostOverrideListener($session, $domainConfiguration);
+        $listener = new HostOverrideListener($session, $translator, $domainConfiguration);
 
         return $listener;
     }

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\NodeBundle\Controller;
 use DateTime;
 use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\AdminBundle\Entity\EntityInterface;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\NodeBundle\Event\RecopyPageTranslationNodeEvent;
 use Kunstmaan\NodeBundle\Form\NodeMenuTabTranslationAdminType;
 use Kunstmaan\NodeBundle\Form\NodeMenuTabAdminType;
@@ -312,16 +313,16 @@ class NodeAdminController extends Controller
                 $date
             );
             $this->get('session')->getFlashBag()->add(
-                'success',
-                'Publishing of the page has been scheduled'
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_node.admin.publish.flash.success_scheduled')
             );
         } else {
             $this->get('kunstmaan_node.admin_node.publisher')->publish(
                 $nodeTranslation
             );
             $this->get('session')->getFlashBag()->add(
-                'success',
-                'The page has been published'
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_node.admin.publish.flash.success_published')
             );
         }
 
@@ -354,10 +355,16 @@ class NodeAdminController extends Controller
         if ($request->get('unpub_date')) {
             $date = new \DateTime($request->get('unpub_date') . ' ' . $request->get('unpub_time'));
             $this->get('kunstmaan_node.admin_node.publisher')->unPublishLater($nodeTranslation, $date);
-            $this->get('session')->getFlashBag()->add('success', 'Unpublishing of the page has been scheduled');
+            $this->get('session')->getFlashBag()->add(
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_node.admin.unpublish.flash.success_scheduled')
+            );
         } else {
             $this->get('kunstmaan_node.admin_node.publisher')->unPublish($nodeTranslation);
-            $this->get('session')->getFlashBag()->add('success', 'The page has been unpublished');
+            $this->get('session')->getFlashBag()->add(
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_node.admin.unpublish.flash.success_unpublished')
+            );
         }
 
         return $this->redirect($this->generateUrl('KunstmaanNodeBundle_nodes_edit', array('id' => $node->getId())));
@@ -387,7 +394,10 @@ class NodeAdminController extends Controller
         $nodeTranslation = $node->getNodeTranslation($this->locale, true);
         $this->get('kunstmaan_node.admin_node.publisher')->unSchedulePublish($nodeTranslation);
 
-        $this->get('session')->getFlashBag()->add('success', 'The scheduling has been canceled');
+        $this->get('session')->getFlashBag()->add(
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_node.admin.unschedule.flash.success')
+        );
 
         return $this->redirect($this->generateUrl('KunstmaanNodeBundle_nodes_edit', array('id' => $id)));
     }
@@ -442,7 +452,10 @@ class NodeAdminController extends Controller
             $response   = new RedirectResponse($url);
         }
 
-        $this->get('session')->getFlashBag()->add('success', 'The page is deleted!');
+        $this->get('session')->getFlashBag()->add(
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_node.admin.delete.flash.success')
+        );
 
         return $response;
     }
@@ -510,7 +523,10 @@ class NodeAdminController extends Controller
 
         $this->updateAcl($originalNode, $nodeNewPage);
 
-        $this->get('session')->getFlashBag()->add('success', 'The page has been duplicated!');
+        $this->get('session')->getFlashBag()->add(
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_node.admin.duplicate.flash.success')
+        );
 
         return $this->redirect(
             $this->generateUrl('KunstmaanNodeBundle_nodes_edit', array('id' => $nodeNewPage->getId()))
@@ -587,7 +603,10 @@ class NodeAdminController extends Controller
             )
         );
 
-        $this->get('session')->getFlashBag()->add('success', 'The page contents has been reverted');
+        $this->get('session')->getFlashBag()->add(
+            FlashTypes::SUCCESS,
+            $this->get('translator')->trans('kuma_node.admin.revert.flash.success')
+        );
 
         return $this->redirect(
             $this->generateUrl(
@@ -993,8 +1012,8 @@ class NodeAdminController extends Controller
                 );
 
                 $this->get('session')->getFlashBag()->add(
-                    'success',
-                    'The page has been edited'
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_node.admin.edit.flash.success')
                 );
 
                 $params = array(
@@ -1196,7 +1215,7 @@ class NodeAdminController extends Controller
         if (is_string($title) && !empty($title)) {
             $newPage->setTitle($title);
         } else {
-            $newPage->setTitle('New page');
+            $newPage->setTitle($this->get('translator')->trans('kuma_node.admin.new_page.title.default'));
         }
         $this->em->persist($newPage);
         $this->em->flush();

--- a/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
@@ -58,8 +59,8 @@ class NodeTranslationListener
         $this->slugifier           = $slugifier;
         $this->domainConfiguration = $domainConfiguration;
     }
-    
-    public function setRequestStack(RequestStack $requestStack) 
+
+    public function setRequestStack(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }
@@ -340,7 +341,7 @@ class NodeTranslationListener
         } elseif (count($flashes) > 0 && $this->isInRequestScope()) {
             // No translations found so we're certain we can show this message.
             $flash = current(array_slice($flashes, -1));
-            $this->session->getFlashBag()->add('warning', $flash);
+            $this->session->getFlashBag()->add(FlashTypes::WARNING, $flash);
         }
 
         return true;
@@ -374,9 +375,9 @@ class NodeTranslationListener
             return $string.$append.'1';
         }
     }
-    
+
     private function isInRequestScope()
     {
-        return $this->requestStack && $this->requestStack->getCurrentRequest();        
+        return $this->requestStack && $this->requestStack->getCurrentRequest();
     }
 }

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
@@ -49,6 +49,33 @@ kuma_node:
         online_public.raw:                  Online / Public version
         offline.raw:                        Offline
         "go_to_draft_version.%url%.raw":    (Go to <a href="%url%">draft version</a>)
+    admin:
+        publish:
+            flash:
+                success_published: The page has been published
+                success_scheduled: Publishing of the page has been scheduled
+        unpublish:
+            flash:
+                success_unpublished: The page has been unpublished
+                success_scheduled: Unpublishing of the page has been scheduled
+        unschedule:
+            flash:
+                success: The scheduling has been canceled
+        delete:
+            flash:
+                success: The page is deleted!
+        duplicate:
+            flash:
+                success: The page has been duplicated!
+        revert:
+            flash:
+                success: The page contents has been reverted
+        edit:
+            flash:
+                success: The page has been edited
+        new_page:
+            title:
+                default: New page
 
     tab:
         properties:

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
@@ -99,3 +99,58 @@ kuma_node:
                     label: Add
                 cancel:
                     label: Cancel
+        unpublish:
+            title:          Unpublish
+            body:           Are you sure you want to unpublish this page? If you do this, the page will be offline!
+            later:
+                label:      Unpublish later
+                button:     Unpublish later
+                cancel:     Cancel
+            now:
+                button:     Unpublish
+                cancel:     Cancel
+        publish:
+            title:          Publish
+            body:           Are you sure you want to publish this page? If you do this, the page will be online!
+            later:
+                label:      Publish later
+                button:     Publish later
+                cancel:     Cancel
+            now:
+                button:     Unpublish
+                cancel:     Cancel
+        versions:
+            title:          Versions
+            table:
+                type:       Type
+                last_modified:  Last modified
+                user:       User
+                actions:    Actions
+            actions:
+                preview:    Preview
+                revert:     Revert
+        add_subpage:
+            title:          Add subpage
+            label:
+                title:      Title
+                type:       Type
+            button:
+                add:        Add
+                cancel:     Cancel
+        delete_page:
+            'title.%page%': Delete page '%page%'
+            'body.%page%':  This will remove the page completely! Are you really sure about this?
+            button:
+                delete:     Delete
+                cancel:     Cancel
+        duplicate_page:
+            'title.%page%': Duplicate page '%page%'
+            label:
+                new_title:  New title
+            button:
+                duplicate:  Duplicate
+                cancel:     Cancel
+        recopyfromlanguage:
+            button:
+                copy:   Copy
+                cancel: Cancel

--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/_modals.html.twig
@@ -11,7 +11,7 @@
                     <i class="fa fa-times"></i>
                 </button>
                 <h3>
-                    Unpublish
+                    {{ 'kuma_node.modal.unpublish.title'|trans() }}
                 </h3>
             </div>
 
@@ -20,13 +20,13 @@
                 <!-- Body -->
                 <div class="modal-body">
                     <p>
-                        Are you sure you want to unpublish this page? If you do this, the page will be offline!
+                        {{ 'kuma_node.modal.unpublish.body'|trans() }}
                     </p>
 
                     <div class="form-group">
                         <label>
                             <input id="unpublish-later__check" type="checkbox">
-                            Unpublish later
+                            {{ 'kuma_node.modal.unpublish.later.label'|trans() }}
                         </label>
                     </div>
 
@@ -58,18 +58,18 @@
                 <div class="modal-footer">
                     <div id="unpublish-later-action" class="btn_group">
                         <button type="submit" id="unpub_publishlater_action" name="submit" class="btn btn-primary btn--raise-on-hover">
-                            Unpublish later
+                            {{ 'kuma_node.modal.unpublish.later.button'|trans() }}
                         </button>
                         <button type="button" class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
-                            Cancel
+                            {{ 'kuma_node.modal.unpublish.later.cancel'|trans() }}
                         </button>
                     </div>
                     <div id="unpublish-action" class="btn_group">
                         <a href="{{ path('KunstmaanNodeBundle_nodes_unpublish', { 'id': node.id}) }}" class="btn btn-danger btn--raise-on-hover">
-                            Unpublish
+                            {{ 'kuma_node.modal.unpublish.now.button'|trans() }}
                         </a>
                         <button type="button" class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
-                            Cancel
+                            {{ 'kuma_node.modal.unpublish.now.cancel'|trans() }}
                         </button>
                     </div>
                 </div>
@@ -90,7 +90,7 @@
                     <i class="fa fa-times"></i>
                 </button>
                 <h3>
-                    Publish
+                    {{ 'kuma_node.modal.publish.title'|trans() }}
                 </h3>
             </div>
 
@@ -99,13 +99,13 @@
                 <!-- Body -->
                 <div class="modal-body">
                     <p>
-                        Are you sure you want to publish this page? If you do this, the page will be online!
+                        {{ 'kuma_node.modal.publish.body'|trans() }}
                     </p>
 
                     <div class="form-group">
                         <label>
                             <input id="publish-later__check" type="checkbox">
-                            Publish later
+                            {{ 'kuma_node.modal.publish.later.label'|trans() }}
                         </label>
                     </div>
 
@@ -136,15 +136,19 @@
                 <div class="modal-footer">
                     <div id="publish-later-action">
                         <button type="submit" name="submit" class="btn btn-primary btn--raise-on-hover">
-                            Publish later
+                            {{ 'kuma_node.modal.publish.later.button'|trans() }}
                         </button>
-                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                            {{ 'kuma_node.modal.publish.later.cancel'|trans() }}
+                        </button>
                     </div>
                     <div id="publish-action">
                         <a href="{{ path('KunstmaanNodeBundle_nodes_publish', { 'id': node.id}) }}" class="btn btn-danger btn--raise-on-hover">
-                            Publish
+                            {{ 'kuma_node.modal.publish.now.button'|trans() }}
                         </a>
-                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                            {{ 'kuma_node.modal.publish.now.cancel'|trans() }}
+                        </button>
                     </div>
                 </div>
             </form>
@@ -163,7 +167,7 @@
                 <button class="close" data-dismiss="modal">
                     <i class="fa fa-times"></i>
                 </button>
-                <h3>Versions</h3>
+                <h3>{{ 'kuma_node.modal.versions.title'|trans() }}</h3>
             </div>
 
             <!-- Body -->
@@ -171,10 +175,10 @@
                 <table class="table table-bordered table-striped">
                     <thead>
                     <tr>
-                        <th>Type</th>
-                        <th>Last modified</th>
-                        <th>User</th>
-                        <th>Actions</th>
+                        <th>{{ 'kuma_node.modal.versions.table.type'|trans() }}</th>
+                        <th>{{ 'kuma_node.modal.versions.table.last_modified'|trans() }}</th>
+                        <th>{{ 'kuma_node.modal.versions.table.user'|trans() }}</th>
+                        <th>{{ 'kuma_node.modal.versions.table.actions'|trans() }}</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -187,12 +191,12 @@
                             <td class="table__actions">
                                 <a href="{{ path('_slug_preview', { 'url': nodeTranslation.url, 'version': nodeVersion.id }) }}" target="_blank" class="link--text table__actions__item table__actions__item--block">
                                     <i class="fa fa-eye"></i>
-                                    Preview
+                                    {{ 'kuma_node.modal.versions.actions.preview'|trans() }}
                                 </a>
                                 {% if (draftNodeVersion is null or nodeVersion.id != draftNodeVersion.id) and (publicVersion is null or nodeVersion.id != publicVersion.id) %}
                                     <a href="{{ path('KunstmaanNodeBundle_nodes_revert', { 'id': node.id, 'version': nodeVersion.id }) }}" class="link--text table__actions__item table__actions__item--block">
                                         <i class="fa fa-refresh"></i>
-                                        Revert
+                                        {{ 'kuma_node.modal.versions.actions.revert'|trans() }}
                                     </a>
                                 {% endif %}
                             </td>
@@ -218,7 +222,7 @@
                     <button class="close" data-dismiss="modal">
                         <i class="fa fa-times"></i>
                     </button>
-                    <h3>Add subpage</h3>
+                    <h3>{{ 'kuma_node.modal.add_subpage.title'|trans() }}</h3>
                 </div>
 
                 <form action="{{ path('KunstmaanNodeBundle_nodes_add', { 'id': node.id }) }}" method="post" novalidate="novalidate">
@@ -227,13 +231,13 @@
                     <div class="modal-body">
                         <div class="form-group">
                             <label for="addpage_title">
-                                Title
+                                {{ 'kuma_node.modal.add_subpage.label.title'|trans() }}
                             </label>
                             <input name="title" type="text" id="addpage_title" class="form-control">
                         </div>
                         <div class="form-group">
                             <label for="addpage_type">
-                                Type
+                                {{ 'kuma_node.modal.add_subpage.label.type'|trans() }}
                             </label>
                             <select name="type" id="addpage_type" class="form-control">
                                 {% for pageType in pagePossibleChildPages %}
@@ -245,8 +249,12 @@
 
                     <!-- Footer -->
                     <div class="modal-footer">
-                        <button type="submit" name="submit" class="btn btn-primary btn--raise-on-hover">Add</button>
-                        <button type="button" class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                        <button type="submit" name="submit" class="btn btn-primary btn--raise-on-hover">
+                            {{ 'kuma_node.modal.add_subpage.button.add'|trans() }}
+                        </button>
+                        <button type="button" class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                            {{ 'kuma_node.modal.add_subpage.button.cancel'|trans() }}
+                        </button>
                     </div>
                 </form>
             </div>
@@ -265,19 +273,23 @@
                 <button class="close" data-dismiss="modal">
                     <i class="fa fa-times"></i>
                 </button>
-                <h3>Delete page '{{ page.title }}'</h3>
+                <h3>{{ 'kuma_node.modal.delete_page.title.%page%'|trans({'%page%': page.title}) }}</h3>
             </div>
 
             <!-- Body -->
             <div class="modal-body">
-                <p>This will remove the page completely! Are you really sure about this?</p>
+                <p>{{ 'kuma_node.modal.delete_page.body.%page%'|trans({'%page%': page.title}) }}</p>
             </div>
 
             <!-- Footer -->
             <div class="modal-footer">
                 <form action="{{ path('KunstmaanNodeBundle_nodes_delete', { 'id': node.id }) }}" method="post" novalidate="novalidate">
-                    <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">Delete</button>
-                    <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                    <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">
+                        {{ 'kuma_node.modal.delete_page.button.delete'|trans() }}
+                    </button>
+                    <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                        {{ 'kuma_node.modal.delete_page.button.cancel'|trans() }}
+                    </button>
                 </form>
             </div>
         </div>
@@ -295,7 +307,7 @@
                 <button class="close" data-dismiss="modal">
                     <i class="fa fa-times"></i>
                 </button>
-                <h3>Duplicate page '{{ page.title }}'</h3>
+                <h3>{{ 'kuma_node.modal.duplicate_page.title.%page%'|trans({'%page%': page.title}) }}</h3>
             </div>
 
             <form action="{{ path('KunstmaanNodeBundle_nodes_duplicate', { 'id': node.id }) }}" method="post" novalidate="novalidate">
@@ -304,7 +316,7 @@
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="duplicatepage_title">
-                            New title
+                            {{ 'kuma_node.modal.duplicate_page.label.new_title'|trans() }}
                         </label>
                         <input name="title" type="text" id="title" class="form-control">
                     </div>
@@ -312,8 +324,12 @@
 
                 <!-- Footer -->
                 <div class="modal-footer">
-                    <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">Duplicate</button>
-                    <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                    <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">
+                        {{ 'kuma_node.modal.duplicate_page.button.duplicate'|trans() }}
+                    </button>
+                    <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                        {{ 'kuma_node.modal.duplicate_page.button.cancel'|trans() }}
+                    </button>
                 </div>
             </form>
         </div>
@@ -362,8 +378,12 @@
 
                     <!-- Footer -->
                     <div class="modal-footer">
-                        <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">Copy</button>
-                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+                        <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">
+                            {{ 'kuma_node.modal.recopyfromlanguage.button.copy'|trans() }}
+                        </button>
+                        <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">
+                            {{ 'kuma_node.modal.recopyfromlanguage.button.cancel'|trans() }}
+                        </button>
                     </div>
                 </form>
             </div>

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\SeoBundle\Controller\Admin;
 
 use Kunstmaan\AdminBundle\Controller\BaseSettingsController;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\SeoBundle\Entity\Robots;
 use Kunstmaan\SeoBundle\Form\RobotsType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -57,7 +58,7 @@ class SettingsController extends BaseSettingsController
 
         if (!$isSaved) {
             $warning = $this->get('translator')->trans('seo.robots.warning');
-            $this->get('session')->getFlashBag()->add('warning', $warning);
+            $this->get('session')->getFlashBag()->add(FlashTypes::WARNING, $warning);
         }
 
         return array(

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\TranslatorBundle\Controller;
 
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -16,7 +17,7 @@ class TranslatorCommandController extends Controller
     {
 
         $this->get('kunstmaan_translator.service.translator.resource_cacher')->flushCache();
-        $this->get('session')->getFlashBag()->add('success', 'All live translations are up to date.');
+        $this->get('session')->getFlashBag()->add(FlashTypes::SUCCESS, $this->get('translator')->trans('kuma_translator.command.clear.flash.success'));
 
         return new RedirectResponse($this->generateUrl('KunstmaanTranslatorBundle_settings_translations'));
     }
@@ -35,7 +36,7 @@ class TranslatorCommandController extends Controller
 
         $this->get('kunstmaan_translator.service.importer.command_handler')->executeImportCommand($importCommand);
 
-        $this->get('session')->getFlashBag()->add('success', 'Translations successfully imported, none existing translations were overwritten.');
+        $this->get('session')->getFlashBag()->add(FlashTypes::SUCCESS, $this->get('translator')->trans('kuma_translator.command.import.flash.success'));
 
         return new RedirectResponse($this->generateUrl('KunstmaanTranslatorBundle_settings_translations'));
     }
@@ -54,7 +55,7 @@ class TranslatorCommandController extends Controller
 
         $this->get('kunstmaan_translator.service.importer.command_handler')->executeImportCommand($importCommand);
 
-        $this->get('session')->getFlashBag()->add('success', 'Translations successfully imported, all existing translations were overwritten.');
+        $this->get('session')->getFlashBag()->add(FlashTypes::SUCCESS, $this->get('translator')->trans('kuma_translator.command.import.flash.force_success'));
 
         return new RedirectResponse($this->generateUrl('KunstmaanTranslatorBundle_settings_translations'));
     }

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\TranslatorBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractAdminListConfigurator;
 use Kunstmaan\TranslatorBundle\AdminList\TranslationAdminListConfigurator;
@@ -36,6 +37,7 @@ class TranslatorController extends AdminListController
      * @Template("KunstmaanTranslatorBundle:Translator:list.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return array
      */
     public function indexAction(Request $request)
     {
@@ -50,12 +52,12 @@ class TranslatorController extends AdminListController
 
         if (!$cacheFresh && !$debugMode) {
             $noticeText = $this->get('translator')->trans('settings.translator.not_live_warning');
-            $this->get('session')->getFlashBag()->add('notice', $noticeText);
+            $this->get('session')->getFlashBag()->add(FlashTypes::INFO, $noticeText);
         }
 
         return array(
-          'adminlist' => $adminList,
-          'adminlistconfigurator' => $configurator
+            'adminlist' => $adminList,
+            'adminlistconfigurator' => $configurator
         );
     }
 
@@ -103,7 +105,7 @@ class TranslatorController extends AdminListController
                 $em->flush();
 
                 $this->get('session')->getFlashBag()->add(
-                  'success',
+                  FlashTypes::SUCCESS,
                   $this->get('translator')->trans('settings.translator.succesful_added')
                 );
 
@@ -173,7 +175,7 @@ class TranslatorController extends AdminListController
                 $em->flush();
 
                 $this->get('session')->getFlashBag()->add(
-                  'success',
+                  FlashTypes::SUCCESS,
                   $this->get('translator')->trans('settings.translator.succesful_edited')
                 );
 

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -10,7 +10,6 @@ use Kunstmaan\TranslatorBundle\AdminList\TranslationAdminListConfigurator;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\TranslatorBundle\Form\TranslationAdminType;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,6 +20,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Translation\TranslatorInterface;
 
 
 class TranslatorController extends AdminListController
@@ -276,7 +276,7 @@ class TranslatorController extends AdminListController
         $id = isset($values['pk']) ? (int) $values['pk'] : 0;
         $em = $this->getDoctrine()->getManager();
         /**
-         * @var Translator $translator
+         * @var TranslatorInterface $translator
          */
         $translator = $this->get('translator');
 

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
@@ -35,3 +35,10 @@ kuma_translator:
             flash:
                 success:        Translations successfully imported, none existing translations were overwritten.
                 force_success:  Translations successfully imported, all existing translations were overwritten.
+    modal:
+        confirmation:
+            force_import:
+                title:  Are you sure you want to force an import?
+                body:   All existing translations will be overwritten.
+                confirm_button: Import
+                cancel_button:  Cancel

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
@@ -27,3 +27,11 @@ kuma_translator:
                 label:  Locale
             text:
                 label:  Text
+    command:
+        clear:
+            flash:
+                success:    All live translations are up to date.
+        import:
+            flash:
+                success:        Translations successfully imported, none existing translations were overwritten.
+                force_success:  Translations successfully imported, all existing translations were overwritten.

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Modals/_modals.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Modals/_modals.html.twig
@@ -10,19 +10,21 @@
         <button class="close" data-dismiss="modal">
             <i class="fa fa-times"></i>
         </button>
-        <h3>Are you sure you want to force an import?</h3>
+        <h3>{{ 'kuma_translator.modal.confirmation.force_import.title'|trans() }}</h3>
         </div>
 
         <!-- Body -->
         <div class="modal-body">
-            <p>All existing translations will be overwritten.</p>
+            <p>{{ 'kuma_translator.modal.confirmation.force_import.body'|trans() }}</p>
         </div>
         <!-- Footer -->
         <div class="modal-footer">
 
         <form action="{{ path('KunstmaanTranslatorBundle_command_import_forced') }}" method="post" novalidate="novalidate">
-            <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">Import</button>
-            <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">Cancel</button>
+            <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover"
+                >{{ 'kuma_translator.modal.confirmation.force_import.confirm_button'|trans() }}</button>
+            <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal"
+                >{{ 'kuma_translator.modal.confirmation.force_import.cancel_button'|trans() }}</button>
         </form>
         </div>
         </div>

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 
 use Kunstmaan\AdminBundle\Controller\BaseSettingsController;
 use Kunstmaan\AdminBundle\Entity\Role;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\RoleType;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\UserManagementBundle\AdminList\RoleAdminListConfigurator;
@@ -68,7 +69,10 @@ class RolesController extends BaseSettingsController
                 $em->persist($role);
                 $em->flush();
 
-                $this->get('session')->getFlashBag()->add('success', 'Role \''.$role->getRole().'\' has been created!');
+                $this->get('session')->getFlashBag()->add(
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_user.roles.add.flash.success.%role%', ['%role%' => $role->getRole()])
+                );
 
                 return new RedirectResponse($this->generateUrl('KunstmaanUserManagementBundle_settings_roles'));
             }
@@ -107,7 +111,10 @@ class RolesController extends BaseSettingsController
                 $em->persist($role);
                 $em->flush();
 
-                $this->get('session')->getFlashBag()->add('success', 'Role \''.$role->getRole().'\' has been edited!');
+                $this->get('session')->getFlashBag()->add(
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_user.roles.edit.flash.success.%role%', ['%role%' => $role->getRole()])
+                );
 
                 return new RedirectResponse($this->generateUrl('KunstmaanUserManagementBundle_settings_roles'));
             }
@@ -139,11 +146,14 @@ class RolesController extends BaseSettingsController
         /* @var Role $role */
         $role = $em->getRepository('KunstmaanAdminBundle:Role')->find($id);
         if (!is_null($role)) {
-            $rolename = $role->getRole();
+            $roleName = $role->getRole();
             $em->remove($role);
             $em->flush();
 
-            $this->get('session')->getFlashBag()->add('success', 'Role \''.$rolename.'\' has been deleted!');
+            $this->get('session')->getFlashBag()->add(
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_user.roles.delete.flash.success.%role%', ['%role%' => $roleName])
+            );
         }
 
         return new RedirectResponse($this->generateUrl('KunstmaanUserManagementBundle_settings_roles'));

--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -4,8 +4,10 @@ namespace Kunstmaan\UserManagementBundle\Controller;
 
 use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Controller\BaseSettingsController;
+use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\AdminBundle\Event\AdaptSimpleFormEvent;
 use Kunstmaan\AdminBundle\Event\Events;
+use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\RoleDependentUserFormInterface;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -109,8 +111,8 @@ class UsersController extends BaseSettingsController
                 $userManager->updateUser($user, true);
 
                 $this->get('session')->getFlashBag()->add(
-                    'success',
-                    'User \''.$user->getUsername().'\' has been created!'
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_user.users.add.flash.success.%username%', ['%username%' => $user->getUsername()])
                 );
 
                 return new RedirectResponse($this->generateUrl('KunstmaanUserManagementBundle_settings_users'));
@@ -178,8 +180,8 @@ class UsersController extends BaseSettingsController
                 $userManager->updateUser($user, true);
 
                 $this->get('session')->getFlashBag()->add(
-                    'success',
-                    'User \''.$user->getUsername().'\' has been edited!'
+                    FlashTypes::SUCCESS,
+                    $this->get('translator')->trans('kuma_user.users.edit.flash.success.%username%', ['%username%' => $user->getUsername()])
                 );
 
                 return new RedirectResponse(
@@ -226,7 +228,10 @@ class UsersController extends BaseSettingsController
             $username = $user->getUsername();
             $em->remove($user);
             $em->flush();
-            $this->get('session')->getFlashBag()->add('success', 'User \''.$username.'\' has been deleted!');
+            $this->get('session')->getFlashBag()->add(
+                FlashTypes::SUCCESS,
+                $this->get('translator')->trans('kuma_user.users.delete.flash.success.%username%', ['%username%' => $username])
+            );
         }
 
         return new RedirectResponse($this->generateUrl('KunstmaanUserManagementBundle_settings_users'));

--- a/src/Kunstmaan/UserManagementBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/translations/messages.en.yml
@@ -24,3 +24,25 @@ settings:
         role: Role
         add: Add Role
         edit: Edit Role
+
+kuma_user:
+    roles:
+        add:
+            flash:
+                'success.%role%': Role '%role%' has been created!
+        edit:
+            flash:
+                'success.%role%': Role '%role%' has been edited!
+        delete:
+            flash:
+                'success.%role%': Role '%role%' has been deleted!
+    users:
+        add:
+            flash:
+                'success.%username%': User '%username%' has been created!
+        edit:
+            flash:
+                'success.%username%': User '%username%' has been edited!
+        delete:
+            flash:
+                'success.%username%': User '%username%' has been deleted!


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Translate flash messages and add the `FlashTypes` to AdminBundle to prevent using invalid type (Eg: `notice`, there isn't `alarm-notice` class to format message)