### PR TITLE
[NodeSearchBundle]: fix request scope

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -512,7 +512,12 @@ class NodePagesConfiguration implements SearchConfigurationInterface
     protected function enterRequestScope($lang)
     {
         $requestStack = $this->container->get('request_stack');
-        if (!$requestStack->getCurrentRequest()) {
+        // If there already is a request, get the locale from it.
+        if ($requestStack->getCurrentRequest()) {
+            $locale = $requestStack->getCurrentRequest()->getLocale();
+        }
+        // If we don't have a request or the current request locale is different from the node langauge
+        if (!$requestStack->getCurrentRequest() || ($locale && $locale !== $lang)) {
             $request = new Request();
             $request->setLocale($lang);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets |  |

When populating the search index, the NodePagesConfiguration calls the enterRequestScope() function. In this function it checks if there is a current request. If not, a new request is created with the language of the node translation. When a new node translation is indexed, with another language, and we already have a request, this function will not be executed fully. Therefore we always have the language of our first node translation in the twig templates. 

This fix will check if the current request locale is different from the node translation locale.
