### PR TITLE
Fix user create (custom user error)

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
@@ -94,7 +94,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, C
         $enabled = false,
         $changed = false
     ) {
-        $user = new User();
+        $user = $this->container->get('fos_user.user_manager')->createUser();
         $user->setUsername($username);
         $user->setPlainPassword($password);
         $user->setRoles($roles);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The original fixture ignores the custom FOS User config. It force uses the `Kunstmaan\AdminBundle\Entity\User` regardless of the config.

