### PR TITLE
[AdminBundle] Remove only current image preview

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_media-chooser.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_media-chooser.js
@@ -20,7 +20,7 @@ kunstmaanbundles.mediaChooser = (function(window, undefined) {
                 $widget = $('#' + linkedID + '-widget'),
                 $input = $('#' + linkedID);
 
-            $('.media-chooser__preview__img').attr({'src': '', 'srcset': '', 'alt': ''});
+            $this.parent('.media-chooser__preview').find('.media-chooser__preview__img').attr({'src': '', 'srcset': '', 'alt': ''});
 
             $(".media-thumbnail__icon").remove();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

If you have multiple images in an pagepart and you remove one of them all image previews are gone.
