### PR TITLE
[NodeBundle] Add node form type by fqcn and replace DI to options

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -935,10 +935,11 @@ class NodeAdminController extends Controller
         $menuWidget = new FormWidget();
         $menuWidget->addType(
             'menunodetranslation',
-            new NodeMenuTabTranslationAdminType($isStructureNode),
-            $nodeTranslation
+            NodeMenuTabTranslationAdminType::class,
+            $nodeTranslation,
+            ['slugable' => !$isStructureNode]
         );
-        $menuWidget->addType('menunode', new NodeMenuTabAdminType($isStructureNode), $node);
+        $menuWidget->addType('menunode', NodeMenuTabAdminType::class, $node, ['available_in_nav' => !$isStructureNode]);
         $tabPane->addTab(new Tab('kuma_node.tab.menu.title', $menuWidget));
 
         $this->get('event_dispatcher')->dispatch(

--- a/src/Kunstmaan/NodeBundle/Form/NodeMenuTabAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeMenuTabAdminType.php
@@ -11,32 +11,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class NodeMenuTabAdminType extends AbstractType
 {
     /**
-     * @var bool
-     */
-    private $isStructureNode;
-
-    /**
-     * @param bool $isStructureNode
-     */
-    public function __construct($isStructureNode = false)
-    {
-        $this->isStructureNode = $isStructureNode;
-    }
-
-    /**
      * @param FormBuilderInterface $builder
      * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!$this->isStructureNode) {
+        if ($options['available_in_nav']) {
             $builder->add('hiddenFromNav', CheckboxType::class, array(
-                'label' => 'kuma_node.form.menu_tab.hidden_from_menu.label', 
+                'label' => 'kuma_node.form.menu_tab.hidden_from_menu.label',
                 'required' => false,
             ));
         }
         $builder->add('internalName', TextType::class, array(
-            'label' => 'kuma_node.form.menu_tab.internal_name.label', 
+            'label' => 'kuma_node.form.menu_tab.internal_name.label',
             'required' => false,
         ));
     }
@@ -53,6 +40,7 @@ class NodeMenuTabAdminType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Kunstmaan\NodeBundle\Entity\Node',
+            'available_in_nav' => true,
         ));
     }
 }

--- a/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeMenuTabTranslationAdminType.php
@@ -12,25 +12,12 @@ use Symfony\Component\Validator\Constraints\Regex;
 class NodeMenuTabTranslationAdminType extends AbstractType
 {
     /**
-     * @var bool
-     */
-    private $isStructureNode;
-
-    /**
-     * @param bool $isStructureNode
-     */
-    public function __construct($isStructureNode = false)
-    {
-        $this->isStructureNode = $isStructureNode;
-    }
-
-    /**
      * @param FormBuilderInterface $builder
      * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!$this->isStructureNode) {
+        if ($options['slugable']) {
             $builder->add('slug', SlugType::class, array(
                 'label' => 'kuma_node.form.menu_tab_translation.slug.label',
                 'required' => false,
@@ -45,7 +32,7 @@ class NodeMenuTabTranslationAdminType extends AbstractType
             'placeholder' => false,
             'required'    => false,
             'attr'        => array('title' => 'kuma_node.form.menu_tab_translation.weight.title'),
-            'choice_translation_domain' => false
+            'choice_translation_domain' => false,
         ));
     }
 
@@ -61,6 +48,7 @@ class NodeMenuTabTranslationAdminType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Kunstmaan\NodeBundle\Entity\NodeTranslation',
+            'slugable' => true,
         ));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |

Parameter passing to `NodeMenuTabAdminType` via constructor does not anymore in Symfony3 as it is recreated again in the form widget:

```
.....
        // Get fully qualified class name of form if not provided as string
        if ($type instanceof AbstractType) {
            $type = get_class($type); // IT WOULD BE RECREATED LATER...
        }
        $this->types[$name] = $type;
.....
```
