### PR TITLE
[NodeBundle]: add recursive children iterator

### DIFF
--- a/src/Kunstmaan/NodeBundle/Entity/NodeIterator.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeIterator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Entity;
+
+use Doctrine\Common\Collections\Collection;
+
+class NodeIterator implements \RecursiveIterator
+{
+    private $_data;
+
+    public function __construct(Collection $data)
+    {
+        $this->_data = $data;
+    }
+
+    public function hasChildren()
+    {
+        return (!$this->_data->current()->getChildren()->isEmpty());
+    }
+
+    public function getChildren()
+    {
+        return new NodeIterator($this->_data->current()->getChildren());
+    }
+
+    public function current()
+    {
+        return $this->_data->current();
+    }
+
+    public function next()
+    {
+        $this->_data->next();
+    }
+
+    public function key()
+    {
+        return $this->_data->key();
+    }
+
+    public function valid()
+    {
+        return $this->_data->current() instanceof Node;
+    }
+
+    public function rewind()
+    {
+        $this->_data->first();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In my usecase I needed a iterator that gets me all the children of a node directly. You can use it like this:

`$nodes = new \RecursiveIteratorIterator(new NodeIterator($parentNode->getChildren()), \RecursiveIteratorIterator::SELF_FIRST);`



