### PR TITLE
[AdminListBundle]: don't redirect on add form

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -139,7 +139,8 @@ abstract class AdminListController extends Controller
                 $form->handleRequest($request);
             }
 
-            if ($form->isValid()) {
+            // Don't redirect to listing when coming from ajax request, needed for url chooser.
+            if ($form->isValid() && !$request->isXmlHttpRequest()) {
                 $this->container->get('event_dispatcher')->dispatch(AdminListEvents::PRE_ADD, new AdminListEvent($helper));
 
                 // Check if Sortable interface is implemented
@@ -217,19 +218,17 @@ abstract class AdminListController extends Controller
                 $form->handleRequest($request);
             }
 
-            if ($form->isValid()) {
+            // Don't redirect to listing when coming from ajax request, needed for url chooser.
+            if ($form->isValid() && !$request->isXmlHttpRequest()) {
                 $this->container->get('event_dispatcher')->dispatch(AdminListEvents::PRE_EDIT, new AdminListEvent($helper));
                 $em->persist($helper);
                 $em->flush();
                 $this->container->get('event_dispatcher')->dispatch(AdminListEvents::POST_EDIT, new AdminListEvent($helper));
                 $indexUrl = $configurator->getIndexUrl();
 
-                // Don't redirect to listing when coming from ajax request, needed for url chooser.
-                if (!$request->isXmlHttpRequest()) {
-                    return new RedirectResponse(
-                        $this->generateUrl($indexUrl['path'], isset($indexUrl['params']) ? $indexUrl['params'] : array())
-                    );
-                }
+                return new RedirectResponse(
+                    $this->generateUrl($indexUrl['path'], isset($indexUrl['params']) ? $indexUrl['params'] : array())
+                );
             }
         }
 

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -958,7 +958,8 @@ class NodeAdminController extends Controller
         if ($request->getMethod() == 'POST') {
             $tabPane->bindRequest($request);
 
-            if ($tabPane->isValid()) {
+            // Don't redirect to listing when coming from ajax request, needed for url chooser.
+            if ($tabPane->isValid() && !$request->isXmlHttpRequest()) {
                 $this->get('event_dispatcher')->dispatch(
                     Events::PRE_PERSIST,
                     new NodeEvent($node, $nodeTranslation, $nodeVersion, $page)
@@ -994,25 +995,22 @@ class NodeAdminController extends Controller
                     );
                 }
 
-                // Don't redirect to listing when coming from ajax request, needed for url chooser.
-                if (!$request->isXmlHttpRequest()) {
-                    $params = array(
-                        'id' => $node->getId(),
-                        'subaction' => $subaction,
-                        'currenttab' => $tabPane->getActiveTab()
-                    );
-                    $params = array_merge(
-                        $params,
-                        $tabPane->getExtraParams($request)
-                    );
+                $params = array(
+                    'id' => $node->getId(),
+                    'subaction' => $subaction,
+                    'currenttab' => $tabPane->getActiveTab()
+                );
+                $params = array_merge(
+                    $params,
+                    $tabPane->getExtraParams($request)
+                );
 
-                    return $this->redirect(
-                        $this->generateUrl(
-                            'KunstmaanNodeBundle_nodes_edit',
-                            $params
-                        )
-                    );
-                }
+                return $this->redirect(
+                    $this->generateUrl(
+                        'KunstmaanNodeBundle_nodes_edit',
+                        $params
+                    )
+                );
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When switching URL chooser in the adminlist add form, we can not do the redirect when submitting the form.

