### PR TITLE
[FormBundle]: fix TopMenuItem

### DIFF
--- a/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/edit.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/edit.html.twig
@@ -3,7 +3,7 @@
 {% block header %}
     {% if adminmenu.current %}
         <div class="page-header">
-            <h1>{{ adminmenu.current.internalname | trans }} {% block page_header_addition %}{% endblock %}</h1>
+            <h1>{{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}</h1>
             <small><strong>date</strong>: {{ formsubmission.created|date }} / <strong>language</strong>: {{ formsubmission.lang }} / <strong>ip</strong>: {{ formsubmission.ipAddress }}</small>
             {% block extra_actions_header %}{% endblock %}
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

InternalName was removed in 3eb66d60d91a27594828f7c4a2f8264d98d34ad3

Removed use of this variable in twig file


