### PR TITLE
[FixturesBundle] Improve argument matching and pass set of fixtures

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Parser/Parser.php
+++ b/src/Kunstmaan/FixturesBundle/Parser/Parser.php
@@ -32,9 +32,20 @@ class Parser
             $entities[$key] = $ref->getEntity();
         }
 
-        $fixture->setProperties($this->parseArray($fixture->getProperties(), $providers, $entities, [$fixture]));
-        $fixture->setParameters($this->parseArray($fixture->getParameters(), $providers, $fixtures, [$fixture]));
-        $fixture->setTranslations($this->parseArray($fixture->getTranslations(), $providers, $fixtures, [$fixture]));
+        $fixture->setProperties($this->parseArray($fixture->getProperties(), $providers, $entities, [
+            $fixture,
+            'fixtures' => $fixtures,
+        ]));
+
+        $fixture->setParameters($this->parseArray($fixture->getParameters(), $providers, $fixtures, [
+            $fixture,
+            'fixtures' => $fixtures,
+        ]));
+
+        $fixture->setTranslations($this->parseArray($fixture->getTranslations(), $providers, $fixtures, [
+            $fixture,
+            'fixtures' => $fixtures,
+        ]));
     }
 
     public function parseEntity($entity, $providers, $fixtures = [], $additional = [])

--- a/src/Kunstmaan/FixturesBundle/Parser/Property/Method.php
+++ b/src/Kunstmaan/FixturesBundle/Parser/Property/Method.php
@@ -49,17 +49,17 @@ class Method implements PropertyParserInterface
                  * 2: Search if method needs arguments en find them through typehint and additional params
                  * 3: Magic methods without arguments
                  */
-                if (method_exists($provider, $method) && !empty($arguments)) {
+                if (method_exists($provider, $method)) {
                     $refl = new \ReflectionMethod($provider, $method);
-                    $value = $this->processValue($pattern, $refl->invokeArgs($provider, $arguments), $value, $matches[0]);
-                    break;
-                } elseif (method_exists($provider, $method)) {
-                    $refl = new \ReflectionMethod($provider, $method);
-                    $parameters = $refl->getParameters();
-                    $arguments = $this->findArguments($parameters, $additional);
 
-                    if (count($parameters) !== count($arguments)) {
-                        throw new \Exception('Can not match all arguments for provider ' . get_class($provider));
+                    if (count($arguments) < $refl->getNumberOfRequiredParameters()) {
+                        $parameters = $refl->getParameters();
+                        $parametersNeeded = array_slice($parameters, count($arguments));
+                        $arguments = array_merge($arguments, $this->findArguments($parametersNeeded, $additional));
+
+                        if (count($parameters) !== count($arguments)) {
+                            throw new \Exception('Can not match all arguments for provider ' . get_class($provider));
+                        }
                     }
 
                     $value = $this->processValue($pattern, $refl->invokeArgs($provider, $arguments), $value, $matches[0]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

This pull request changes two things:

Currently if you have a provider implementing a method that is called without arguments the MethodParser will try and complete these arguments based on type or name. If it is called with arguments they are passed two the providers method. This PR changes this to check if the number of arguments passed to the function matches the number of required arguments and will try to complete the missing ones as before.

Also, as the parses will try to complete missing arguments based on name, we pass all the fixtures currently being parsed with the `fixtures` key. This will allow you to add a parameter named `$fixtures` to your provider method which will be completed by the parser.

