### PR TITLE
[AdminListBundle]: urlchooser ajax requests

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -224,9 +224,12 @@ abstract class AdminListController extends Controller
                 $this->container->get('event_dispatcher')->dispatch(AdminListEvents::POST_EDIT, new AdminListEvent($helper));
                 $indexUrl = $configurator->getIndexUrl();
 
-                return new RedirectResponse(
-                    $this->generateUrl($indexUrl['path'], isset($indexUrl['params']) ? $indexUrl['params'] : array())
-                );
+                // Don't redirect to listing when coming from ajax request, needed for url chooser.
+                if (!$request->isXmlHttpRequest()) {
+                    return new RedirectResponse(
+                        $this->generateUrl($indexUrl['path'], isset($indexUrl['params']) ? $indexUrl['params'] : array())
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When having an admin list form with a urlchooser, the new urlchooser does not work because when submitting the form with ajax, you will get redirected to the listing. This fix prevents this.

