### PR TITLE
[Composer]: revert twig to 1.25

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "twig/extensions": "~1.0",
         "egulias/email-validator": "~1.2",
         "box/spout": "^2.5",
+        "twig/twig": "1.25",
         "ruflin/elastica": "^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

As of twig 1.26 they removed the twig extension getName() function. 

See https://github.com/twigphp/Twig/issues/2147

Symfony has also released a new tag but we do not install dev releases of symfony. Therefore we need to use twig 1.25 for now.
