### PR TITLE
[AdminBundle]: sequence can't be submitted for new url chooser

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
@@ -207,11 +207,12 @@ kunstmaanbundles.urlChooser = (function (window, undefined) {
                     }
                     else {
                         // Main sequence can not be submitted.
-                        if (field.name.indexOf('main_sequence') == -1) {
+                        if (field.name.indexOf('sequence') == -1) {
                             values[field.name] = field.value;
                         }
                     }
                 });
+
 
                 // Add the selected li value.
                 values[$(this).data('name')] = $(this).data('value');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When using the new url chooser, sequence values can't be submitted with ajax. Otherwise, choosing another link type will not work.

