### PR TITLE
[SearchBundle] check if index exists before deleting

### DIFF
--- a/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
+++ b/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
@@ -132,11 +132,16 @@ class ElasticaProvider implements SearchProviderInterface
     /**
      * @param string $indexName
      *
-     * @return \Elastica\Response
+     * @return \Elastica\Response|null
      */
     public function deleteIndex($indexName)
     {
-        return $this->getIndex($indexName)->delete();
+        $index = $this->getIndex($indexName);
+        if ($index->exists()) {
+            return $index->delete();
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

Check if the index exists before trying to delete it, otherwise it throws an exception.