### PR TITLE
[MediaBundle] Auto guess Extension when missing from file or throw validation error if not possible to guess.

### DIFF
--- a/src/Kunstmaan/MediaBundle/Form/File/FileType.php
+++ b/src/Kunstmaan/MediaBundle/Form/File/FileType.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\MediaBundle\Form\File;
 
 use Kunstmaan\MediaBundle\Repository\FolderRepository;
+use Kunstmaan\MediaBundle\Validator\Constraints\HasGuessableExtension;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -47,7 +48,7 @@ class FileType extends AbstractType
             BaseFileType::class,
             array(
                 'label' => 'media.form.file.file.label',
-                'constraints' => array(new File()),
+                'constraints' => array(new File(), new HasGuessableExtension()),
                 'required' => false
             )
         );
@@ -81,7 +82,7 @@ class FileType extends AbstractType
                         BaseFileType::class,
                         array(
                             'label' => 'media.form.file.file.label',
-                            'constraints' => array(new NotBlank(), new File()),
+                            'constraints' => array(new NotBlank(), new File(), new HasGuessableExtension()),
                             'required' => true
                         )
                     );

--- a/src/Kunstmaan/MediaBundle/Helper/ExtensionGuesserFactory.php
+++ b/src/Kunstmaan/MediaBundle/Helper/ExtensionGuesserFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper;
+
+use Kunstmaan\MediaBundle\Helper\File\SVGExtensionGuesser;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+
+class ExtensionGuesserFactory implements ExtensionGuesserFactoryInterface
+{
+    /**
+     * Should return an extension guesser instance, used for file uploads
+     *
+     * NOTE: If you override this, you'll probably still have to register the SVGExtensionGuesser as last guesser...
+     *
+     * @return ExtensionGuesserInterface
+     */
+    public function get()
+    {
+        $guesser = ExtensionGuesser::getInstance();
+        $guesser->register(new SVGExtensionGuesser());
+
+        return $guesser;
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/ExtensionGuesserFactoryInterface.php
+++ b/src/Kunstmaan/MediaBundle/Helper/ExtensionGuesserFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper;
+
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+
+interface ExtensionGuesserFactoryInterface
+{
+    /**
+     * @return ExtensionGuesserInterface
+     */
+    public function get();
+}

--- a/src/Kunstmaan/MediaBundle/Helper/File/SVGExtensionGuesser.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/SVGExtensionGuesser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Helper\File;
+
+use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface;
+
+/**
+ * SVGMimeTypeGuesser
+ *
+ * @package Kunstmaan\MediaBundle\Helper\File
+ */
+class SVGExtensionGuesser implements ExtensionGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function guess($mimeType)
+    {
+       if($mimeType === 'image/svg+xml') {
+           return 'svg';
+       }
+        
+        return null;
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Helper/Image/ImageHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Image/ImageHandler.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Helper\Image;
 
+use Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactoryInterface;
 use Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Kunstmaan\MediaBundle\Helper\File\FileHandler;
@@ -16,11 +17,14 @@ class ImageHandler extends FileHandler
     protected $aviaryApiKey;
 
     /**
+     * @param int $priority
+     * @param MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory
+     * @param ExtensionGuesserFactoryInterface $extensionGuesserFactoryInterface
      * @param string $aviaryApiKey The aviary key
      */
-    public function __construct($priority, MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory, $aviaryApiKey)
+    public function __construct($priority, MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory, ExtensionGuesserFactoryInterface $extensionGuesserFactoryInterface, $aviaryApiKey)
     {
-        parent::__construct($priority, $mimeTypeGuesserFactory);
+        parent::__construct($priority, $mimeTypeGuesserFactory, $extensionGuesserFactoryInterface);
         $this->aviaryApiKey = $aviaryApiKey;
     }
 

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -28,7 +28,7 @@ services:
 
     kunstmaan_media.media_handlers.image:
         class: '%kunstmaan_media.media_handler.image.class%'
-        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '%aviary_api_key%']
+        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory', '%aviary_api_key%']
         calls:
             - [ setFileSystem, [ '@kunstmaan_media.filesystem' ] ]
             - [ setMediaPath, [ '%kunstmaan_media.media_path%' ] ]
@@ -39,7 +39,7 @@ services:
 
     kunstmaan_media.media_handlers.file:
         class: '%kunstmaan_media.media_handler.file.class%'
-        arguments: [0, '@kunstmaan_media.mimetype_guesser.factory']
+        arguments: [0, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory']
         calls:
             - [ setFileSystem, [ '@kunstmaan_media.filesystem' ] ]
             - [ setMediaPath, [ '%kunstmaan_media.media_path%' ] ]

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -9,6 +9,8 @@ parameters:
     kunstmaan_media.icon_font.default_loader.class: 'Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader'
     kunstmaan_media.media_creator_service.class: 'Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService'
     kunstmaan_media.mimetype_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory'
+    kunstmaan_media.extension_guesser.factory.class: 'Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactory'
+    kunstmaan_media.validator.has_guessable_extension.class: 'Kunstmaan\MediaBundle\Validator\Constraints\HasGuessableExtensionValidator'
 
 services:
     kunstmaan_media.media_manager:
@@ -73,6 +75,9 @@ services:
     kunstmaan_media.mimetype_guesser.factory:
         class: '%kunstmaan_media.mimetype_guesser.factory.class%'
 
+    kunstmaan_media.extension_guesser.factory:
+        class: '%kunstmaan_media.extension_guesser.factory.class%'
+
     kunstmaan_media.command.migratename:
         class: Kunstmaan\MediaBundle\Command\MigrateNameCommand
         calls:
@@ -98,3 +103,11 @@ services:
         class: Gaufrette\Filesystem
         arguments:
             - '@kunstmaan_media.filesystem_adapter'
+
+    kunstmaan_media.validator.has_guessable_extension:
+        class: '%kunstmaan_media.validator.has_guessable_extension.class%'
+        tags:
+            - { name: validator.constraint_validator, alias: has_guessable_extension }
+        calls:
+            - [setMimeTypeGuesser, ['@kunstmaan_media.mimetype_guesser.factory']]
+            - [setExtensionGuesser, ['@kunstmaan_media.extension_guesser.factory']]

--- a/src/Kunstmaan/MediaBundle/Tests/Helper/File/PdfHandlerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Helper/File/PdfHandlerTest.php
@@ -30,10 +30,11 @@ class PdfHandlerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->pdfTransformer = $this->getMock('Kunstmaan\MediaBundle\Helper\Transformer\PreviewTransformerInterface');
-        $factory = $this->getMock('Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface');
+        $mockMimeTypeGuesserfactory = $this->getMock('Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface');
+        $mockExtensionGuesserfactory = $this->getMock('Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactoryInterface');
         $this->filesDir = realpath(__DIR__ . '/../../Files');
 
-        $this->object = new PdfHandler(1, $factory);
+        $this->object = new PdfHandler(1, $mockMimeTypeGuesserfactory, $mockExtensionGuesserfactory);
         $this->object->setPdfTransformer($this->pdfTransformer);
     }
 

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/HasGuessableExtension.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/HasGuessableExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class HasGuessableExtension extends Constraint
+{
+    const NOT_GUESSABLE_ERROR = 1;
+
+    protected static $errorNames = array(
+        self::NOT_GUESSABLE_ERROR => 'NOT_GUESSABLE_ERROR',
+    );
+
+    public $notGuessableErrorMessage = 'The uploaded file has no extension and could not be automatically guessed by the system.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/HasGuessableExtensionValidator.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/HasGuessableExtensionValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Validator\Constraints;
+
+use Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactoryInterface;
+use Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactoryInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Class hasGuessableExtensionValidator
+ */
+class HasGuessableExtensionValidator extends ConstraintValidator
+{
+
+    /**
+     * @var ExtensionGuesserInterface $extensionGuesser
+     */
+    private $extensionGuesser;
+
+    /**
+     * @var MimeTypeGuesserInterface $mimeTypeGuesser
+     */
+    private $mimeTypeGuesser;
+
+    /**
+     * @param $value
+     * @param Constraint  $constraint
+     *
+     * @throws ConstraintDefinitionException
+     * @throws UnexpectedTypeException
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof HasGuessableExtension) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\HasGuessableExtension');
+        }
+
+        if (!$value instanceof UploadedFile) {
+            return;
+        }
+
+        $contentType = $this->mimeTypeGuesser->guess($value->getPathname());
+        $pathInfo = pathinfo($value->getClientOriginalName());
+        if (!array_key_exists('extension', $pathInfo)) {
+            $pathInfo['extension'] = $this->extensionGuesser->guess($contentType);
+        }
+
+        if ($pathInfo['extension'] === NULL) {
+            $this->context->buildViolation($constraint->notGuessableErrorMessage)
+                ->setCode(HasGuessableExtension::NOT_GUESSABLE_ERROR)
+                ->addViolation();
+        }
+    }
+
+    /**
+     * @param ExtensionGuesserFactoryInterface $extensionGuesserFactory
+     */
+    public function setExtensionGuesser(ExtensionGuesserFactoryInterface $extensionGuesserFactory)
+    {
+        $this->extensionGuesser = $extensionGuesserFactory->get();
+    }
+
+    /**
+     * @param MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory
+     */
+    public function setMimeTypeGuesser(MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory)
+    {
+        $this->mimeTypeGuesser= $mimeTypeGuesserFactory->get();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1183 

* [x] Implement extensionguesser in filehandler logic
* [x] User friendly error message when impossible to guess extension/mimetype
* [x] Fix tests

Allow files to be uploaded without an extension in the filename. Detect it based on Symfony's MimeTypeGuesser and ExtensionGuesser.

I was going to write a simple check check to avoid the internal server error first but I figured this small "feature" is pretty cool. 