### PR TITLE
[URLChooser]: add link_types

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
@@ -122,7 +122,7 @@ kunstmaanbundles.urlChooser = (function (window, undefined) {
             parent.$('#' + linkedInputId).val(itemUrl).change();
 
             // Set proper URL
-            parent.$('#' + linkedInputId).parents().find('.js-urlchooser-value').val(replacedUrl);
+            parent.$('#' + linkedInputId).parent().find('.js-urlchooser-value').val(replacedUrl);
 
             // Close modal
             parent.$('#' + parentModalId).modal('hide');

--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
@@ -47,7 +47,14 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
             }
         }
         else {
-            $attributes['choose_url'] = true;
+            $choices = $form->get('link_type')->getConfig()->getOption('choices');
+            $firstOption = array_shift($choices);
+
+            if ($firstOption == URLChooserType::INTERNAL) {
+                $attributes['choose_url'] = true;
+            }
+
+            $form->get('link_type')->setData($firstOption);
         }
 
         $form->add('link_url', TextType::class, array(

--- a/src/Kunstmaan/NodeBundle/Form/Type/URLChooserType.php
+++ b/src/Kunstmaan/NodeBundle/Form/Type/URLChooserType.php
@@ -32,24 +32,30 @@ class URLChooserType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!$options['internal_link_only']) {
-            $choices = [
-                'pagepart.link.internal' => URLChooserType::INTERNAL,
-                'pagepart.link.external' => URLChooserType::EXTERNAL,
-                'pagepart.link.email' => URLChooserType::EMAIL,
-            ];
+        $choices = [
+            'pagepart.link.internal' => URLChooserType::INTERNAL,
+            'pagepart.link.external' => URLChooserType::EXTERNAL,
+            'pagepart.link.email' => URLChooserType::EMAIL,
+        ];
 
-            $builder->add('link_type', ChoiceType::class, array(
-                'required' => true,
-                'mapped' => false,
-                'attr' => array(
-                    'class' => 'js-change-link-type',
-                ),
-                'choices' => $choices,
-            ));
-
-            $builder->get('link_type')->addEventSubscriber(new URLChooserLinkTypeSubscriber());
+        if ($types = $options['link_types']) {
+            foreach ($choices as $key => $choice) {
+                if (!in_array($choice, $types)) {
+                    unset($choices[$key]);
+                }
+            }
         }
+
+        $builder->add('link_type', ChoiceType::class, array(
+            'required' => true,
+            'mapped' => false,
+            'attr' => array(
+                'class' => 'js-change-link-type',
+            ),
+            'choices' => $choices,
+        ));
+
+        $builder->get('link_type')->addEventSubscriber(new URLChooserLinkTypeSubscriber());
 
         $builder->addEventSubscriber(new URLChooserFormSubscriber());
         $builder->addViewTransformer(new URLChooserToLinkTransformer());
@@ -64,7 +70,7 @@ class URLChooserType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => null,
-            'internal_link_only' => false
+            'link_types' => []
         ));
     }
 

--- a/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
@@ -106,9 +106,10 @@ class URLHelper
                             if ($hostId) {
                                 $urlParams['otherSite'] = $hostId;
                             }
+
                             $url = $this->router->generate('_slug', $urlParams);
 
-                            $text = str_replace($fullTag, $hostBaseUrl . $url, $text);
+                            $text = str_replace($fullTag, $hostId ? $hostBaseUrl : '' . $url, $text);
                         }
                     }
 

--- a/src/Kunstmaan/SeoBundle/Form/SocialType.php
+++ b/src/Kunstmaan/SeoBundle/Form/SocialType.php
@@ -40,7 +40,10 @@ class SocialType extends AbstractType
             ->add('ogUrl', URLChooserType::class, array(
                 'label' => 'seo.form.og.url',
                 'required'  => false,
-                'internal_link_only' => true
+                'link_types' => [
+                    URLChooserType::INTERNAL,
+                    URLChooserType::EXTERNAL,
+                ]
             ))
             ->add('ogType', ChoiceType::class, array(
                 'label'     => 'seo.form.og.type',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #1293

- Removed the internal_link_only option in favour of the link_types option to provide which link types can be used. 
- Adapted the SocialForm to allow external and internal url's for og:url.
- Removed absolute url when the link is on the current host.
