### PR TITLE
[AllBundle]: removed getName from twig extensions

### DIFF
--- a/src/Kunstmaan/AdminBundle/Twig/AdminPermissionsTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/AdminPermissionsTwigExtension.php
@@ -46,14 +46,4 @@ class AdminPermissionsTwigExtension extends \Twig_Extension
             'recursiveSupport'  => true
         ), $parameters));
     }
-
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'permissionsadmin_twig_extension';
-    }
 }

--- a/src/Kunstmaan/AdminBundle/Twig/DateByLocaleExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/DateByLocaleExtension.php
@@ -21,15 +21,6 @@ class DateByLocaleExtension extends \Twig_Extension
         );
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'TwigLocaleExtension';
-    }
 
     /**
      * A date formatting filter for Twig, renders the date using the specified parameters.

--- a/src/Kunstmaan/AdminBundle/Twig/FormToolsExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/FormToolsExtension.php
@@ -39,15 +39,6 @@ class FormToolsExtension extends \Twig_Extension
         );
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'FormToolsExtension';
-    }
 
     /**
      * Return if there are error messages.

--- a/src/Kunstmaan/AdminBundle/Twig/GoogleSignInTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/GoogleSignInTwigExtension.php
@@ -46,12 +46,4 @@ class GoogleSignInTwigExtension extends Twig_Extension
         return $this->clientId;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'google_signin_twig_extension';
-    }
-
 }

--- a/src/Kunstmaan/AdminBundle/Twig/LocaleSwitcherTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/LocaleSwitcherTwigExtension.php
@@ -79,13 +79,4 @@ class LocaleSwitcherTwigExtension extends \Twig_Extension
         return $this->domainConfiguration->getBackendLocales($switchedHost);
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'localeswitcher_twig_extension';
-    }
 }

--- a/src/Kunstmaan/AdminBundle/Twig/MenuTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/MenuTwigExtension.php
@@ -61,13 +61,4 @@ class MenuTwigExtension extends \Twig_Extension
         return $this->adminPanel->getAdminPanelActions();
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'adminmenu_twig_extension';
-    }
 }

--- a/src/Kunstmaan/AdminBundle/Twig/MultiDomainAdminTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/MultiDomainAdminTwigExtension.php
@@ -94,13 +94,4 @@ class MultiDomainAdminTwigExtension extends \Twig_Extension
         return $this->domainConfiguration->getHosts();
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'MultiDomainAdminTwigExtension';
-    }
 }

--- a/src/Kunstmaan/AdminBundle/Twig/TabsTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/TabsTwigExtension.php
@@ -41,12 +41,5 @@ class TabsTwigExtension extends Twig_Extension
         )));
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'tabs_twig_extension';
-    }
 
 }

--- a/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
+++ b/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
@@ -80,14 +80,5 @@ class AdminListTwigExtension extends \Twig_Extension
         return ExportService::getSupportedExtensions();
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'adminlist_twig_extension';
-    }
 
 }

--- a/src/Kunstmaan/ConfigBundle/Twig/ConfigTwigExtension.php
+++ b/src/Kunstmaan/ConfigBundle/Twig/ConfigTwigExtension.php
@@ -77,11 +77,4 @@ class ConfigTwigExtension extends Twig_Extension
         return null;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kunstmaan_config_twig_extension';
-    }
 }

--- a/src/Kunstmaan/LeadGenerationBundle/Twig/PopupTwigExtension.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Twig/PopupTwigExtension.php
@@ -143,11 +143,4 @@ class PopupTwigExtension extends \Twig_Extension
         return $rules;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kunstmaan_lead_generation_popup_twig_extension';
-    }
 }

--- a/src/Kunstmaan/MenuBundle/Twig/MenuTwigExtension.php
+++ b/src/Kunstmaan/MenuBundle/Twig/MenuTwigExtension.php
@@ -113,11 +113,4 @@ class MenuTwigExtension extends \Twig_Extension
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kunstmaan_menu_twig_extension';
-    }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Twig/MultiDomainTwigExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/Twig/MultiDomainTwigExtension.php
@@ -70,13 +70,4 @@ class MultiDomainTwigExtension extends \Twig_Extension implements \Twig_Extensio
         return $this->domainConfiguration->getFullHost();
     }
 
-    /**
-     * Get the Twig extension name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return 'MultiDomainTwigExtension';
-    }
 }

--- a/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
@@ -258,12 +258,4 @@ class NodeTwigExtension extends Twig_Extension
             $parameters
         );
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'node_twig_extension';
-    }
 }

--- a/src/Kunstmaan/NodeBundle/Twig/PagesConfigurationTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/PagesConfigurationTwigExtension.php
@@ -54,13 +54,4 @@ class PagesConfigurationTwigExtension extends \Twig_Extension
         return $this->pagesConfiguration->getHomepageTypes();
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'pages_configuration_twig_extension';
-    }
 }

--- a/src/Kunstmaan/NodeBundle/Twig/UrlReplaceTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/UrlReplaceTwigExtension.php
@@ -35,11 +35,4 @@ class UrlReplaceTwigExtension extends \Twig_Extension
         return $this->urlHelper->replaceUrl($text);
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kunstmaan_url_replace_extension';
-    }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
@@ -89,13 +89,4 @@ class KunstmaanNodeSearchTwigExtension extends \Twig_Extension
         return $template->render($newTwigContext);
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'kunstmaan_node_search_twig_extension';
-    }
 }

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
@@ -55,11 +55,4 @@ class PagePartAdminTwigExtension extends \Twig_Extension
         )));
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'pagepartadmin_twig_extension';
-    }
 }

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -74,12 +74,5 @@ class PagePartTwigExtension extends \Twig_Extension
         return $pageparts;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'pageparts_twig_extension';
-    }
 
 }

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
@@ -61,12 +61,5 @@ class PageTemplateTwigExtension extends \Twig_Extension
         return $this->templateConfiguration->findOrCreateFor($page)->getPageTemplate();
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'pagetemplate_twig_extension';
-    }
 
 }

--- a/src/Kunstmaan/SeoBundle/Twig/GoogleAnalyticsTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/GoogleAnalyticsTwigExtension.php
@@ -125,13 +125,6 @@ class GoogleAnalyticsTwigExtension extends Twig_Extension
         return $template->render($options);
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kuma_google_analytics_twig_extension';
-    }
 
 
     /**

--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -168,14 +168,6 @@ class SeoTwigExtension extends Twig_Extension
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kuma_seo_twig_extension';
-    }
-
 
     /**
      * @param array $values

--- a/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
+++ b/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
@@ -56,15 +56,5 @@ class SitemapTwigExtension extends \Twig_Extension
         return false;
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return "kunstmaan_sitemap_extension";
-    }
-
 }
 

--- a/src/Kunstmaan/UtilitiesBundle/Twig/UtilitiesTwigExtension.php
+++ b/src/Kunstmaan/UtilitiesBundle/Twig/UtilitiesTwigExtension.php
@@ -43,12 +43,5 @@ class UtilitiesTwigExtension extends Twig_Extension
         return $this->slugifier->slugify($text, '');
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'kunstmaan_utilities_twig_extension';
-    }
 
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1321 

As of twig 1.26 they removed the twig extension getName() function.

I removed the getName() function in all twig extension files.
