### PR TITLE
Define parent service of PDF handler

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -17,6 +17,7 @@ services:
 
     kunstmaan_media.media_handlers.pdf:
         class: '%kunstmaan_media.media_handler.pdf.class%'
+        parent: kunstmaan_media.media_handlers.file
         arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory']
         calls:
             - [ setMediaPath, [ '%kernel.root_dir%' ] ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

PdfHandler service definition doesn't call setSlugifier(), causing PdfHandler::prepareMedia() to fail if it's ever called.