### PR TITLE
Prevent exception in node editor if search provider is unavailable

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
@@ -104,6 +104,7 @@ kuma_admin:
     edit:
         flash:
             success: The welcome page has been edited!
+            search_provider_offline: Search indexing unavailable!
     password_check:
         flash:
             error: Your password has not yet been changed

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -1045,6 +1045,10 @@ class NodeAdminController extends Controller
             'KunstmaanNodeBundle:QueuedNodeTranslationAction'
         )->findOneBy(array('nodeTranslation' => $nodeTranslation));
 
+        if (! $this->get('kunstmaan_node_search.search_configuration.node')->isSearchProviderAvailable()) {
+            $this->addFlash('warning', $this->get('translator')->trans('kuma_admin.edit.flash.search_provider_offline'));
+        }
+
         return array(
             'page'                        => $page,
             'entityname'                  => ClassLookup::getClass($page),

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -19,6 +19,7 @@ use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\SearchBundle\Configuration\SearchConfigurationInterface;
+use Kunstmaan\SearchBundle\Exception\SearchProviderException;
 use Kunstmaan\SearchBundle\Provider\SearchProviderInterface;
 use Kunstmaan\SearchBundle\Search\AnalysisFactoryInterface;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
@@ -221,6 +222,23 @@ class NodePagesConfiguration implements SearchConfigurationInterface
     }
 
     /**
+     * Check if search provider service is running
+     *
+     * @return bool
+     */
+    public function isSearchProviderAvailable()
+    {
+        try {
+            $this->searchProvider->getClient()->getStatus();
+
+            return true;
+        } catch (\Exception $e) {
+
+            return false;
+        }
+    }
+
+    /**
      * Index a node translation
      *
      * @param NodeTranslation $nodeTranslation
@@ -252,7 +270,10 @@ class NodePagesConfiguration implements SearchConfigurationInterface
         if ($this->isIndexable($page)) {
             $this->addPageToIndex($nodeTranslation, $node, $publicNodeVersion, $page);
             if ($add) {
-                $this->searchProvider->addDocuments($this->documents);
+                try {
+                    $this->searchProvider->addDocuments($this->documents);
+                } catch (SearchProviderException $e) {
+                }
                 $this->documents = array();
             }
         }

--- a/src/Kunstmaan/SearchBundle/Exception/SearchProviderException.php
+++ b/src/Kunstmaan/SearchBundle/Exception/SearchProviderException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: whitezo
+ * Date: 2016. 06. 14.
+ * Time: 11:45
+ */
+
+namespace Kunstmaan\SearchBundle\Exception;
+
+
+class SearchProviderException extends \RuntimeException
+{
+
+}

--- a/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
+++ b/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\SearchBundle\Provider;
 use Elastica\Client;
 use Elastica\Document;
 use Elastica\Index;
+use Kunstmaan\SearchBundle\Exception\SearchProviderException;
 
 class ElasticaProvider implements SearchProviderInterface
 {
@@ -93,11 +94,17 @@ class ElasticaProvider implements SearchProviderInterface
      * @param string $indexType
      *
      * @return \Elastica\Bulk\ResponseSet
+     * @throws SearchProviderException
      */
     public function addDocuments($docs, $indexName = '', $indexType = '')
     {
-        // Ignore indexName & indexType for Elastica, they have already been set in the document...
-        return $this->getClient()->addDocuments($docs);
+        try {
+            // Ignore indexName & indexType for Elastica, they have already been set in the document...
+            return $this->getClient()->addDocuments($docs);
+        } catch (\Exception $e)
+        {
+            throw new SearchProviderException('Search provider unavailable');
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Page save won't throw an exception if search provider (elasticsearch) is not running/available at the moment but saves page without indexing it.