### PR TITLE
[SearchBundle] Allow easier switching between language and ngram word analyzers.

### DIFF
--- a/src/Kunstmaan/SearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SearchBundle/Resources/config/services.yml
@@ -5,8 +5,14 @@ parameters:
     kunstmaan_search.search_configuration_chain.class: Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain
     kunstmaan_search.search_provider_chain.class: Kunstmaan\SearchBundle\Provider\SearchProviderChain
     kunstmaan_search.search.class: Kunstmaan\SearchBundle\Search\Search
-    kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\AnalysisFactory
     kunstmaan_search.search_provider.elastica.class: Kunstmaan\SearchBundle\Provider\ElasticaProvider
+    kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory
+    # Default analysis factory provides language aware analyzers. if you need nGram analyzers you
+    # can use the provided nGramAnalysisFactory by overriding the following parameter.
+    #kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\NGramAnalysisFactory
+    # Ofcourse you can also provide your own implementation as long as it implements the
+    # AnalysisFactoryInterface. More information can be found in the
+    # documentation of this SearchBundle
 
 services:
     kunstmaan_search.search:

--- a/src/Kunstmaan/SearchBundle/Resources/doc/SearchBundle.md
+++ b/src/Kunstmaan/SearchBundle/Resources/doc/SearchBundle.md
@@ -1,0 +1,44 @@
+# SearchBundle documentation
+
+## Analyzers
+
+The Bundles provide 2 sorts of analyzers to choose from. you can choose between
+them by overriding the analysisfactory parameter in the services.
+
+### Language Analyzer
+
+The default analyzer is a language intelligent analyzer who only analyzes real
+words and conjugations. This is a great default and for normal search forms
+this will be the perfect fit.
+
+Default configuration:
+```YAML
+parameters:
+    kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory
+```
+
+### NGram Analyzer
+
+The second analyzer the bundles provides is an nGram based analyzer. This
+analyzer is not language intelligent but splits everything in little chunks of
+words to be searched on. This can be very helpful for a google-like search
+implementation but is slower and more cpu intensive than word based search.
+
+nGram configuration
+```YAML
+parameters:
+    kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\NGramAnalysisFactory
+```
+
+### Custom analyzers
+
+You can easily provide your own analysisfactory with a custom analyzer
+specific for your needs. Create a class that implements the
+AnalysisFactoryInterface and then override the analysisfactory parameter with
+your own class name.
+
+custom configuration
+```YAML
+parameters:
+    kunstmaan_search.search.factory.analysis.class: Demo\AppBundle\Search\CustomAnalysisFactory
+```

--- a/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
+++ b/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
@@ -2,16 +2,16 @@
 
 namespace Kunstmaan\SearchBundle\Search;
 
-class AnalysisFactory implements AnalysisFactoryInterface
+abstract class AbstractAnalysisFactory implements AnalysisFactoryInterface
 {
     /** @var array */
-    private $analyzers;
+    protected $analyzers;
 
     /** @var array */
-    private $tokenizers;
+    protected $tokenizers;
 
     /** @var array */
-    private $filters;
+    protected $filters;
 
     public function __construct()
     {
@@ -39,48 +39,15 @@ class AnalysisFactory implements AnalysisFactoryInterface
      *
      * @return AnalysisFactoryInterface
      */
-    public function addIndexAnalyzer($language)
-    {
-        $this->analyzers['default'] = array(
-            'type'      => $language,
-            'tokenizer' => 'standard',
-            'filter'    => array(
-                'trim',
-                'ngram',
-                'lowercase',
-                'asciifolding',
-                'strip_special_chars',
-                $language . '_stop',
-                $language . '_stemmer'
-            )
-        );
-
-        return $this;
-    }
+    public abstract function addIndexAnalyzer($language);
 
     /**
      * @param string $language
      *
      * @return AnalysisFactoryInterface
      */
-    public function addSuggestionAnalyzer($language)
-    {
-        $this->analyzers['default_search'] = array(
-            'type'      => $language,
-            'tokenizer' => 'standard',
-            'filter'    => array(
-                'trim',
-                'ngram',
-                'lowercase',
-                'asciifolding',
-                'strip_special_chars',
-                $language . '_stop',
-                $language . '_stemmer'
-            )
-        );
+    public abstract function addSuggestionAnalyzer($language);
 
-        return $this;
-    }
 
     /**
      * @param string $language
@@ -131,12 +98,13 @@ class AnalysisFactory implements AnalysisFactoryInterface
     /**
      * @return AnalysisFactoryInterface
      */
-    public function addNGramFilter()
+    public function addNGramTokenizer()
     {
-        $this->filters['ngram'] = array(
+        $this->tokenizers['kuma_ngram'] = array(
             'type'     => 'nGram',
             'min_gram' => 4,
-            'max_gram' => 30
+            'max_gram' => 30,
+            'token_chars' => [ "letter", "digit" ]
         );
         return $this;
     }
@@ -152,7 +120,7 @@ class AnalysisFactory implements AnalysisFactoryInterface
             ->addIndexAnalyzer($language)
             ->addSuggestionAnalyzer($language)
             ->addStripSpecialCharsFilter()
-            ->addNGramFilter()
+            ->addNGramTokenizer()
             ->addStopWordsFilter($language)
             ->addStemmerFilter($language);
 

--- a/src/Kunstmaan/SearchBundle/Search/AnalysisFactoryInterface.php
+++ b/src/Kunstmaan/SearchBundle/Search/AnalysisFactoryInterface.php
@@ -45,7 +45,7 @@ interface AnalysisFactoryInterface
     /**
      * @return AnalysisFactoryInterface
      */
-    public function addNGramFilter();
+    public function addNGramTokenizer();
 
     /**
      * @param string $language

--- a/src/Kunstmaan/SearchBundle/Search/LanguageAnalysisFactory.php
+++ b/src/Kunstmaan/SearchBundle/Search/LanguageAnalysisFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kunstmaan\SearchBundle\Search;
+
+class LanguageAnalysisFactory extends AbstractAnalysisFactory
+{
+    /**
+     * @param string $language
+     *
+     * @return AnalysisFactoryInterface
+     */
+    public function addIndexAnalyzer($language)
+    {
+        $this->analyzers['default'] = array(
+            'type' => $language,
+            'tokenizer' => 'standard',
+            'filter'    => array(
+                'trim',
+                'lowercase',
+                'asciifolding',
+                'strip_special_chars',
+                $language . '_stop',
+                $language . '_stemmer'
+            )
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $language
+     *
+     * @return AnalysisFactoryInterface
+     */
+    public function addSuggestionAnalyzer($language)
+    {
+        $this->analyzers['default_search'] = array(
+            'type' => $language,
+            'tokenizer' => 'standard',
+            'filter'    => array(
+                'trim',
+                'lowercase',
+                'asciifolding',
+                'strip_special_chars',
+                $language . '_stop',
+                $language . '_stemmer'
+            )
+        );
+
+        return $this;
+    }
+}

--- a/src/Kunstmaan/SearchBundle/Search/NGramAnalysisFactory.php
+++ b/src/Kunstmaan/SearchBundle/Search/NGramAnalysisFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kunstmaan\SearchBundle\Search;
+
+class NGramAnalysisFactory extends AbstractAnalysisFactory
+{
+    /**
+     * @param string $language
+     *
+     * @return AnalysisFactoryInterface
+     */
+    public function addIndexAnalyzer($language)
+    {
+        $this->analyzers['default'] = array(
+            'type' => 'custom',
+            'tokenizer' => 'kuma_ngram',
+            'filter'    => array(
+                'trim',
+                'lowercase',
+                'asciifolding',
+                'strip_special_chars',
+                $language . '_stop',
+                $language . '_stemmer'
+            )
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $language
+     *
+     * @return AnalysisFactoryInterface
+     */
+    public function addSuggestionAnalyzer($language)
+    {
+        $this->analyzers['default_search'] = array(
+            'type' => 'custom',
+            'tokenizer' => 'kuma_ngram',
+            'filter'    => array(
+                'trim',
+                'lowercase',
+                'asciifolding',
+                'strip_special_chars',
+                $language . '_stop',
+                $language . '_stemmer'
+            )
+        );
+
+        return $this;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 

Minor BC break: method name in analysisfactory interface changed. addnGramFilter has been changed to addnGramTokenizer because nGrams are supposed to be used as tokenizers and not as a filter. This change actually reflects how elasticsearch is implemented.


