### PR TITLE
[AdminBundle] OAuthUserCreator Should query on username and email

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreatorInterface.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreatorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Helper\Security\OAuth;
+
+/**
+ * Interface OAuthUserCreatorInterface
+ */
+interface OAuthUserCreatorInterface
+{
+    /**
+     * Returns an implementation of AbstractUser defined by the $userClass parameter.
+     * Checks if there already exists an account for the given googleId or email. If yes updates
+     * the access levels accordingly and returns that user. If no creates a new user with the
+     * configured access levels.
+     *
+     * Returns Null if email is not in configured domains
+     *
+     * @param string email
+     * @param string googleId
+     *
+     * @return mixed AbstractUser Implementation
+    */
+    public function getOrCreateUser($email, $googleId);
+}

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserFinder.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserFinder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Helper\Security\OAuth;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class OAuthUserFinder implements OAuthUserFinderInterface
+{
+
+    /** @var EntityManager */
+    private $em;
+
+    /** @var string */
+    private $userClass;
+
+    /**
+     * OAuthUserCreator constructor.
+     * @param EntityManagerInterface $em
+     * @param $userClass
+     */
+    public function __construct(EntityManagerInterface $em, $userClass)
+    {
+        $this->em = $em;
+        $this->userClass = $userClass;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findUserByGoogleSignInData($email, $googleId)
+    {
+        //Check if already logged in before via Google auth
+        $user = $this->em->getRepository($this->userClass)
+            ->findOneBy(array('googleId' => $googleId));
+
+        if (!$user instanceof $this->userClass) {
+            //Check if Email was already present in database but not logged in via Google auth
+            $user = $this->em->getRepository($this->userClass)
+                ->findOneBy(array('email' => $email));
+
+            if(!$user instanceof $this->userClass) {
+                //Last chance try looking for email address in username field
+                $user = $this->em->getRepository($this->userClass)
+                    ->findOneBy(array('username' => $email));
+            }
+        }
+
+        return $user;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserFinderInterface.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserFinderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Helper\Security\OAuth;
+
+/**
+ * Interface OAuthUserFinderInterface
+ */
+interface OAuthUserFinderInterface
+{
+
+    /**
+     * Tries to find a user in database based on email and googleId fields.
+     * Returns null when nothing has been found.
+     *
+     * @param string email
+     * @param string googleId
+     *
+     * @return mixed AbstractUser Implementation
+    */
+    public function findUserByGoogleSignInData($email, $googleId);
+}
+

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -196,6 +196,13 @@ services:
             - '@doctrine.orm.entity_manager'
             - '%kunstmaan_admin.google_signin.hosted_domains%'
             - '%fos_user.model.user.class%'
+            - '@kunstmaan_admin.oauth_user_finder'
+
+    kunstmaan_admin.oauth_user_finder:
+        class: Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserFinder
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '%fos_user.model.user.class%'
 
     kunstmaan_admin.google_signin.twig.extension:
         class: Kunstmaan\AdminBundle\Twig\GoogleSignInTwigExtension

--- a/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
+++ b/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle\Security;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreator;
+use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreatorInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -41,11 +42,11 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      * @param RouterInterface $router
      * @param Session $session
      * @param TranslatorInterface $translator
-     * @param OAuthUserCreator $oAuthUserCreator
+     * @param OAuthUserCreatorInterface $oAuthUserCreator
      * @param $clientId
      * @param $clientSecret
      */
-    public function __construct(RouterInterface $router, Session $session, TranslatorInterface $translator, OAuthUserCreator $oAuthUserCreator, $clientId, $clientSecret)
+    public function __construct(RouterInterface $router, Session $session, TranslatorInterface $translator, OAuthUserCreatorInterface $oAuthUserCreator, $clientId, $clientSecret)
     {
         $this->router = $router;
         $this->session = $session;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1144 

When someone signs in for the first time using google sign in, his user should be searched based on
email or username. 