### PR TITLE
[AdminBundle] Instanceof check always fails with a custom user class in oauthusercreator

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
@@ -44,12 +44,12 @@ class OAuthUserCreator
         $user = $this->em->getRepository($this->userClass)
             ->findOneBy(array('googleId' => $googleId));
 
-        if (!$user instanceof User && $this->isConfiguredDomain($email)) {
+        if (!$user instanceof $this->userClass && $this->isConfiguredDomain($email)) {
 
             $user = $this->em->getRepository($this->userClass)
                 ->findOneBy(array('username' => $email));
 
-            if(!$user instanceof User) {
+            if(!$user instanceof $this->userClass) {
                 $user = new $this->userClass;
                 $user->setUsername($email);
                 $user->setEmail($email);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

[AdminBundle] check if instanceof $this->userClass instead of User