### PR TITLE
[AdminBundle] Added post-install script to setup single lang site

### DIFF
--- a/src/Kunstmaan/AdminBundle/Composer/ScriptHandler.php
+++ b/src/Kunstmaan/AdminBundle/Composer/ScriptHandler.php
@@ -1,0 +1,84 @@
+<?php
+namespace Kunstmaan\AdminBundle\Composer;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Parser;
+use Composer\Script\Event;
+
+class ScriptHandler
+{
+    protected static $options = array(
+        'symfony-app-dir' => 'app',
+        'multi-language-option' => 'multilanguage'
+    );
+
+    /**
+     * @param Event $event
+     */
+    public static function checkMultiLangConfigs(Event $event)
+    {
+        $options = static::getOptions($event);
+        $appDir = getcwd() . '/' . $options['symfony-app-dir'];
+        $configDir = $appDir . '/config';
+        $parametersFile = $configDir . '/parameters.yml';
+        $routingFile = $configDir . '/routing.yml';
+        $securityFile = $configDir . '/security.yml';
+        $singleLangRoutingFile = $configDir . '/routing.singlelang.yml';
+        $singleLangSecurityFile = $configDir . '/security.singlelang.yml';
+        $multiLangRoutingFile = $configDir . '/routing.multilang.yml';
+        $multiLangSecurityFile = $configDir . '/security.multilang.yml';
+
+        if (is_file($parametersFile)) {
+            $parameters = self::getConfigParameters($parametersFile);
+
+            if (isset($parameters[$options['multi-language-option']])) {
+                $multiLanguage = $parameters[$options['multi-language-option']];
+                if (! $multiLanguage) {
+                    $fs = new Filesystem();
+
+                    // move routing
+                    if (is_file($singleLangRoutingFile) && ! is_file($multiLangRoutingFile)) {
+                        try {
+                            $fs->rename($routingFile, $multiLangRoutingFile);
+                            $fs->rename($singleLangRoutingFile, $routingFile);
+                            $event->getIO()->write(sprintf("Replaced routing config with single language config"));
+                        } catch (IOException $ioE) {
+                            $event->getIO()->write(sprintf('Exception while moving routing file to singlelang routing file: <error>%s</error>', $ioE->getMessage()));
+                        }
+                    }
+                    // move security
+                    if (is_file($singleLangSecurityFile) && ! is_file($multiLangSecurityFile)) {
+                        try {
+                            $fs->rename($securityFile, $multiLangSecurityFile);
+                            $fs->rename($singleLangSecurityFile, $securityFile);
+                            $event->getIO()->write(sprintf("Replaced security config with single language config"));
+                        } catch (IOException $ioE) {
+                            $event->getIO()->write(sprintf('Exception while moving routing file to singlelang routing file: <error>%s</error>', $ioE->getMessage()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Event $event
+     * @return array
+     */
+    protected static function getOptions(Event $event)
+    {
+        return array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
+    }
+
+    /**
+     * @param string $parametersFile
+     * @return array
+     */
+    protected static function getConfigParameters($parametersFile)
+    {
+        $ymlParser = new Parser();
+        $config = $ymlParser->parse(file_get_contents($parametersFile));
+        return isset($config['parameters']) ? $config['parameters'] : array();
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -148,6 +148,6 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
         $registry = $this->getContainer()->get('doctrine');
 
-        return new DefaultSiteGenerator($filesystem, $registry, '/defaultsite', $this->assistant);
+        return new DefaultSiteGenerator($filesystem, $registry, '/defaultsite', $this->assistant, $this->getContainer());
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -421,6 +421,11 @@ class DefaultSiteGenerator extends KunstmaanGenerator
      * @return bool
      */
     private function isMultiLangEnvironment() {
+        // use the multilanguage parameter, if it exists
+        if ($this->container->hasParameter('multilanguage')) {
+            return $this->container->getParameter('multilanguage');
+        }
+
         // This is a pretty silly implementation.
         // It just checks if it can find _locale in the routing.yml
         $routingFile = file_get_contents($this->rootDir.'/app/config/routing.yml');

--- a/src/Kunstmaan/GeneratorBundle/Tests/Generator/DefaultSiteGeneratorTest.php
+++ b/src/Kunstmaan/GeneratorBundle/Tests/Generator/DefaultSiteGeneratorTest.php
@@ -17,8 +17,10 @@ class DefaultSiteGeneratorTest extends \PHPUnit_Framework_TestCase
         $filesystem->remove($path);
 
         $bundle = $this->getBundle($path);
+        $kernel = new \AppKernel('phpunit', true);
+        $kernel->boot();
 
-        $generator = new DefaultSiteGenerator($filesystem, $this->getRegistry(), '/defaultsite', $this->getAssistant());
+        $generator = new DefaultSiteGenerator($filesystem, $this->getRegistry(), '/defaultsite', $this->getAssistant(), $kernel->getContainer());
         $generator->generate($bundle, '', __DIR__ . '/../data', false);
 
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 1086

[AdminBundle] Added post-install script to setup configs for single language file
[GeneratorBundle] Use multilanguage parameter to detect multi/single language, when generating default-site