### PR TITLE
[NodeBundle]: url chooser fix

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -996,22 +996,25 @@ class NodeAdminController extends Controller
                     );
                 }
 
-                $params = array(
-                    'id' => $node->getId(),
-                    'subaction' => $subaction,
-                    'currenttab' => $tabPane->getActiveTab()
-                );
-                $params = array_merge(
-                    $params,
-                    $tabPane->getExtraParams($request)
-                );
+                // Don't redirect to listing when coming from ajax request, needed for url chooser.
+                if (!$request->isXmlHttpRequest()) {
+                    $params = array(
+                        'id' => $node->getId(),
+                        'subaction' => $subaction,
+                        'currenttab' => $tabPane->getActiveTab()
+                    );
+                    $params = array_merge(
+                        $params,
+                        $tabPane->getExtraParams($request)
+                    );
 
-                return $this->redirect(
-                    $this->generateUrl(
-                        'KunstmaanNodeBundle_nodes_edit',
-                        $params
-                    )
-                );
+                    return $this->redirect(
+                        $this->generateUrl(
+                            'KunstmaanNodeBundle_nodes_edit',
+                            $params
+                        )
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When changing the link type of the URL chooser in a node edit, we can not execute the redirect when ajax request is made. When for example choosing the "external" link type, an ajax request will submit the form to change the field. The edit action will redirect again to the edit page and the field will not be replaced.

