### PR TITLE
Load modules in sidebar

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Modules/index.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Modules/index.html.twig
@@ -1,4 +1,1 @@
 {% extends 'KunstmaanAdminBundle:Default:layout.html.twig' %}
-
-{% block sidebar %}{% endblock %}
-{% block content %}{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Modules page availables from the breadcrumb, but there is nothing now. This fix enables the sidebar menu.

