### PR TITLE
[MediaBundle] fix adding new media object crash

### DIFF
--- a/src/Kunstmaan/MediaBundle/Entity/Media.php
+++ b/src/Kunstmaan/MediaBundle/Entity/Media.php
@@ -149,6 +149,7 @@ class Media extends AbstractEntity
         $this->setCreatedAt(new \DateTime());
         $this->setUpdatedAt(new \DateTime());
         $this->deleted = false;
+        $this->removedFromFileSystem = false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

When adding a new media object set the removedFromFileSystem property to false.

