### PR TITLE
[MediaBundle] CleanDeleteMediaCommand fix + new column in Media

### DIFF
--- a/UPGRADE-3.6.md
+++ b/UPGRADE-3.6.md
@@ -51,3 +51,9 @@ If you have overwritten, implemented, extended any of these interfaces and class
 * Document field 'contentanalyzer' has been removed from the default mapping configuration.
 * Parameter 'index_name' is not available anymore. Has been with the option 'copy_to'
 
+# UPGRADE FROM 3.6 to 3.6.1
+
+## [MediaBundle] Media has a new column.
+
+The Media entity has a new column named removed_from_file_system. This is used in the CleanDeleteMediaCommand to indicate in the database that a file, that was flagged as deleted, has been removed from the filesystem.
+So you have to generate a migration and execute it.

--- a/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
@@ -52,11 +52,11 @@ class CleanDeletedMediaCommand extends ContainerAwareCommand
             }
             $em->flush();
             $em->commit();
+            $output->writeln('<info>All Media flagged as deleted, have now been removed from the file system.<info>');
         } catch (\Exception $e) {
             $em->rollback();
-            $output->writeln('An error occured while trying to delete Media from the file system:\n <error>'. $e->getMessage() . '</error>');
+            $output->writeln('An error occured while trying to delete Media from the file system:');
+            $output->writeln('<error>'. $e->getMessage() . '</error>');
         }
-
-        $output->writeln('<info>All Media flagged as deleted, have now been removed from the file system.<info>');
     }
 }

--- a/src/Kunstmaan/MediaBundle/Entity/Media.php
+++ b/src/Kunstmaan/MediaBundle/Entity/Media.php
@@ -135,6 +135,13 @@ class Media extends AbstractEntity
     protected $deleted;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", name="removed_from_file_system")
+     */
+    protected $removedFromFileSystem;
+
+    /**
      * constructor
      */
     public function __construct()
@@ -550,6 +557,22 @@ class Media extends AbstractEntity
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isRemovedFromFileSystem()
+    {
+        return $this->removedFromFileSystem;
+    }
+
+    /**
+     * @param boolean $removedFromFileSystem
+     */
+    public function setRemovedFromFileSystem($removedFromFileSystem)
+    {
+        $this->removedFromFileSystem = $removedFromFileSystem;
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -192,10 +192,6 @@ class FileHandler extends AbstractMediaHandler
      */
     public function removeMedia(Media $media)
     {
-        # Remove links to content in database
-        $media->setContentType(null);
-        $media->setUrl(null);
-
         $adapter = $this->fileSystem->getAdapter();
 
         # Remove the file from filesystem
@@ -206,7 +202,7 @@ class FileHandler extends AbstractMediaHandler
 
         # Remove the files containing folder if there's nothing left
         $folderPath = $this->getFileFolderPath($media);
-        if($adapter->exists($folderPath) && $adapter->isDirectory($folderPath)) {
+        if($adapter->exists($folderPath) && $adapter->isDirectory($folderPath) && !empty($folderPath)) {
 
             $allMyKeys = $adapter->keys();
             $everythingfromdir = preg_grep('/'.$folderPath, $allMyKeys);
@@ -215,6 +211,8 @@ class FileHandler extends AbstractMediaHandler
                 $adapter->delete($folderPath);
             }
         }
+
+        $media->setRemovedFromFileSystem(true);
     }
 
     /**
@@ -313,7 +311,9 @@ class FileHandler extends AbstractMediaHandler
 
         $parts    = pathinfo($filename);
         $filename = $this->slugifier->slugify($parts['filename']);
-        $filename .= '.'.strtolower($parts['extension']);
+        if (array_key_exists('extension', $parts)) {
+            $filename .= '.'.strtolower($parts['extension']);
+        }
 
         return sprintf(
             '%s/%s',

--- a/src/Kunstmaan/MediaBundle/Repository/MediaRepository.php
+++ b/src/Kunstmaan/MediaBundle/Repository/MediaRepository.php
@@ -68,11 +68,12 @@ class MediaRepository extends EntityRepository
 
     /**
      * Finds all Media  that has their deleted flag set to 1
+     * and have their remove_from_file_system flag set to 0
      *
      * @return object[]
      */
     public function findAllDeleted()
     {
-        return $this->findBy(array('deleted' => true));
+        return $this->findBy(array('deleted' => true, 'removedFromFileSystem' => false));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

I have added a new column removed_from_file_system to indicate in the database if it is removed from the fs or not.
Furthermore I fixed some small issues I had when using the command