### PR TITLE
[GeneratorBundle] use constants for fixture references

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
@@ -12,6 +12,10 @@ use Kunstmaan\AdminBundle\Entity\Group;
  */
 class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
+    const REFERENCE_ADMINS_GROUP = 'admins-group';
+    const REFERENCE_GUESTS_GROUP = 'guests-group';
+    const REFERENCE_SUPERADMINS_GROUP = 'superadmins-group';
+
     /**
      * Load data fixtures with the passed EntityManager
      *
@@ -20,25 +24,25 @@ class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager)
     {
         $group1 = $this->createGroup($manager, 'Administrators', array(
-            $this->getReference('permissionmanager-role'),
-            $this->getReference('admin-role')
+            $this->getReference(RoleFixtures::REFERENCE_PERMISSIONMANAGER_ROLE),
+            $this->getReference(RoleFixtures::REFERENCE_ADMIN_ROLE)
         ));
 
         $group2 = $this->createGroup($manager, 'Guests', array(
-            $this->getReference('guest-role')
+            $this->getReference(RoleFixtures::REFERENCE_GUEST_ROLE)
         ));
 
         $group3 = $this->createGroup($manager, 'Super administrators', array(
-            $this->getReference('permissionmanager-role'),
-            $this->getReference('superadmin-role'),
-            $this->getReference('admin-role'),
+            $this->getReference(RoleFixtures::REFERENCE_PERMISSIONMANAGER_ROLE),
+            $this->getReference(RoleFixtures::REFERENCE_ADMIN_ROLE),
+            $this->getReference(RoleFixtures::REFERENCE_GUEST_ROLE),
         ));
 
         $manager->flush();
 
-        $this->addReference('admins-group',       $group1);
-        $this->addReference('guests-group',       $group2);
-        $this->addReference('superadmins-group',  $group3);
+        $this->addReference(self::REFERENCE_ADMINS_GROUP,       $group1);
+        $this->addReference(self::REFERENCE_GUESTS_GROUP,       $group2);
+        $this->addReference(self::REFERENCE_SUPERADMINS_GROUP,  $group3);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
@@ -13,6 +13,11 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 class RoleFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
+    const REFERENCE_PERMISSIONMANAGER_ROLE = 'permissionmanager-role';
+    const REFERENCE_ADMIN_ROLE = 'admin-role';
+    const REFERENCE_SUPERADMIN_ROLE = 'superadmin-role';
+    const REFERENCE_GUEST_ROLE = 'guest-role';
+
     /**
      * Load data fixtures with the passed EntityManager
      *
@@ -27,10 +32,10 @@ class RoleFixtures extends AbstractFixture implements OrderedFixtureInterface
 
         $manager->flush();
 
-        $this->addReference('permissionmanager-role', $role1);
-        $this->addReference('admin-role', $role2);
-        $this->addReference('superadmin-role', $role3);
-        $this->addReference('guest-role', $role4);
+        $this->addReference(self::REFERENCE_PERMISSIONMANAGER_ROLE, $role1);
+        $this->addReference(self::REFERENCE_ADMIN_ROLE, $role2);
+        $this->addReference(self::REFERENCE_SUPERADMIN_ROLE, $role3);
+        $this->addReference(self::REFERENCE_GUEST_ROLE, $role4);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  */
 class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
 {
+    const REFERENCE_ADMIN_USER = 'adminuser';
+
     /** @var ContainerInterface */
     private $container;
 
@@ -47,7 +49,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, C
             'admin@domain.com',
             $this->container->getParameter('kunstmaan_admin.default_admin_locale'),
             array('ROLE_SUPER_ADMIN'),
-            array($manager->merge($this->getReference('superadmins-group'))),
+            array($manager->merge($this->getReference(GroupFixtures::REFERENCE_SUPERADMINS_GROUP))),
             true,
             false
         );
@@ -63,7 +65,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, C
         $contents = str_replace('-adminpwd-', $password, $contents);
         file_put_contents($file, $contents);
 
-        $this->setReference('adminuser', $user1);
+        $this->setReference(self::REFERENCE_ADMIN_USER, $user1);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

With this people can reference the built-in fixtures in their own custom fixtures without surprises. I replaced all reference strings with constanst.

