### PR TITLE
[FixtureBundle] Check allowed_children and getPossibleChildTypes in fixture generator

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
@@ -12,6 +12,7 @@ services:
             - '@kunstmaan_node.acl_permission_creator_service'
             - '@kunstmaan_fixtures.populator.populator'
             - '@kunstmaan_utilities.slugifier'
+            - '@kunstmaan_node.pages_configuration'
         tags:
             - { name: kunstmaan_fixtures.builder, alias: PageBuilder }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no (TBD)
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no

This will make fixtures more _production ready_ :)

It's a BC break because projects with _wrong_ fixtures will have to adjust their code.
