### PR TITLE
[NodeBundle] fix bug error label not correct slugchooser

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
@@ -7,6 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class NodeMenuTabTranslationAdminType extends AbstractType
 {
@@ -33,6 +34,9 @@ class NodeMenuTabTranslationAdminType extends AbstractType
             $builder->add('slug', SlugType::class, array(
                 'label' => 'kuma_node.form.menu_tab_translation.slug.label',
                 'required' => false,
+                'constraints' => array(
+                    new Regex("/^[a-zA-Z0-9\-_\/]+$/")
+                )
             ));
         }
         $builder->add('weight', ChoiceType::class, array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1226 

This fixes the issue where when trying to update the slug of a page the error messages would not be displayed correctly. The only problem for me is that I do not understand why this fix works and the original code does not. It should give the exact same results? Maybe a bug in the Assert/Regex code?

