### PR TITLE
[AdminListBundle] replace PhpExcel for a more performant variant box/spout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzle/guzzle": "~3.9",
         "white-october/pagerfanta-bundle": "~1.0",
-        "phpoffice/phpexcel": "~1.8",
         "kunstmaan/google-api-custom": "~1.0",
         "ddeboer/data-import-bundle": "~0.1",
         "gedmo/doctrine-extensions": "~2.3",
@@ -44,11 +43,12 @@
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "symfony-cmf/routing-bundle": "~1.4.0",
         "symfony-cmf/routing": "~1.4.0",
-        "ruflin/elastica": "~3.2",
         "fpn/doctrine-extensions-taggable": "~0.9",
         "sensio/generator-bundle": "~2.5",
         "twig/extensions": "~1.0",
-        "egulias/email-validator": "~1.2"
+        "egulias/email-validator": "~1.2",
+        "box/spout": "^2.5",
+        "ruflin/elastica": "^3.2"
     },
     "require-dev": {
         "behat/behat": "~2.5.0",

--- a/src/Kunstmaan/AdminListBundle/Service/ExportService.php
+++ b/src/Kunstmaan/AdminListBundle/Service/ExportService.php
@@ -2,11 +2,14 @@
 
 namespace Kunstmaan\AdminListBundle\Service;
 
+use Box\Spout\Writer\WriterInterface;
 use Kunstmaan\AdminListBundle\AdminList\ExportableInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Translation\Translator;
+use Box\Spout\Writer\WriterFactory;
+use Box\Spout\Common\Type;
 
 class ExportService
 {
@@ -55,17 +58,15 @@ class ExportService
     {
         switch ($_format) {
             case self::EXT_EXCEL:
-                $writer   = $this->createExcelSheet($adminList);
-                $response = $this->createResponseForExcel($writer);
+                $response = $this->streamExcelSheet($adminList);
                 break;
             default:
                 $content  = $this->createFromTemplate($adminList, $_format, $template);
                 $response = $this->createResponse($content, $_format);
+                $filename = sprintf('entries.%s', $_format);
+                $response->headers->set('Content-Disposition', sprintf('attachment; filename=%s', $filename));
                 break;
         }
-
-        $filename = sprintf('entries.%s', $_format);
-        $response->headers->set('Content-Disposition', sprintf('attachment; filename=%s', $filename));
 
         return $response;
     }
@@ -98,52 +99,53 @@ class ExportService
     /**
      * @param ExportableInterface $adminList
      *
-     * @return \PHPExcel_Writer_Excel2007
+     * @return Response
      *
      * @throws \Exception
-     * @throws \PHPExcel_Exception
      */
-    public function createExcelSheet(ExportableInterface $adminList)
+    public function streamExcelSheet(ExportableInterface $adminList)
     {
-        $objPHPExcel = new \PHPExcel();
-
-        $objWorksheet = $objPHPExcel->getActiveSheet();
-
-        $number = 1;
-
-        $row = array();
-        foreach ($adminList->getExportColumns() as $column) {
-            $row[] = $this->translator->trans($column->getHeader());
-        }
-        $objWorksheet->fromArray($row, null, 'A' . $number++);
-
-        $iterator = $adminList->getIterator();
-        foreach ($iterator as $item) {
-            if (array_key_exists(0, $item)) {
-                $itemObject = $item[0];
-            } else {
-                $itemObject = $item;
-            }
+        $response = new StreamedResponse();
+        $response->setCallback(function () use ($adminList) {
+            $writer = WriterFactory::create(Type::XLSX);
+            $writer->openToBrowser("export.xlsx");
 
             $row = array();
             foreach ($adminList->getExportColumns() as $column) {
-                $data = $adminList->getStringValue($itemObject, $column->getName());
-                if (is_object($data)) {
-                    if (!$this->renderer->exists($column->getTemplate())) {
-                        throw new \Exception('No export template defined for ' . get_class($data));
-                    }
+                $row[] = $this->translator->trans($column->getHeader());
+            }
+            $writer->addRow($row);
 
-                    $data = $this->renderer->render($column->getTemplate(), array('object' => $data));
+            $iterator = $adminList->getIterator();
+            $rows = array();
+            foreach ($iterator as $item) {
+                if (array_key_exists(0, $item)) {
+                    $itemObject = $item[0];
+                } else {
+                    $itemObject = $item;
                 }
 
-                $row[] = $data;
+                $row = array();
+                foreach ($adminList->getExportColumns() as $column) {
+                    $data = $adminList->getStringValue($itemObject, $column->getName());
+                    if (is_object($data)) {
+                        if (!$this->renderer->exists($column->getTemplate())) {
+                            throw new \Exception('No export template defined for ' . get_class($data));
+                        }
+
+                        $data = $this->renderer->render($column->getTemplate(), array('object' => $data));
+                    }
+
+                    $row[] = $data;
+                }
+                $rows[] = $row;
             }
-            $objWorksheet->fromArray($row, null, 'A' . $number++);
-        }
 
-        $objWriter = new \PHPExcel_Writer_Excel2007($objPHPExcel);
+            $writer->addRows($rows);
+            $writer->close();
+        });
 
-        return $objWriter;
+        return $response;
     }
 
     /**
@@ -157,24 +159,6 @@ class ExportService
         $response = new Response();
         $response->headers->set('Content-Type', sprintf('text/%s', $_format));
         $response->setContent($content);
-
-        return $response;
-    }
-
-    /**
-     * @param \PHPExcel_Writer_IWriter $writer
-     *
-     * @return StreamedResponse
-     */
-    public function createResponseForExcel(\PHPExcel_Writer_IWriter $writer)
-    {
-        $response = new StreamedResponse(
-            function () use ($writer) {
-                $writer->save('php://output');
-            }
-        );
-
-        $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 
         return $response;
     }

--- a/src/Kunstmaan/AdminListBundle/Tests/Service/ExportServiceTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/Service/ExportServiceTest.php
@@ -90,15 +90,15 @@ class ExportServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Kunstmaan\AdminListBundle\Service\ExportService::createExcelSheet
-     * @todo   Implement testCreateExcelSheet().
+     * @covers Kunstmaan\AdminListBundle\Service\ExportService::streamExcelSheet
      */
-    public function testCreateExcelSheet()
+    public function testStreamExcelSheet()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $adminList = $this->getMock('Kunstmaan\AdminListBundle\AdminList\ExportableInterface');
+
+        $response = $this->object->streamExcelSheet($adminList);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
     }
 
     /**
@@ -107,16 +107,6 @@ class ExportServiceTest extends \PHPUnit_Framework_TestCase
     public function testCreateResponse()
     {
         $response = $this->object->createResponse('content', ExportService::EXT_CSV);
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-    }
-
-    /**
-     * @covers Kunstmaan\AdminListBundle\Service\ExportService::createResponseForExcel
-     */
-    public function testCreateResponseForExcel()
-    {
-        $writer = $this->getMock('\PHPExcel_Writer_IWriter');
-        $response = $this->object->createResponseForExcel($writer);
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1234

- [x] Implement code
- [x] Gotta fix the tests

#### Why
We ran into some troubles with extremely large databases. Sometimes connections would time out and memory limits of the hardware would be exceeded. By using a much more performant excel bundle we will be able to avoid those hardware limits a lot longer. In fact spout will never flood the memory like PhpExcel does because it works with chucks of the excel and leaves untouched parts out of memory. Spout will scale better in general

#### Some crude benchmarks I did on a very simple table with 5 columns and 120000 rows

      | Bundles + PhpExcel | Bundles + Spout
--- | -------------------- | ----------------- 
1 | 04m 10s | 01m 15s
2 | 04m 12s | 01m 17s
3 | 04m 12s | 01m 15s
4 | 04m 15s | 01m 12s
5 | 04m 14s | 01m 12s

Average memory usage for PhpExcel was a 150ish Mb and around 5Mb for Spout.

tl:dr
Replace PhpExcel with box/spout because it is faster and has move convenience functions like
openToBrowser().
Refactor logic a small bit to reduce code size
Limit system calls to excel writer to shave off some extra seconds