### PR TITLE
Check if host exists

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -116,7 +116,7 @@ class DomainConfiguration extends BaseDomainConfiguration
      */
     public function getBackendLocales($host = null)
     {
-        if (!$host) {
+        if (!$host && $this->getHost()) {
             $host = $this->hosts[$this->getHost()];
         }
 
@@ -268,7 +268,11 @@ class DomainConfiguration extends BaseDomainConfiguration
     {
         $host = $this->getRealHost($host);
 
-        return $this->hosts[$host];
+        if ($host) {
+            return $this->hosts[$host];
+        }
+
+        return null;
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When indexing nodes, $this->getHost() is empty, therefore we need to check it it exists.