### PR TITLE
[MediaBundle] Rename soft deleted media

### DIFF
--- a/src/Kunstmaan/MediaBundle/Command/MigrateSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/MigrateSoftDeletedCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\MediaBundle\Entity\Media;
+use Kunstmaan\MediaBundle\Helper\File\FileHandler;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateSoftDeletedCommand extends ContainerAwareCommand
+{
+    /** @var EntityManager $em */
+    protected $em;
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Migrating soft-deleted media...');
+        /**
+         * @var EntityManager
+         */
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $medias = $em->getRepository('KunstmaanMediaBundle:Media')->findAll();
+        $manager = $this->getContainer()->get('kunstmaan_media.media_manager');
+        $updates = 0;
+        $fileRenameQueue = array();
+        try {
+            $em->beginTransaction();
+            /** @var Media $media */
+            foreach ($medias as $media) {
+                $handler = $manager->getHandler($media);
+                if ($media->isDeleted() && $media->getLocation() === 'local' && $handler instanceof FileHandler) {
+                    $oldUrl = $media->getUrl();
+                    $newUrl = $newFileUrl = dirname($oldUrl) . '/' . uniqid() . '.' . pathinfo($oldUrl, PATHINFO_EXTENSION);
+                    $fileRenameQueue[] = array($oldUrl, $newUrl, $handler);
+                    $media->setUrl($newUrl);
+                    $em->persist($media);
+                    $updates++;
+                }
+            }
+            $em->flush();
+            $em->commit();
+        } catch (\Exception $e) {
+            $em->rollback();
+            $output->writeln('An error occured while migrating soft-deleted media : <error>' . $e->getMessage() . '</error>');
+        }
+
+        foreach ($fileRenameQueue as $row) {
+            list ($oldUrl, $newUrl, $handler) = $row;
+            $handler->fileSystem->rename(
+                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $oldUrl),
+                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $newUrl)
+            );
+            $output->writeln('Renamed <info>' . $oldUrl . '</info> to <info>' . basename($newUrl) . '</info>');
+        }
+
+        $output->writeln('<info>' . $updates . ' soft-deleted media files have been renamed.</info>');
+    }
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('kuma:media:migrate-soft-deleted')
+            ->setDescription('Migrate soft-deleted media to rename public media.')
+            ->setHelp(
+                "The <info>kuma:media:migrate-name</info> command can be used to migrate soft-deleted media which is still publically available under the original filename."
+            );
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -45,6 +45,8 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
         } catch (\Exception $e) {
             $em->rollback();
             $output->writeln('An error occured while updating soft-deleted media : <error>' . $e->getMessage() . '</error>');
+            $updates = 0;
+            $fileRenameQueue = array();
         }
 
         foreach ($fileRenameQueue as $row) {

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -9,14 +9,14 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MigrateSoftDeletedCommand extends ContainerAwareCommand
+class RenameSoftDeletedCommand extends ContainerAwareCommand
 {
     /** @var EntityManager $em */
     protected $em;
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln('Migrating soft-deleted media...');
+        $output->writeln('Renaming soft-deleted media...');
         /**
          * @var EntityManager
          */
@@ -44,7 +44,7 @@ class MigrateSoftDeletedCommand extends ContainerAwareCommand
             $em->commit();
         } catch (\Exception $e) {
             $em->rollback();
-            $output->writeln('An error occured while migrating soft-deleted media : <error>' . $e->getMessage() . '</error>');
+            $output->writeln('An error occured while updating soft-deleted media : <error>' . $e->getMessage() . '</error>');
         }
 
         foreach ($fileRenameQueue as $row) {
@@ -64,10 +64,10 @@ class MigrateSoftDeletedCommand extends ContainerAwareCommand
         parent::configure();
 
         $this
-            ->setName('kuma:media:migrate-soft-deleted')
-            ->setDescription('Migrate soft-deleted media to rename public media.')
+            ->setName('kuma:media:rename-soft-deleted')
+            ->setDescription('Rename physical files for soft-deleted media.')
             ->setHelp(
-                "The <info>kuma:media:migrate-name</info> command can be used to migrate soft-deleted media which is still publically available under the original filename."
+                "The <info>kuma:media:rename-soft-deleted</info> command can be used to rename soft-deleted media which is still publically available under the original filename."
             );
     }
 }

--- a/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
+++ b/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
@@ -111,8 +111,8 @@ class DoctrineMediaListener
         $handler = $this->mediaManager->getHandler($entity);
         if (isset($this->fileUrlMap[$url]) && $handler instanceof FileHandler) {
             $handler->fileSystem->rename(
-                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $this->fileUrlMap[$url]),
-                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $url)
+                preg_replace('~^' . preg_quote($handler->mediaPath, '~') . '~', '/', $this->fileUrlMap[$url]),
+                preg_replace('~^' . preg_quote($handler->mediaPath, '~') . '~', '/', $url)
             );
             unset($this->fileUrlMap[$url]);
         }

--- a/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
+++ b/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MediaBundle\EventListener;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Kunstmaan\MediaBundle\Entity\Media;
+use Kunstmaan\MediaBundle\Helper\File\FileHandler;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
 
@@ -17,6 +18,11 @@ class DoctrineMediaListener
      * @var MediaManager $mediaManager
      */
     private $mediaManager;
+
+    /**
+     * @var array
+     */
+    private $fileUrlMap = array();
 
     /**
      * @param MediaManager $mediaManager
@@ -65,6 +71,20 @@ class DoctrineMediaListener
                 $em->getClassMetadata(ClassLookup::getClass($entity)),
                 $eventArgs->getEntity()
             );
+
+            // local media is soft-deleted or soft-delete is reverted
+            $changeSet = $eventArgs->getEntityChangeSet();
+            if (isset($changeSet['deleted']) && $entity->getLocation() === 'local') {
+                $deleted = (!$changeSet['deleted'][0] && $changeSet['deleted'][1]);
+                $reverted = ($changeSet['deleted'][0] && !$changeSet['deleted'][1]);
+                if ($deleted || $reverted) {
+                    $oldFileUrl = $entity->getUrl();
+                    $newFileName = ($reverted ? $entity->getOriginalFilename() : uniqid());
+                    $newFileUrl = dirname($oldFileUrl) . '/' . $newFileName . '.' . pathinfo($oldFileUrl, PATHINFO_EXTENSION);
+                    $entity->setUrl($newFileUrl);
+                    $this->fileUrlMap[$newFileUrl] = $oldFileUrl;
+                }
+            }
         }
     }
 
@@ -87,6 +107,15 @@ class DoctrineMediaListener
         }
 
         $this->mediaManager->saveMedia($entity, $new);
+        $url = $entity->getUrl();
+        $handler = $this->mediaManager->getHandler($entity);
+        if (isset($this->fileUrlMap[$url]) && $handler instanceof FileHandler) {
+            $handler->fileSystem->rename(
+                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $this->fileUrlMap[$url]),
+                preg_replace('~^' . preg_quote(FileHandler::MEDIA_PATH, '~') . '~', '/', $url)
+            );
+            unset($this->fileUrlMap[$url]);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes?
| Deprecations? | no

This renames a physical local file if the associated media entity is soft-deleted. I dont think its OK to keep the physical file publicly available for soft-deleted media **under the same URL**.

It restores the orginal filename when you _readd_ a soft deleted media entity, ie;
`$media->setDeleted(false); $em->persist($media);`

Any thoughts?

![image](https://cloud.githubusercontent.com/assets/1047696/16262310/5dec4f90-386f-11e6-862a-4788aa8f4b70.png)
