### PR TITLE
[ArticleBundle] fix syntax error in configurators

### DIFF
--- a/src/Kunstmaan/ArticleBundle/PagePartAdmin/AbstractArticleOverviewPagePagePartAdminConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/PagePartAdmin/AbstractArticleOverviewPagePagePartAdminConfigurator.php
@@ -90,4 +90,12 @@ class AbstractArticleOverviewPagePagePartAdminConfigurator extends AbstractPageP
     {
         return "main";
     }
+
+    /**
+     * @return string
+     */
+    public function getWidgetTemplate()
+    {
+        return "";
+    }
 }

--- a/src/Kunstmaan/ArticleBundle/PagePartAdmin/AbstractArticlePagePagePartAdminConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/PagePartAdmin/AbstractArticlePagePagePartAdminConfigurator.php
@@ -90,4 +90,12 @@ class AbstractArticlePagePagePartAdminConfigurator extends AbstractPagePartAdmin
     {
         return "main";
     }
+
+    /**
+     * @return string
+     */
+    public function getWidgetTemplate()
+    {
+        return "";
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1381 

new interfaces forces implementing method getWidgetTemplate but is not necessary for article configurators.