### PR TITLE
[NodeBundle] link select language problem

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/Widgets/selectLink.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/Widgets/selectLink.html.twig
@@ -80,7 +80,8 @@
                 <hr>
             </div>
 
-            <nav role="navigation" id="app__sidebar__navigation" class="app__sidebar__module app__sidebar__navigation" data-reorder-url="{{ path('KunstmaanNodeBundle_nodes_reorder') }}" data-base-url={{ "/" ~ app.request.locale }}>
+            {% set base_url = multilanguage is not defined or multilanguage ? '/' ~ app.request.locale : '' %}
+            <nav role="navigation" id="app__sidebar__navigation" class="app__sidebar__module app__sidebar__navigation" data-reorder-url="{{ path('KunstmaanNodeBundle_nodes_reorder') }}" data-base-url={{ base_url }}>
                 <ul>
                     {% for item in tree.rootItems %}
                         {{ macros.selectLinkRecTreeView(tree, item) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1159 

Uses the "multilanguage" twig global variable to control the base url. This is not defined by default (and consistently can only be defined in the standard edition), so when the variable is missing, then the old behavior applies (generates locale aware base urls, like multilanguage == true).

Generating urls with routing would be much better, but its not that simple.

The multilanguage variable should come from this: https://github.com/Kunstmaan/KunstmaanBundlesStandardEdition/pull/208