### PR TITLE
[AdminListBundle]: Add Form & Request property and Response function in AdminListEvent

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -40,6 +40,10 @@ When adding a rich text field or a wysiwyg field, you will need to pipe the outp
  
 The DomainConfigurationInterface has also been changed. If you have implemented this interface, please be sure to check the required methods.
 
+##EventListener
+
+The AdminListEvent has been changed, properties Form, Request and function Response have been added.
+
 ##Node version locking
 
 See https://github.com/Kunstmaan/KunstmaanBundlesCMS/tree/master/src/Kunstmaan/NodeBundle/Resources/doc/Locking.md

--- a/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
+++ b/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
@@ -3,6 +3,9 @@
 namespace Kunstmaan\AdminListBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class AdminListEvent extends Event
 {
@@ -12,12 +15,31 @@ class AdminListEvent extends Event
     protected $entity;
 
     /**
+     * @var FormInterface
+     */
+    protected $form;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
      * AdminListEvent constructor.
      * @param object $entity
+     * @param Request $request
+     * @param FormInterface|null $form
      */
-    public function __construct($entity)
+    public function __construct($entity, Request $request, FormInterface $form = null)
     {
         $this->entity = $entity;
+        $this->request = $request;
+        $this->form = $form;
     }
 
     /**
@@ -26,5 +48,41 @@ class AdminListEvent extends Event
     public function getEntity()
     {
         return $this->entity;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return FormInterface|null
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets a response and stops event propagation.
+     *
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        $this->stopPropagation();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?   | yes
| Deprecations?|no

Add Form and Request property in the AdminListEvent to have more flexibility in adapting the adminlistscontroller.
Also added a Response function, so you can give a custom Response in the adminlistcontoller.