### PR TITLE
[NodeBundle]: add custom form type for node translations

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Form;
+
+use Kunstmaan\NodeBundle\Repository\NodeRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NodeChoiceType extends AbstractType
+{
+    /** @var $requestStack RequestStack */
+    private $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            array(
+                'page_class' => array(),
+                'locale' => null,
+                'online' => true,
+                'class' => 'Kunstmaan\NodeBundle\Entity\Node',
+                'choice_label' => 'nodeTranslations[0].title',
+                'query_builder' => function (NodeRepository $er) {
+                    return $er->createQueryBuilder('n');
+                },
+            )
+        );
+
+        $queryBuilderNormalizer = function (Options $options, $queryBuilder) {
+            if (is_callable($queryBuilder)) {
+                $queryBuilder = call_user_func($queryBuilder, $options['em']->getRepository($options['class']));
+            }
+
+            if (!empty($options['page_class'])) {
+                $queryBuilder
+                    ->select('n, nt')
+                    ->innerJoin('n.nodeTranslations', 'nt')
+                    ->innerJoin('nt.publicNodeVersion', 'nv')
+                    ->andWhere('nt.online = :online')
+                    ->andWhere('nt.lang = :lang')
+                    ->andWhere('n.deleted != 1')
+                    ->andWhere('n.refEntityName IN(:refEntityName)')
+                    ->setParameter('lang', $options['locale'] ? $options['locale'] : $this->getCurrentLocale())
+                    ->setParameter('refEntityName', $options['page_class'])
+                    ->setParameter('online', $options['online']);
+            }
+
+            return $queryBuilder;
+        };
+
+        $resolver->setNormalizer('query_builder', $queryBuilderNormalizer);
+        $resolver->setAllowedTypes('query_builder', array('null', 'callable', 'Doctrine\ORM\QueryBuilder'));
+
+    }
+
+    public function getParent()
+    {
+        return EntityType::class;
+    }
+
+    private function getCurrentLocale()
+    {
+        return $this->requestStack->getCurrentRequest()->getLocale();
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -32,6 +32,13 @@ services:
         tags:
             - { name: 'form.type' }
 
+    kunstmaan_node.form.type.nodechoice:
+        class: Kunstmaan\NodeBundle\Form\NodeChoiceType
+        arguments:
+            - "@request_stack"
+        tags:
+            - { name: form.type }
+
     kunstmaan_node.admin_node.publisher:
         class: Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher
         arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.authorization_checker', '@event_dispatcher', '@kunstmaan_admin.clone.helper']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I have added a new form type to use instead of the EntityType when working with node translations.

When you want to have a entity fields that has a relationship to a node and you want to create a form for this entities relationship, you would normally use the EntityType. By using the NodeTranslationChoiceType, the title used as choice_label, will be automatically the title in the current language. You can also provide the "locale" parameter to set a default locale.

Example:

`   ->add('question', NodeTranslationChoiceType::class,
                array(
                    'page_class' => array(StartersVraagPage::class),
                )
            )`
