### PR TITLE
[NodeBundle]: add group by clause for mysql 5.7

### DIFF
--- a/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
@@ -316,7 +316,7 @@ SQL;
                 '(v.node_id = n.id AND v.lang <> :lang)'
             )
             ->where('n.deleted = 0')
-            ->addGroupBy('n.id')
+            ->addGroupBy('n.id, t.url')
             ->addOrderBy('t.weight', 'ASC')
             ->addOrderBy('t.title', 'ASC');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

When using mysql 5.7, the following error will be thrown:

Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 't.url' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by"

As of mysql 5.7 we need to add a new group by clause said in https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html.

