### PR TITLE
[AdminListBundle]: form submit to form handlerequest

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -136,7 +136,7 @@ abstract class AdminListController extends Controller
                 $tabPane->bindRequest($request);
                 $form = $tabPane->getForm();
             } else {
-                $form->submit($request);
+                $form->handleRequest($request);
             }
 
             if ($form->isValid()) {
@@ -214,7 +214,7 @@ abstract class AdminListController extends Controller
                 $tabPane->bindRequest($request);
                 $form = $tabPane->getForm();
             } else {
-                $form->submit($request);
+                $form->handleRequest($request);
             }
 
             if ($form->isValid()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When submitting a form at an admin list, form submit should be replaced by handlerequest.

