### PR TITLE
[AdminListBundle]: revert pull request #889

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/export.csv.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/export.csv.twig
@@ -5,13 +5,16 @@
 {%- endfor -%}
 {% set counter = 0 %}
 {% for item in iterator %}
-{% set item = item[counter] %}
-{% set counter = counter + 1 %}
+{% if item[0] is defined %}
+{% set item = item[0] %}
+{% else %}
+{% set item = item %}
+{% endif %}
 {% for column in adminlist.exportColumns -%}
 {%- set columnName = column.name -%}
 {%- set template = column.template -%}
 {% if template is not null and template != 1 and template != "" %}
-{{- quote|raw -}}{% include template with {'row': item, 'columnName': columnName, 'object': adminlist.getValue(item, columnName)} %}{{- quote|raw -}}
+{{- quote|raw -}}{% include template with {'row': item, 'columnName': columnName, 'object': adminlist.getStringValue(item, columnName)} %}{{- quote|raw -}}
 {% else %}
 {{- quote|raw -}}{{- adminlist.getStringValue(item, columnName) -}}{{- quote|raw -}}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In pull request https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/889 the export.csv.twig was changed. This does not work so therefor this revert.

Also use getStringValue instead of getValue, the ExportList class does not contain the getValue method.
