### PR TITLE
[GeneratorBundle] Fixed rendering form label class

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
@@ -26,8 +26,9 @@
         {% if not compound %}
             {% set label_attr = label_attr|merge({'for': id}) %}
         {% endif %}
+        {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' form-control-label')|trim}) %}
         {% if required %}
-            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' form-control-label form-control-label--required')|trim}) %}
+            {% set label_attr = label_attr|merge({'class': label_attr.class ~ ' form-control-label--required'}) %}
         {% endif %}
         {% if label is empty %}
             {% set label = name|humanize %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Form label class (form-control-label) is only rendering if required is true
