### PR TITLE
[NodeBundle] Make it easier to hide add homepage button

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -126,7 +126,7 @@ class NodeAdminController extends Controller
         $nodeAdminListConfigurator->addSimpleItemAction('Preview', $itemRoute, 'eye');
 
         $nodeAdminListConfigurator->setDomainConfiguration($this->get('kunstmaan_admin.domain_configuration'));
-        $nodeAdminListConfigurator->setShowAddHomepage($this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN'));
+        $nodeAdminListConfigurator->setShowAddHomepage($this->getParameter('kunstmaan_node.show_add_homepage') && $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN'));
 
         /** @var AdminList $adminlist */
         $adminlist = $this->get('kunstmaan_adminlist.factory')->createList($nodeAdminListConfigurator);

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -50,6 +50,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('publish_later_stepping')->defaultValue('15')->end()
                 ->scalarNode('unpublish_later_stepping')->defaultValue('15')->end()
+                ->booleanNode('show_add_homepage')->defaultTrue()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -35,6 +35,8 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
             'Kunstmaan\NodeBundle\Helper\PagesConfiguration', [$config['pages']]
         ));
 
+        $container->setParameter('kunstmaan_node.show_add_homepage', $config['show_add_homepage']);
+
         $loader->load('services.yml');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

It is not easy to hide the add homepage button (except with css). Added extra bundle configuration option

```
kunstmaan_node:
    show_add_homepage: false
```