### PR TITLE
[All bundles] Allow /admin/ url to be configurable in parameters.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ autoload.php
 .DS_Store
 npm-debug.log
 *~
+*test.db

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('admin_password')->end()
                 ->scalarNode('dashboard_route')->end()
+                ->scalarNode('admin_prefix')->defaultValue('admin')->end()
                 ->arrayNode('admin_locales')
                     ->defaultValue(array('en'))
                     ->prototype('scalar')->end()

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -50,6 +50,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_admin.session_security.ip_check', $config['session_security']['ip_check']);
         $container->setParameter('kunstmaan_admin.session_security.user_agent_check', $config['session_security']['user_agent_check']);
 
+        $container->setParameter('kunstmaan_admin.admin_prefix', $this->normalizeUrlSlice($config['admin_prefix']));
+
         $container->setParameter('kunstmaan_admin.google_signin.enabled', $config['google_signin']['enabled']);
         $container->setParameter('kunstmaan_admin.google_signin.client_id', $config['google_signin']['client_id']);
         $container->setParameter('kunstmaan_admin.google_signin.client_secret', $config['google_signin']['client_secret']);
@@ -128,5 +130,24 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $definition->addTag('kunstmaan_admin.menu.adaptor');
 
         $container->setDefinition('kunstmaan_admin.menu.adaptor.simple', $definition);
+    }
+
+    /**
+     * @param string $urlSlice
+     *
+     * @return string
+     */
+    protected function normalizeUrlSlice($urlSlice)
+    {
+        /* Get rid of exotic characters that would break the url */
+        $urlSlice = filter_var($urlSlice, FILTER_SANITIZE_URL);
+
+        /* Remove leading and trailing slashes */
+        $urlSlice = trim($urlSlice, '/');
+
+        /* Make sure our $urlSlice is literally used in our regex */
+        $urlSlice = preg_quote($urlSlice);
+
+        return $urlSlice;
     }
 }

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -10,6 +10,7 @@ use Symfony\Component\Routing\RouterInterface as Router;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 
 /**
  * PasswordCheckListener to check if the user has to change his password
@@ -42,19 +43,26 @@ class PasswordCheckListener
     private $translator;
 
     /**
+     * @var AdminRouteHelper
+     */
+    private $adminRouteHelper;
+
+    /**
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param TokenStorageInterface $tokenStorage
      * @param Router $router
      * @param Session $session
      * @param TranslatorInterface $translator
+     * @param AdminRouteHelper $adminRouteHelper
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, TranslatorInterface $translator)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, TranslatorInterface $translator, AdminRouteHelper $adminRouteHelper)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
         $this->router = $router;
         $this->session = $session;
         $this->translator = $translator;
+        $this->adminRouteHelper = $adminRouteHelper;
     }
 
     /**
@@ -63,7 +71,7 @@ class PasswordCheckListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $url = $event->getRequest()->getRequestUri();
-        if ($this->tokenStorage->getToken() && $this->isAdminRoute($url)) {
+        if ($this->tokenStorage->getToken() && $this->adminRouteHelper->isAdminRoute($url)) {
             $route = $event->getRequest()->get('_route');
             if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') && $route != 'fos_user_change_password') {
                 $user = $this->tokenStorage->getToken()->getUser();
@@ -77,26 +85,5 @@ class PasswordCheckListener
                 }
             }
         }
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return bool
-     */
-    private function isAdminRoute($url)
-    {
-        preg_match('/^\/(app_(.*)\.php\/)?([a-zA-Z_-]{2,5}\/)?admin\/(.*)/', $url, $matches);
-
-        // Check if path is part of admin area
-        if (count($matches) === 0) {
-            return false;
-        }
-
-        if (strpos($url, '/admin/preview') !== false) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Helper;
+
+use Kunstmaan\NodeBundle\Router\SlugRouter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class AdminRouteHelper
+ */
+class AdminRouteHelper
+{
+    protected static $ADMIN_MATCH_REGEX = '/^\/(app_[a-zA-Z]+\.php\/)?([a-zA-Z_-]{2,5}\/)?%s\/(.*)/';
+
+    /**
+     * @var string $adminKey
+     */
+    protected $adminKey;
+
+    /**
+     * @var RequestStack $requestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @param string $adminKey
+     * @param RequestStack $requestStack
+     */
+    public function __construct($adminKey, RequestStack $requestStack)
+    {
+        $this->adminKey = $adminKey;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Checks wether the given url points to an admin route
+     *
+     * @param string $url
+     *
+     * @return bool
+     */
+    public function isAdminRoute($url)
+    {
+        if ($this->matchesPreviewRoute($url)) {
+            return false;
+        }
+
+        preg_match(sprintf(self::$ADMIN_MATCH_REGEX, $this->adminKey), $url, $matches);
+
+        // Check if path is part of admin area
+        if (count($matches) === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks the current request if it's route is equal to SlugRouter::$SLUG_PREVIEW
+     *
+     * @param string $url
+     *
+     * @return boolean
+     */
+    protected function matchesPreviewRoute($url)
+    {
+        $routeName = $this->requestStack->getCurrentRequest()->get('_route');
+
+        return $routeName == SlugRouter::$SLUG_PREVIEW;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
@@ -1,21 +1,21 @@
 KunstmaanAdminBundle_default:
     resource: '@KunstmaanAdminBundle/Controller/DefaultController.php'
     type:     annotation
-    prefix:   /admin  
+    prefix:   /%kunstmaan_admin.admin_prefix%
 
 KunstmaanAdminBundle_modules:
     resource: '@KunstmaanAdminBundle/Controller/ModulesController.php'
     type:     annotation
-    prefix:   /admin/modules
-        
+    prefix:   /%kunstmaan_admin.admin_prefix%/modules
+
 KunstmaanAdminBundle_settings:
     resource: '@KunstmaanAdminBundle/Controller/SettingsController.php'
     type:     annotation
-    prefix:   /admin/settings      
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings
 
 # Change user password route
 KunstmaanAdminBundle_user_change_password:
-    path: /admin/settings/users/{id}/edit
+    path: /%kunstmaan_admin.admin_prefix%/settings/users/{id}/edit
     defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
     methods: [GET, POST]
 
@@ -24,27 +24,27 @@ KunstmaanAdminBundle_user_change_password:
 ###########################
 
 fos_user_security_login:
-    path: /admin/login
+    path: /%kunstmaan_admin.admin_prefix%/login
     defaults: { _controller: FOSUserBundle:Security:login }
 
 fos_user_security_check:
-    path: /admin/login_check
+    path: /%kunstmaan_admin.admin_prefix%/login_check
     defaults: { _controller: FOSUserBundle:Security:check }
-        
+
 fos_user_security_logout:
-    path: /admin/logout
+    path: /%kunstmaan_admin.admin_prefix%/logout
     defaults: { _controller: FOSUserBundle:Security:logout }
 
 fos_user_profile:
     resource: '@FOSUserBundle/Resources/config/routing/profile.xml'
-    prefix: /admin/profile
+    prefix: /%kunstmaan_admin.admin_prefix%/profile
 
 fos_user_resetting:
     resource: '@FOSUserBundle/Resources/config/routing/resetting.xml'
-    prefix: /admin/resetting
+    prefix: /%kunstmaan_admin.admin_prefix%/resetting
 
 fos_user_change_password:
-    path: /admin/profile/change-password
+    path: /%kunstmaan_admin.admin_prefix%/profile/change-password
     defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
     methods: [GET, POST]
 
@@ -52,5 +52,5 @@ fos_user_change_password:
 ## Google OAuth Sign In ##
 ##########################
 KunstmaanAdminBundle_oauth_signin:
-    path: /admin/google_signin_check
+    path: /%kunstmaan_admin.admin_prefix%/google_signin_check
     defaults: { _controller: KunstmaanAdminBundle:OAuth:check }

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -13,6 +13,8 @@ parameters:
     kunstmaan_admin.firewall.provider_key: 'main'
     kunstmaan_admin.domain_configuration.class: 'Kunstmaan\AdminBundle\Helper\DomainConfiguration'
     kunstmaan_admin.validator.password_restrictions.class: 'Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictionsValidator'
+    kunstmaan_admin.adminroute.helper.class: 'Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
+    kunstmaan_admin.adminroute.twig.class: 'Kunstmaan\AdminBundle\Twig\AdminRouteHelperTwigExtension'
 
 services:
     kunstmaan_admin.menubuilder:
@@ -35,13 +37,13 @@ services:
 
     kunstmaan_admin.login.listener:
         class: '%kunstmaan_admin.login.listener.class%'
-        arguments: ['@kunstmaan_admin.logger', '@kunstmaan_admin.versionchecker']
+        arguments: ['@kunstmaan_admin.logger', '@kunstmaan_admin.versionchecker', '@kunstmaan_admin.adminroute.helper']
         tags:
             - { name: 'kernel.event_listener', event: 'security.interactive_login' }
 
     kunstmaan_admin.admin_locale.listener:
         class: '%kunstmaan_admin.admin_locale.listener.class%'
-        arguments: ['@security.token_storage', '@translator', '%kunstmaan_admin.default_admin_locale%', '%kunstmaan_admin.firewall.provider_key%']
+        arguments: ['@security.token_storage', '@translator', '@kunstmaan_admin.adminroute.helper', '%kunstmaan_admin.default_admin_locale%', '%kunstmaan_admin.firewall.provider_key%']
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.request', method: 'onKernelRequest' }
 
@@ -106,6 +108,16 @@ services:
     kunstmaan_admin.clone.helper:
         class: Kunstmaan\AdminBundle\Helper\CloneHelper
         arguments: ['@doctrine.orm.entity_manager', '@event_dispatcher']
+
+    kunstmaan_admin.adminroute.helper:
+        class: '%kunstmaan_admin.adminroute.helper.class%'
+        arguments: ['%kunstmaan_admin.admin_prefix%', '@request_stack']
+
+    kunstmaan_admin.adminroute.twig.extension:
+        class: '%kunstmaan_admin.adminroute.twig.class%'
+        arguments: ['@kunstmaan_admin.adminroute.helper']
+        tags:
+            -  { name: 'twig.extension' }
 
     kunstmaan_admin.clone.listener:
         class: '%kunstmaan_admin.clone.listener.class%'
@@ -185,7 +197,7 @@ services:
 
     kunstmaan_admin.password_check.listener:
         class: '%kunstmaan_admin.password_check.listener.class%'
-        arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session', '@translator']
+        arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session', '@translator', '@kunstmaan_admin.adminroute.helper']
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 1 }
 

--- a/src/Kunstmaan/AdminBundle/Resources/doc/ConfiguringAdminRoute.md
+++ b/src/Kunstmaan/AdminBundle/Resources/doc/ConfiguringAdminRoute.md
@@ -1,0 +1,25 @@
+# Configuring the admin route.
+
+You can now configure the url for the Admin side of your Kunstmaan Bundles Cms.
+
+You can do this by configuring the following option in your applications configurationg file.
+
+```yaml
+kunstmaan_admin:
+    admin_prefix: 'vip' #example
+```
+
+In your security.yml you should double check your firewalls and
+access_control_list for any hardcoded references to /admin/ and replace them
+with your new prefix.
+
+```yaml
+#Example
+access_control:
+    - { path: ^/([^/]*)/vip/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/([^/]*)/vip/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/([^/]*)/vip, role: ROLE_ADMIN }
+```
+
+No other configuration is needed to have a custom route for the backend of your
+application.

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\Helper;
+
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Kunstmaan\NodeBundle\Router\SlugRouter;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class AdminRouteHelperTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $ADMIN_KEY = 'admin';
+    protected static $ALTERNATIVE_ADMIN_KEY = 'vip';
+    protected static $NON_ADMIN_URL = '/en/some_path/%s/nodes';
+    protected static $ADMIN_URL = '/en/%s/nodes';
+    protected static $PREVIEW_ADMIN_URL = '/en/%s/preview/blog/page/1';
+
+    /**
+     * @covers Kunstmaan\AdminBundle\Helper\AdminRouteHelper::isAdminRoute
+     */
+    public function testIsAdminRouteReturnsTrueWhenAdminUrl()
+    {
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL, self::$ADMIN_KEY));
+        $this->assertTrue($result);
+
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL, self::$ALTERNATIVE_ADMIN_KEY));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @covers Kunstmaan\AdminBundle\Helper\AdminRouteHelper::isAdminRoute
+     */
+    public function testIsAdminRouteReturnsFalseWhenFrontendUrl()
+    {
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$NON_ADMIN_URL, self::$ADMIN_KEY));
+        $this->assertFalse($result);
+
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$NON_ADMIN_URL, self::$ALTERNATIVE_ADMIN_KEY));
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @covers Kunstmaan\AdminBundle\Helper\AdminRouteHelper::isAdminRoute
+     */
+    public function testIsAdminRouteReturnsFalseWhenPreviewUrl()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push($this->getPreviewRequest());
+
+        $adminRouteHelper = new AdminRouteHelper(self::$ADMIN_KEY, $requestStack);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$PREVIEW_ADMIN_URL, self::$ADMIN_KEY));
+        $this->assertFalse($result);
+
+        $adminRouteHelper = new AdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY, $requestStack);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$PREVIEW_ADMIN_URL, self::$ALTERNATIVE_ADMIN_KEY));
+        $this->assertFalse($result);
+    }
+
+    private function getAdminRouteHelper($adminKey)
+    {
+        return new AdminRouteHelper($adminKey, $this->getRequestStack());
+    }
+
+    private function getRequestStack()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push($this->getRequest());
+
+        return $requestStack;
+    }
+
+    private function getRequest()
+    {
+        return Request::create('http://domain.tld/');
+    }
+
+    private function getPreviewRequest()
+    {
+        return Request::create('http://domain.tld/', 'GET', array('_route' => SlugRouter::$SLUG_PREVIEW));
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Twig/AdminRouteHelperTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/AdminRouteHelperTwigExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Twig;
+
+use Twig_Environment;
+
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
+use Symfony\Component\Form\FormView;
+
+class AdminRouteHelperTwigExtension extends \Twig_Extension
+{
+    /** @var AdminRouteHelper $adminRouteHelper */
+    private $adminRouteHelper;
+
+    /**
+     * @param AdminRouteHelper $adminRouteHelper
+     */
+    public function __construct(AdminRouteHelper $adminRouteHelper)
+    {
+        $this->adminRouteHelper = $adminRouteHelper;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('is_admin_route', array($this, 'isAdminRoute')),
+        );
+    }
+
+    /**
+     * Lets the adminroutehelper determine wether the URI is an admin route
+     *
+     * @return boolean
+     */
+    public function isAdminRoute($URI)
+    {
+        return $this->adminRouteHelper->isAdminRoute($URI);
+    }
+
+    /**
+     * Get the Twig extension name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'admin_route_helper_twig_extension';
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Resources/doc/AdminListBundle.md
+++ b/src/Kunstmaan/AdminListBundle/Resources/doc/AdminListBundle.md
@@ -311,7 +311,7 @@ Add the following lines to your routing.yml.
 YourBundle_documents:
     resource: "@YourBundle/Controller/DocumentAdminController.php"
     type: annotation
-    prefix: /{_locale}/admin/documents
+    prefix: /{_locale}/%kunstmaan_admin.admin_prefix%/documents
     requirements:
         _locale: "%requiredlocales%"
 ```

--- a/src/Kunstmaan/DashboardBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/routing.yml
@@ -1,14 +1,14 @@
 kunstmaan_dashboard:
     resource: '@KunstmaanDashboardBundle/Controller/DashboardController.php'
     type:     annotation
-    prefix:   /admin/dashboard
+    prefix:   /%kunstmaan_admin.admin_prefix%/dashboard
 
 kunstmaan_dashboard_googleanalytics:
     resource: '@KunstmaanDashboardBundle/Controller/GoogleAnalyticsController.php'
     type:     annotation
-    prefix:   /admin/dashboard/widget/googleanalytics
+    prefix:   /%kunstmaan_admin.admin_prefix%/dashboard/widget/googleanalytics
 
 kunstmaan_dashboard_googleanalytics_AJAX:
     resource: '@KunstmaanDashboardBundle/Controller/GoogleAnalyticsAJAXController.php'
     type:     annotation
-    prefix:   /admin/dashboard/ajax/
+    prefix:   /%kunstmaan_admin.admin_prefix%/dashboard/ajax/

--- a/src/Kunstmaan/FormBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanFormBundle_formsubmissions:
     resource: '@KunstmaanFormBundle/Controller/FormSubmissionsController.php'
     type:     annotation
-    prefix:   /admin/formsubmissions
+    prefix:   /%kunstmaan_admin.admin_prefix%/formsubmissions

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminListCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminListCommand.php
@@ -146,6 +146,7 @@ EOT
         Bundle $bundle,
         $entityClass
     ) {
+        $adminKey = $this->getContainer()->getParameter('kunstmaan_admin.admin_prefix');
         $auto      = true;
         $multilang = false;
         if ($input->isInteractive()) {
@@ -164,7 +165,7 @@ EOT
         $code = sprintf("%s:\n", strtolower($bundle->getName()) . '_' . strtolower($entityClass) . '_admin_list');
         $code .= sprintf("    resource: '@%s/Controller/%sAdminListController.php'\n", $bundle->getName(), $entityClass, "'");
         $code .= "    type:     annotation\n";
-        $code .= sprintf("    prefix:   %s/admin/%s/\n", $prefix, strtolower($entityClass));
+        $code .= sprintf("    prefix:   %s/%s/%s/\n", $prefix, $adminKey, strtolower($entityClass));
         if ($multilang) {
             $code .= "    requirements:\n";
             $code .= "         _locale: \"%requiredlocales%\"\n";
@@ -205,11 +206,10 @@ EOT
      * KunstmaanTestBundle_TestEntity:
      * resource: "@KunstmaanTestBundle/Controller/TestEntityAdminListController.php"
      * type:     annotation
-     * prefix:   /{_locale}/admin/testentity/
+     * prefix:   /{_locale}/%kunstmaan_admin.admin_prefix%/testentity/
      * requirements:
      * _locale: "%requiredlocales%"
      */
-
     protected function createGenerator()
     {
         return new AdminListGenerator(GeneratorUtils::getFullSkeletonPath('adminlist'));

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_multilanguage.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_multilanguage.yml
@@ -3,13 +3,13 @@
 {{ bundle.getName()|lower }}_{{ entity_class|lower }}page_admin_list:
     resource: '@{{ bundle.getName() }}/Controller/{{ entity_class }}PageAdminListController.php'
     type:     annotation
-    prefix:   /{_locale}/admin/{{ entity_class|lower }}page/
+    prefix:   /{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}page/
     requirements:
          _locale: "%requiredlocales%"
 
 {{ bundle.getName()|lower }}_{{ entity_class|lower }}author_admin_list:
     resource: '@{{ bundle.getName() }}/Controller/{{ entity_class }}AuthorAdminListController.php'
     type:     annotation
-    prefix:   /{_locale}/admin/{{ entity_class|lower }}author/
+    prefix:   /{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}author/
     requirements:
          _locale: "%requiredlocales%"

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_singlelanguage.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_singlelanguage.yml
@@ -3,9 +3,9 @@
 {{ bundle.getName()|lower }}_{{ entity_class|lower }}page_admin_list:
     resource: '@{{ bundle.getName() }}/Controller/{{ entity_class }}PageAdminListController.php'
     type:     annotation
-    prefix:   /admin/{{ entity_class|lower }}page/
+    prefix:   /%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}page/
 
 {{ bundle.getName()|lower }}_{{ entity_class|lower }}author_admin_list:
     resource: '@{{ bundle.getName() }}/Controller/{{ entity_class }}AuthorAdminListController.php'
     type:     annotation
-    prefix:   /admin/{{ entity_class|lower }}author/
+    prefix:   /%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}author/

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/routing.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Resources/config/routing.yml
@@ -7,7 +7,7 @@
 {{ bundle.name|lower }}_bike_admin_list:
     resource: '@{{ bundle.name }}/Controller/BikeAdminListController.php'
     type:     annotation
-    prefix:   /{_locale}/admin/bike/
+    prefix:   /{_locale}/%kunstmaan_admin.admin_prefix%/bike/
     requirements:
          _locale: "%requiredlocales%"
 {% endif %}

--- a/src/Kunstmaan/LeadGenerationBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/LeadGenerationBundle/Resources/config/routing.yml
@@ -1,13 +1,13 @@
 kunstmaanleadgenerationbundle_popups_admin_list:
     resource: '@KunstmaanLeadGenerationBundle/Controller/PopupsAdminListController.php'
     type:     annotation
-    prefix:   /admin/popups/
+    prefix:   /%kunstmaan_admin.admin_prefix%/popups/
     requirements:
          _locale: '%requiredlocales%'
 
 kunstmaanleadgenerationbundle_rules_admin_list:
     resource: '@KunstmaanLeadGenerationBundle/Controller/RulesAdminListController.php'
     type:     annotation
-    prefix:   /admin/popups/
+    prefix:   /%kunstmaan_admin.admin_prefix%/popups/
     requirements:
          _locale: '%requiredlocales%'

--- a/src/Kunstmaan/MediaBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/routing.yml
@@ -1,24 +1,24 @@
 KunstmaanMediaBundle_media:
     resource: '@KunstmaanMediaBundle/Controller/MediaController.php'
     type:     annotation
-    prefix:   /admin/media
-        
+    prefix:   /%kunstmaan_admin.admin_prefix%/media
+
 KunstmaanMediaBundle_aviary:
     resource: '@KunstmaanMediaBundle/Controller/AviaryController.php'
     type:     annotation
     prefix:   /
-        
+
 KunstmaanMediaBundle_media_chooser:
     resource: '@KunstmaanMediaBundle/Controller/ChooserController.php'
     type:     annotation
-    prefix:   /admin/media
-        
+    prefix:   /%kunstmaan_admin.admin_prefix%/media
+
 KunstmaanMediaBundle_media_folder:
     resource: '@KunstmaanMediaBundle/Controller/FolderController.php'
     type:     annotation
-    prefix:   /admin/media/folder
+    prefix:   /%kunstmaan_admin.admin_prefix%/media/folder
 
 KunstmaanMediaBundle_icon_font:
     resource: '@KunstmaanMediaBundle/Controller/IconFontController.php'
     type:     annotation
-    prefix:   /admin/media/icon-font
+    prefix:   /%kunstmaan_admin.admin_prefix%/media/icon-font

--- a/src/Kunstmaan/MenuBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/routing.yml
@@ -1,9 +1,9 @@
 kunstmaanmenubundle_menu_admin_list:
     resource: '@KunstmaanMenuBundle/Controller/MenuAdminListController.php'
     type:     annotation
-    prefix:   /admin/menu/
+    prefix:   /%kunstmaan_admin.admin_prefix%/menu/
 
 kunstmaanmenubundle_menuitem_admin_list:
     resource: '@KunstmaanMenuBundle/Controller/MenuItemAdminListController.php'
     type:     annotation
-    prefix:   /admin/menu/
+    prefix:   /%kunstmaan_admin.admin_prefix%/menu/

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\MultiDomainBundle\EventListener;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -28,18 +29,26 @@ class HostOverrideListener
     protected $domainConfiguration;
 
     /**
+     * @var AdminRouteHelper
+     */
+    protected $adminRouteHelper;
+
+    /**
      * @param Session                      $session
      * @param TranslatorInterface          $translator
      * @param DomainConfigurationInterface $domainConfiguration
+     * @param AdminRouteHelper $adminRouteHelper
      */
     public function __construct(
         Session $session,
         TranslatorInterface $translator,
-        DomainConfigurationInterface $domainConfiguration
+        DomainConfigurationInterface $domainConfiguration,
+        AdminRouteHelper $adminRouteHelper
     ) {
         $this->session             = $session;
         $this->translator          = $translator;
         $this->domainConfiguration = $domainConfiguration;
+        $this->adminRouteHelper    = $adminRouteHelper;
     }
 
     /**
@@ -61,7 +70,7 @@ class HostOverrideListener
             return;
         }
 
-        if (!$this->isAdminRoute($request->getRequestUri())) {
+        if (!$this->adminRouteHelper->isAdminRoute($request->getRequestUri())) {
             return;
         }
 
@@ -72,30 +81,5 @@ class HostOverrideListener
                 $this->translator->trans('multi_domain.host_override_active')
             );
         }
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return bool
-     */
-    protected function isAdminRoute($url)
-    {
-        preg_match(
-            '/^\/(app_(.*)\.php\/)?([a-zA-Z_-]{2,5}\/)?admin\/(.*)/',
-            $url,
-            $matches
-        );
-
-        // Check if path is part of admin area
-        if (count($matches) === 0) {
-            return false;
-        }
-
-        if (strpos($url, '/admin/preview') !== false) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -27,6 +27,11 @@ class DomainConfiguration extends BaseDomainConfiguration
     protected $aliases = array();
 
     /**
+     * @var AdminRouteHelper
+     */
+    protected $adminRouteHelper;
+
+    /**
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
@@ -41,6 +46,8 @@ class DomainConfiguration extends BaseDomainConfiguration
                 }
             }
         }
+
+        $this->adminRouteHelper = $container->get('kunstmaan_admin.adminroute.helper');
     }
 
     /**
@@ -202,7 +209,7 @@ class DomainConfiguration extends BaseDomainConfiguration
         $request = $this->getMasterRequest();
 
         return !is_null($request) &&
-        $this->isAdminRoute($request->getRequestUri()) &&
+        $this->adminRouteHelper->isAdminRoute($request->getRequestUri()) &&
         $request->hasPreviousSession() &&
         $request->getSession()->has(self::OVERRIDE_HOST);
     }
@@ -215,7 +222,7 @@ class DomainConfiguration extends BaseDomainConfiguration
         $request = $this->getMasterRequest();
 
         return !is_null($request) &&
-        $this->isAdminRoute($request->getRequestUri()) &&
+        $this->adminRouteHelper->isAdminRoute($request->getRequestUri()) &&
         $request->hasPreviousSession() &&
         $request->getSession()->has(self::SWITCH_HOST);
     }
@@ -246,27 +253,6 @@ class DomainConfiguration extends BaseDomainConfiguration
         }
 
         return $this->hosts[$host];
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return bool
-     */
-    protected function isAdminRoute($url)
-    {
-        preg_match(
-            '/^\/(app_(.*)\.php\/)?([a-zA-Z_-]{2,5}\/)?admin\/(.*)/',
-            $url,
-            $matches
-        );
-
-        // Check if path is part of admin area
-        if (count($matches) === 0) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 kunstmaanmultidomainbundle_site_switch:
     resource: '@KunstmaanMultiDomainBundle/Controller/SiteSwitchController.php'
     type:     annotation
-    prefix:   /admin/multi-domain
+    prefix:   /%kunstmaan_admin.admin_prefix%/multi-domain

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -16,7 +16,7 @@ services:
 
     kunstmaan_multi_domain.host_override_listener:
         class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
-        arguments: ['@session', '@translator', '@kunstmaan_admin.domain_configuration']
+        arguments: ['@session', '@translator', '@kunstmaan_admin.domain_configuration', '@kunstmaan_admin.adminroute.helper']
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 

--- a/src/Kunstmaan/MultiDomainBundle/Tests/EventListener/HostOverrideListenerTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/EventListener/HostOverrideListenerTest.php
@@ -37,7 +37,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsSetForAdmin()
     {
@@ -56,7 +55,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsNotSetForAdminRedirectResponse()
     {
@@ -74,7 +72,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsNotSetForSubRequest()
     {
@@ -92,7 +89,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsNotSetForXmlRequest()
     {
@@ -110,7 +106,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsNotSetForPreview()
     {
@@ -128,7 +123,6 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::__construct
      * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::onKernelResponse
-     * @covers Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener::isAdminRoute
      */
     public function testHostOverrideMessageIsNotSetForFrontend()
     {
@@ -158,7 +152,21 @@ class HostOverrideListenerTest extends \PHPUnit_Framework_TestCase
         $translator->method('trans')
             ->willReturnArgument(0);
 
-        $listener = new HostOverrideListener($session, $translator, $domainConfiguration);
+        $adminRouteReturnValueMap = array(
+            array('/nl/admin/preview/some-uri', false),
+            array('/nl/some-uri', false),
+            array('/nl/admin/some-admin-uri', true)
+        );
+
+        $adminRouteHelper = $this->getMockBuilder('Kunstmaan\AdminBundle\Helper\AdminRouteHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adminRouteHelper
+            ->expects($this->any())
+            ->method('isAdminRoute')
+            ->will($this->returnValueMap($adminRouteReturnValueMap));
+
+        $listener = new HostOverrideListener($session, $translator, $domainConfiguration, $adminRouteHelper);
 
         return $listener;
     }

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
@@ -72,7 +72,6 @@ class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getMasterRequest
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getHost
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::hasHostOverride
-     * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::isAdminRoute
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getHostOverride
      */
     public function testGetHostWithOverrideOnFrontend()
@@ -87,7 +86,6 @@ class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getMasterRequest
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getHost
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::hasHostOverride
-     * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::isAdminRoute
      * @covers Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::getHostOverride
      */
     public function testGetHostWithOverrideOnBackend()
@@ -298,6 +296,7 @@ class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
         $serviceMap = array(
             array('request_stack', 1, $this->getRequestStack($request)),
             array('doctrine.orm.entity_manager', 1, $this->getEntityManager()),
+            array('kunstmaan_admin.adminroute.helper', 1, $this->getAdminRouteHelper())
         );
 
         $container
@@ -316,6 +315,24 @@ class DomainConfigurationTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->getNodeRepository());
 
         return $em;
+    }
+
+    private function getAdminRouteHelper()
+    {
+        $adminRouteReturnValueMap = array(
+            array('/frontend-uri', false),
+            array('/nl/admin/backend-uri', true)
+        );
+
+        $adminRouteHelper = $this->getMockBuilder('Kunstmaan\AdminBundle\Helper\AdminRouteHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $adminRouteHelper
+            ->expects($this->any())
+            ->method('isAdminRoute')
+            ->will($this->returnValueMap($adminRouteReturnValueMap));
+
+        return $adminRouteHelper;
     }
 
     private function getNodeRepository()

--- a/src/Kunstmaan/NodeBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/routing.yml
@@ -1,14 +1,14 @@
 KunstmaanNodeBundle_widgets:
     resource: '@KunstmaanNodeBundle/Controller/WidgetsController.php'
     type:     annotation
-    prefix:   /admin/nodewidgets
+    prefix:   /%kunstmaan_admin.admin_prefix%/nodewidgets
 
 KunstmaanNodeBundle_nodes:
     resource: '@KunstmaanNodeBundle/Controller/NodeAdminController.php'
     type:     annotation
-    prefix:   /admin/nodes
+    prefix:   /%kunstmaan_admin.admin_prefix%/nodes
 
 kunstmaan_node.url_replace.controller:
     resource: '@KunstmaanNodeBundle/Controller/UrlReplaceController.php'
     type:     annotation
-    prefix:   /admin/url-replace
+    prefix:   /%kunstmaan_admin.admin_prefix%/url-replace

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -23,6 +23,10 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class SlugRouter implements RouterInterface
 {
+
+    public static $SLUG = "_slug";
+    public static $SLUG_PREVIEW = "_slug_preview";
+
     /** @var RequestContext */
     protected $context;
 
@@ -41,6 +45,9 @@ class SlugRouter implements RouterInterface
     /** @var DomainConfigurationInterface */
     protected $domainConfiguration;
 
+    /** @var string */
+    protected $adminKey;
+
     /**
      * The constructor for this service
      *
@@ -51,6 +58,7 @@ class SlugRouter implements RouterInterface
         $this->container = $container;
         $this->slugPattern = "[a-zA-Z0-9\-_\/]*";
         $this->domainConfiguration = $container->get('kunstmaan_admin.domain_configuration');
+        $this->adminKey            = $container->getParameter('kunstmaan_admin.admin_prefix');
     }
 
     /**
@@ -173,7 +181,7 @@ class SlugRouter implements RouterInterface
     protected function addPreviewRoute()
     {
         $routeParameters = $this->getPreviewRouteParameters();
-        $this->addRoute('_slug_preview', $routeParameters);
+        $this->addRoute(self::$SLUG_PREVIEW, $routeParameters);
     }
 
     /**
@@ -182,7 +190,7 @@ class SlugRouter implements RouterInterface
     protected function addSlugRoute()
     {
         $routeParameters = $this->getSlugRouteParameters();
-        $this->addRoute('_slug', $routeParameters);
+        $this->addRoute(self::$SLUG, $routeParameters);
     }
 
     /**
@@ -192,8 +200,8 @@ class SlugRouter implements RouterInterface
      */
     protected function getPreviewRouteParameters()
     {
-        $previewPath = '/admin/preview/{url}';
-        $previewDefaults = array(
+        $previewPath         = sprintf('/%s/preview/{url}', $this->adminKey);
+        $previewDefaults     = array(
             '_controller' => 'KunstmaanNodeBundle:Slug:slug',
             'preview' => true,
             'url' => '',

--- a/src/Kunstmaan/RedirectBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanRedirectBundle_redirect_adminlist:
     resource: '@KunstmaanRedirectBundle/Controller/RedirectAdminListController.php'
     type:     annotation
-    prefix:   /admin/settings/redirect/
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/redirect/

--- a/src/Kunstmaan/SeoBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanSeoBundle_settings:
     resource: '@KunstmaanSeoBundle/Controller/Admin/SettingsController.php'
-    prefix:   /admin/settings/robots
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/robots
     type:     annotation

--- a/src/Kunstmaan/TaggingBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/TaggingBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 KunstmaanTaggingBundle_admin_tag:
     resource: '@KunstmaanTaggingBundle/Controller/TagAdminListController.php'
     type:     annotation
-    prefix:   /admin/tags/
+    prefix:   /%kunstmaan_admin.admin_prefix%/tags/

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/routing.yml
@@ -1,12 +1,12 @@
 KunstmaanTranslatorBundle_translations:
     resource: '@KunstmaanTranslatorBundle/Controller/TranslatorController.php'
     type:     annotation
-    prefix:   /admin/settings/translations
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/translations
 
 KunstmaanTranslatorBundle_translations_commands:
     resource: '@KunstmaanTranslatorBundle/Controller/TranslatorCommandController.php'
     type:     annotation
-    prefix:   /admin/settings/translations
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/translations
 
 #KunstmaanTranslatorBundle_settings_translations_add:
 #    pattern:   /add/{domain}/{locale}/{keyword}

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
@@ -1,20 +1,20 @@
 KunstmaanUserManagementBundle_user_settings:
     resource: '@KunstmaanUserManagementBundle/Controller/UsersController.php'
     type:     annotation
-    prefix:   /admin/settings/users
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/users
 
 KunstmaanUserManagementBundle_group_settings:
     resource: '@KunstmaanUserManagementBundle/Controller/GroupsController.php'
     type:     annotation
-    prefix:   /admin/settings/groups
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/groups
 
 KunstmaanUserManagementBundle_role_settings:
     resource: '@KunstmaanUserManagementBundle/Controller/RolesController.php'
     type:     annotation
-    prefix:   /admin/settings/roles
+    prefix:   /%kunstmaan_admin.admin_prefix%/settings/roles
 
 # Override default user change password route...
 KunstmaanAdminBundle_user_change_password:
-    path: /admin/settings/users/{id}/edit
+    path: /%kunstmaan_admin.admin_prefix%/settings/users/{id}/edit
     defaults: { _controller: KunstmaanUserManagementBundle:Users:edit, id: '' }
     methods: [GET]


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #1323 |
- [x] Still need to test everything
- [x] write tests for new helper service
- [x] better check for previewurl not via regex
- [x] explore better option configuration
- [x] documententation on configuration and usage

[All bundles] Allow /admin/ url to be configurable in parameters.yml, refactor code to not have duplicate isAdminroute method spread around the codebase

More than likely oversight which breaks the site: If you decide to configure your admin url you have to double check your security.yml file to see if there are no hardcoded /admin/'s left in the firewalls or access_control list.