### PR TITLE
[MediaBundle]: extension_guesser needs to be passed to pdf handler to

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -17,7 +17,7 @@ services:
 
     kunstmaan_media.media_handlers.pdf:
         class: '%kunstmaan_media.media_handler.pdf.class%'
-        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory']
+        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory']
         calls:
             - [ setMediaPath, [ '%kernel.root_dir%' ] ]
             - [ setPdfTransformer, [ '@kunstmaan_media.pdf_transformer' ]]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Because of the changed FileHandler in pull request https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/1208, the Pdf media handler also needs to pass the new parameter.

