### PR TITLE
[UserManagementBundle] User form rendered twice when using tabpanes

### DIFF
--- a/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
+++ b/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
@@ -52,5 +52,10 @@
                 {{ form_rest(form) }}
             {% endif %}
         </fieldset>
-    {{ form_end(form) }}
+
+    {% if tabPane is defined %}
+        {{ form_end(tabPane.formView) }}
+    {% else %}
+        {{ form_end(form) }}
+    {% endif %}
 {% endblock %}

--- a/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
+++ b/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
@@ -4,7 +4,7 @@
 {% block header %}{% endblock %}
 
 {% block content %}
-    {% set formParams = {'method': 'POST', 'action': path('KunstmaanUserManagementBundle_settings_users_edit', { 'id' : user.id }), 'attr': {'novalidate': 'novalidate'}} %}q
+    {% set formParams = {'method': 'POST', 'action': path('KunstmaanUserManagementBundle_settings_users_edit', { 'id' : user.id }), 'attr': {'novalidate': 'novalidate'}} %}
     {% if tabPane is defined %}
         {{ form_start(tabPane.formView, formParams) }}
     {% else %}

--- a/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
+++ b/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig
@@ -4,7 +4,12 @@
 {% block header %}{% endblock %}
 
 {% block content %}
-    {{ form_start(form, {'method': 'POST', 'action': path('KunstmaanUserManagementBundle_settings_users_edit', { 'id' : user.id }), 'attr': {'novalidate': 'novalidate'}}) }}
+    {% set formParams = {'method': 'POST', 'action': path('KunstmaanUserManagementBundle_settings_users_edit', { 'id' : user.id }), 'attr': {'novalidate': 'novalidate'}} %}q
+    {% if tabPane is defined %}
+        {{ form_start(tabPane.formView, formParams) }}
+    {% else %}
+        {{ form_start(form, formParams) }}
+    {% endif %}
 
         <!-- Header -->
         <header class="app__content__header">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | no|
| BC breaks?    | no|
| Deprecations? | no|
| Fixed tickets | #1141|

Had to figure this one out :) the problem is we have 2 instances of `FormView`, one assigned by default to the template (https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/master/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php#L197) the other one is generated from `TabPane::getFormView` when needed. Both track their own "am i rendered" state.

So we have to ignore one based on `tabPane` being set yes/no, as done with rendering the form itself;
https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/master/src/Kunstmaan/UserManagementBundle/Resources/views/Users/edit.html.twig#L49

Your welcome :) not sure this is also a low-level problem in e.g. the adminbundle itself... Also noticed the event is only triggered for *user* edit action, not add :( (ref #628)