### PR TITLE
[SeoBundle] Catch exception when OG image no longer exists

### DIFF
--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -61,8 +61,10 @@
         {% set dimensions = get_image_dimensions(imageUrl) %}
         <meta property="og:image" content="{{ asset(imageUrl) }}">
         <meta property="og:image:type" content="{{ seo.ogImage.contentType }}">
-        <meta property="og:image:height" content="{{ dimensions.height }}">
-        <meta property="og:image:width" content="{{ dimensions.width }}">
+        {% if dimensions %}
+            <meta property="og:image:height" content="{{ dimensions.height }}">
+            <meta property="og:image:width" content="{{ dimensions.width }}">
+        {% endif %}
         <link rel="image_src" href="{{ asset(imageUrl) }}"/>
     {% endif %}
 {% endif %}

--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -244,11 +244,16 @@ class SeoTwigExtension extends Twig_Extension
     /**
      * @param $src
      *
-     * @return Seo
+     * @return array|null
      */
     public function getImageDimensions($src)
     {
-        list($width, $height) = getimagesize($src);
+        try {
+            list($width, $height) = getimagesize($src);
+        } catch (\Exception $e) {
+            return null;
+        }
+
         return array('width' => $width, 'height' => $height);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

When the selected ogImage is no longer present on disk, `get_image_dimensions` will throw an exception.

