### PR TITLE
[AdminBundle]: admin token can also be PostAuthenticationGuardToken

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -79,7 +79,7 @@ class AdminLocaleListener implements EventSubscriberInterface
      */
     private function isAdminToken($providerKey, TokenInterface $token = null)
     {
-        return ($token instanceof UsernamePasswordToken || $token instanceof RememberMeToken) && $token->getProviderKey() === $providerKey;
+        return ($token instanceof UsernamePasswordToken || $token instanceof RememberMeToken || $token instanceof PostAuthenticationGuardToken) && $token->getProviderKey() === $providerKey;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When logging in with the google sign in, we do not have a UsernamePassword token anymore. It will be a PostAuthenticationGuardToken. Therefore the admin locale you have chosen does not work anymore. When checking the admin token we should also check if the user's token is a PostAuthenticationGuardToken.

