### PR TITLE
[TranslatorBundle]: Scale textarea to content

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Resources/ui/js/_inline-edit.js
+++ b/src/Kunstmaan/TranslatorBundle/Resources/ui/js/_inline-edit.js
@@ -9,6 +9,11 @@ kunstmaanTranslatorBundle.inlineEdit = (function(window, undefined) {
 
         $('.js-editable').each(function() {
             var $field = $(this);
+            var width = $field.width();
+
+            $field.on('shown', function(e, editable) {
+                editable.input.$input.css('width', width + 50);
+            });
 
             $field.editable({
                 showbuttons: 'bottom',
@@ -21,12 +26,11 @@ kunstmaanTranslatorBundle.inlineEdit = (function(window, undefined) {
                     params.domain = $field.data('domain');
                     params.keyword = $field.data('keyword');
                     params.translationId = $field.data('tid');
-
                     return params;
                 },
                 success: function(response, newValue) {
                     if (response.success) {
-                    $field.data('uid', response.uid);
+                        $field.data('uid', response.uid);
                     }
                 }
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Scale textareas to the content that is being edited.

![screen shot 2016-10-12 at 14 30 30](https://cloud.githubusercontent.com/assets/6680607/19310465/7c4994ca-908a-11e6-80d9-77dcda7c31a7.png)

Textarea was too small for the content.

![screen shot 2016-10-12 at 14 31 22](https://cloud.githubusercontent.com/assets/6680607/19310466/7c49df20-908a-11e6-889e-6b7bda1322ea.png)


