### PR TITLE
Create a „Community Bundles” documentation page

### DIFF
--- a/docs/07-06-community-bundles.md
+++ b/docs/07-06-community-bundles.md
@@ -1,0 +1,30 @@
+# Community Bundles
+
+The community has created a number of bundles that extend the functionality of the Kunstmaan Bundles CMS, but aren’t a part of the core. You can install them separately from those locations:
+
+## Bundles
+
+| Name | Description |
+| ---- | ----------- |
+| [KunstmaanExtraBundle](https://github.com/syzygypl/kunstmaan-extra-bundle) | Miscellaneous helpers aiming to reduce the boilerplate in day-to-day work | 
+| [PageMediaSetBundle](https://github.com/syzygypl/page-media-set-bundle) | Easily add images (header image, thumbnail, etc) to any page without a hassle |
+| [PageActionsBundle](https://github.com/syzygypl/page-actions-bundle) | Allows registering sub-actions to any page type, handled by your custom controller. For example adding a „Thank You” type of page to a contact form | 
+| [KunstmaanAlgoliaBundle](https://github.com/syzygypl/kunstmaan-algolia-bundle) | Add [Algolia](https://www.algolia.com) indexer alongside the default Elasticsearch | 
+| [KunstmaanFeedBundle](https://github.com/syzygypl/kunstmaan-feed-bundle) | Quickly fetch published pages from elasticsearch instead of the database (for instance for most popular articles lists, etc) |
+| [RemoteMediaBundle](https://github.com/syzygypl/remote-media-bundle) | Store your media files in an S3 bucket and fetch them using a CDN url (optionally) | 
+| [WebtownKunstmaanExtensionBundle](https://github.com/webtown-php/KunstmaanExtensionBundle) | Various Kunstmaan Bundles CMS features | 
+| [KunstmaanNodeSettingsBundle](https://github.com/mlebkowski/kunstmaan-node-settings-bundle) | Easily add custom settings to any node or page type using separate CMS tabs | 
+| [KunstmaanContentApiBundle](https://github.com/DreadLabs/KunstmaanContentApiBundle) | Allow your content to be served via an API |
+| [KunstmaanConfigBundle](https://github.com/DreadLabs/KunstmaanConfigBundle) | Provide streamlined configuration for a Kunstmaan CMS application |
+| [KunstmaanDistributedBundle](https://github.com/DreadLabs/KunstmaanDistributedBundle) | Configures a Kunstmaan Bundles CMS instance for running on distributed, clustered infrastructure |
+| [KunstmaanGermanBackendBundle](https://github.com/DreadLabs/KunstmaanGermanBackendBundle) | German translations for the admin area |
+| [KunstmaanSocialMediaBundle](https://gitlab.superrb.com/kuma/KunstmaanSocialMediaBundle) | The KunstmaanSocialMediaBundle makes working with social media feeds (currently Instagram, Tumblr, Twitter and Vimeo) and the KunstmaanBundles CMS easier |
+| [KunstmaanStockistsFinderBundle](https://gitlab.superrb.com/kuma/KunstmaanStockistsFinderBundle) | The KunstmaanStockistsFinderBundle is for adding a postcode search, with a list of stockists and their pins on a map |
+
+## Boilerplates
+
+Bootstrap your new project faster using those templates
+
+ * [tentwofour CMS template](https://github.com/tentwofour/CMSTemplate)
+ * [mlebkowski’s kitchen sink](https://github.com/mlebkowski/kunstmaan-kitchen-sink) — bootstrap to use with the [KunstmaanExtraBundle](https://github.com/syzygypl/kunstmaan-extra-bundle)
+ 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Hello,

I gathered all projects extending the core and put them in a separate documentation page. I think it would be beneficial for all to advertise those project this way:
 * Kunstmaan Bundles CMS will build a larger community and will encourage to create new bundles
 * Bundle creators will have their work acknowledged and introduced to a larger audience
 * End users (developers) will have it easier to find more functionality for their Kunstmaan Bundles CMS projects

Those are all of the projects I can find that require `kunstmaan/bundles-cms` in their composer, aren’t deprecated, have some readme, etc.

What do you think? 🎉 