### PR TITLE
[PagePartBundle]: pass the page parameter to twig

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -50,7 +50,8 @@ class PagePartTwigExtension extends \Twig_Extension
         $entityRepository = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
         $pageparts = $entityRepository->getPageParts($page, $contextName);
         $newTwigContext = array_merge($parameters, array(
-            'pageparts' => $pageparts
+            'pageparts' => $pageparts,
+            'page' => $page
         ));
         $newTwigContext = array_merge($newTwigContext, $twigContext);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When having a twig file calling the render_pageparts twig function with another name for the variable "page", the twig function will not work.

For example when executing "{{ render_pageparts(projectPage, 'main') }}", the widget.html.twig in the PagePartBundle will return an error that the variable "page" does not exist. Therefor we pass it to the twig widget file.

