### PR TITLE
[UserManagementBundle] workaround for custom user entity class

### DIFF
--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -85,7 +85,7 @@ class UsersController extends BaseSettingsController
         $this->checkPermission();
         $user = $this->getUserClassInstance();
 
-        $options = array('password_required' => true, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'), 'validation_groups' => array('Registration'));
+        $options = array('password_required' => true, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'), 'validation_groups' => array('Registration'), 'data_class' => get_class($user));
         $formTypeClassName = $user->getFormTypeClass();
         $formType = new $formTypeClassName();
 
@@ -148,7 +148,7 @@ class UsersController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
 
         $user = $em->getRepository($this->container->getParameter('fos_user.model.user.class'))->find($id);
-        $options = array('password_required' => false, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'));
+        $options = array('password_required' => false, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'), 'data_class' => get_class($user));
         $formFqn = $user->getFormTypeClass();
         $formType = new $formFqn();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Fixed tickets | ~

Fixes

> The form's view data is expected to be an instance of class Kunstmaan\AdminBundle\Entity\User, but is an instance of class **Company\Entity\User**. You can avoid this error by setting the "data_class" option to null or by adding a view transformer that transforms an instance of class **Company\Entity\User** to an instance of Kunstmaan\AdminBundle\Entity\User.

at `/admin/settings/users/add` and  #`/admin/settings/users/xxx/edit`

as we configured `fos.user_class` in `config.yml`