### PR TITLE
[AdminListBundle] Allow locking of individual entities in adminlists.

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_app-entity-version-lock.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_app-entity-version-lock.js
@@ -1,0 +1,43 @@
+var kunstmaanbundles = kunstmaanbundles || {};
+
+kunstmaanbundles.appEntityVersionLock = (function(window, undefined) {
+
+    var init, checkEntityVersionLock;
+
+    init = function () {
+        if ($('body').hasClass('js-entity-version-lock')) {
+            kunstmaanbundles.appEntityVersionLock.checkEntityVersionLock();
+        }
+    };
+
+    checkEntityVersionLock = function() {
+        var $elem = $('#js-entity-version-lock-data');
+        if ($elem) {
+            var url = $elem.data('url');
+            var interval = $elem.data('check-interval') * 1000;
+
+            if (url) {
+                $.getJSON(url, function (data) {
+                    if (data.lock) {
+                        $elem.find('.message').html(data.message);
+                        $elem.removeClass('hidden');
+                    } else {
+                        $elem.addClass('hidden');
+                    }
+
+                    if (interval) {
+                        setTimeout(function () {
+                            kunstmaanbundles.appEntityVersionLock.checkEntityVersionLock();
+                        }, interval);
+                    }
+                });
+            }
+        }
+    };
+
+    return {
+        init: init,
+        checkEntityVersionLock: checkEntityVersionLock
+    };
+
+})(window);

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/app.js
@@ -43,6 +43,7 @@ kunstmaanbundles.app = (function($, window, undefined) {
         kunstmaanbundles.rangeslider.init();
         kunstmaanbundles.googleOAuth.init();
         kunstmaanbundles.appNodeVersionLock.init();
+        kunstmaanbundles.appEntityVersionLock.init();
     };
 
 

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -23,6 +23,7 @@
     "@KunstmaanAdminBundle/Resources/ui/js/_app-sidebar-search-focus.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-main-actions.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-node-version-lock.js"
+    "@KunstmaanAdminBundle/Resources/ui/js/_app-entity-version-lock.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-filter.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-sortable-table.js"
     "@KunstmaanAdminBundle/Resources/ui/js/_app-check-if-edited.js"

--- a/src/Kunstmaan/AdminListBundle/Controller/EntityLockCheckController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/EntityLockCheckController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Controller;
+
+use Kunstmaan\AdminListBundle\Service\EntityVersionLockService;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * EntityLockCheckController
+ */
+class EntityLockCheckController extends Controller
+{
+    /**
+     * You can override this method to return the correct entity manager when using multiple databases ...
+     *
+     * @return \Doctrine\Common\Persistence\ObjectManager|object
+     */
+    protected function getEntityManager()
+    {
+        return $this->getDoctrine()->getManager();
+    }
+
+    /**
+     * @Route(
+     *      "check/{id}/{repository}",
+     *      requirements={"id" = "\d+"},
+     *      name="KunstmaanAdminListBundle_entity_lock_check"
+     * )
+     * @param Request $request
+     * @param $id
+     * @param $repository
+     * @return JsonResponse
+     */
+    public function checkAction(Request $request, $id, $repository)
+    {
+        $entityIsLocked = false;
+        $message = '';
+
+        /** @var LockableEntityInterface $entity */
+        $entity = $this->getEntityManager()->getRepository($repository)->find($id);
+
+        try {
+            /** @var EntityVersionLockService $entityVersionLockservice */
+            $entityVersionLockService = $this->get('kunstmaan_entity.admin_entity.entity_version_lock_service');
+
+            $entityIsLocked = $entityVersionLockService->isEntityLocked($this->getUser(), $entity);
+
+            if ($entityIsLocked) {
+                $user = $entityVersionLockService->getUsersWithEntityVersionLock($entity, $this->getUser());
+                $message = $this->get('translator')->trans('kuma_admin_list.edit.flash.locked', array('%user%' => implode(', ', $user)));
+            }
+
+        } catch (AccessDeniedException $ade) {}
+
+        return new JsonResponse(['lock' => $entityIsLocked, 'message' => $message]);
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminListBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,21 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('kunstmaan_k_admin_list');
+        $root = $treeBuilder->root('kunstmaan_k_admin_list');
+
+        /** @var ArrayNodeDefinition $pages */
+        $root
+            ->children()
+                ->arrayNode('lock')
+                    ->addDefaultsIfNotSet()
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('check_interval')->defaultValue(15)->end()
+                        ->scalarNode('threshold')->defaultValue(35)->end()
+                        ->booleanNode('enabled')->defaultFalse()->end()
+                    ->end()
+                ->end()
+            ->end();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/Kunstmaan/AdminListBundle/DependencyInjection/KunstmaanAdminListExtension.php
+++ b/src/Kunstmaan/AdminListBundle/DependencyInjection/KunstmaanAdminListExtension.php
@@ -21,9 +21,14 @@ class KunstmaanAdminListExtension extends Extension implements PrependExtensionI
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        $container->setParameter('kunstmaan_entity.lock_check_interval', $config['lock']['check_interval']);
+        $container->setParameter('kunstmaan_entity.lock_threshold', $config['lock']['threshold']);
+        $container->setParameter('kunstmaan_entity.lock_enabled', $config['lock']['enabled']);
+
         $loader->load('services.yml');
     }
 
@@ -42,6 +47,5 @@ class KunstmaanAdminListExtension extends Extension implements PrependExtensionI
         $container->prependExtensionConfig('twig', $config);
         $configs = $container->getExtensionConfig($this->getAlias());
         $config = $this->processConfiguration(new Configuration(), $configs);
-
     }
 }

--- a/src/Kunstmaan/AdminListBundle/Entity/EntityVersionLock.php
+++ b/src/Kunstmaan/AdminListBundle/Entity/EntityVersionLock.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * EntityVersionLock
+ *
+ * @ORM\Table(name="kuma_entity_version_lock", indexes={
+ *     @ORM\Index(name="nt_owner_public_idx", columns={"owner", "lockable_entity_id"}),
+ * })
+ * @ORM\Entity(repositoryClass="Kunstmaan\AdminListBundle\Repository\EntityVersionLockRepository")
+ */
+class EntityVersionLock extends \Kunstmaan\AdminBundle\Entity\AbstractEntity
+{
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="owner", type="string", length=255)
+     */
+    private $owner;
+
+    /**
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @var LockableEntity
+     *
+     * @ORM\ManyToOne(targetEntity="Kunstmaan\AdminListBundle\Entity\LockableEntity")
+     * @ORM\JoinColumn(name="lockable_entity_id", referencedColumnName="id")
+     */
+    private $lockableEntity;
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return EntityVersionLock
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Set owner
+     *
+     * @param string
+     *
+     * @return EntityVersionLock
+     */
+    public function setOwner($owner)
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    /**
+     * Get owner
+     *
+     * @return string
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+
+    /**
+     * @return LockableEntity
+     */
+    public function getLockableEntity()
+    {
+        return $this->lockableEntity;
+    }
+
+    /**
+     * @param LockableEntity $lockableEntity
+     *
+     * @return EntityVersionLock
+     */
+    public function setLockableEntity($lockableEntity)
+    {
+        $this->lockableEntity = $lockableEntity;
+
+        return $this;
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
+++ b/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\AdminBundle\Entity\AbstractEntity;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity(repositoryClass="Kunstmaan\AdminListBundle\Repository\LockableEntityRepository")
+ * @ORM\Table(name="kuma_lockable_entity",
+ *    uniqueConstraints={@ORM\UniqueConstraint(name="ix_kuma_lockable_entity_id_class", columns={"entityId", "entityClass"})},
+ *    indexes={@ORM\Index(name="idx__lockable_entity_id_class", columns={"entityId", "entityClass"})}
+ * )
+ */
+class LockableEntity extends AbstractEntity
+{
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
+    protected $created;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
+    protected $updated;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    protected $entityClass;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(type="bigint")
+     */
+    protected $entityId;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->setCreated(new \DateTime());
+        $this->setUpdated(new \DateTime());
+    }
+
+    /**
+     * Set created
+     *
+     * @param \DateTime $created
+     *
+     * @return LockableEntity
+     */
+    public function setCreated(\DateTime $created)
+    {
+        $this->created = $created;
+
+        return $this;
+    }
+
+    /**
+     * Get created
+     *
+     * @return \DateTime
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * Set updated
+     *
+     * @param \DateTime $updated
+     *
+     * @return LockableEntity
+     */
+    public function setUpdated(\DateTime $updated)
+    {
+        $this->updated = $updated;
+
+        return $this;
+    }
+
+    /**
+     * Get updated
+     *
+     * @return \DateTime
+     */
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * Get entityClass.
+     *
+     * @return string.
+     */
+    public function getEntityClass()
+    {
+        return $this->entityClass;
+    }
+
+    /**
+     * @param $entityClass
+     *
+     * @return LockableEntity
+     */
+    public function setEntityClass($entityClass)
+    {
+        $this->entityClass = $entityClass;
+
+        return $this;
+    }
+
+    /**
+     * Get entityId.
+     *
+     * @return integer.
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * Set integer
+     *
+     * @param $entityId
+     *
+     * @return LockableEntity
+     */
+    public function setEntityId($entityId)
+    {
+        $this->entityId = $entityId;
+
+        return $this;
+    }
+}
+

--- a/src/Kunstmaan/AdminListBundle/Entity/LockableEntityInterface.php
+++ b/src/Kunstmaan/AdminListBundle/Entity/LockableEntityInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Entity;
+
+/**
+ * Interface LockableEntityInterface
+ */
+interface LockableEntityInterface
+{
+    public function getId();
+}

--- a/src/Kunstmaan/AdminListBundle/Repository/EntityVersionLockRepository.php
+++ b/src/Kunstmaan/AdminListBundle/Repository/EntityVersionLockRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Kunstmaan\AdminListBundle\Entity\LockableEntity;
+use FOS\UserBundle\Model\User;
+
+/**
+ * EntityVersionLockRepository
+ */
+class EntityVersionLockRepository extends EntityRepository
+{
+    /**
+     * Check if there is a entity lock that's not passed the threshold.
+     *
+     * @param LockableEntity $entity
+     * @param int $threshold
+     * @param User $userToExclude
+     * @return EntityVersionLock[]
+     */
+    public function getLocksForLockableEntity(LockableEntity $entity, $threshold, User $userToExclude = null)
+    {
+        $qb = $this->createQueryBuilder('evl')
+            ->select('evl')
+            ->join('evl.lockableEntity', 'le')
+            ->where('le.id = :e')
+            ->andWhere('evl.createdAt > :date')
+            ->setParameter('e', $entity->getId())
+            ->setParameter('date', new \DateTime(sprintf('-%s seconds', $threshold)))
+        ;
+
+        if (!is_null($userToExclude)) {
+            $qb->andWhere('evl.owner <> :owner')
+                ->setParameter('owner', $userToExclude->getUsername())
+            ;
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Get locks that are passed the threshold.
+     *
+     * @param LockableEntity $entity
+     * @param int $threshold
+     * @return mixed
+     */
+    public function getExpiredLocks(LockableEntity $entity, $threshold)
+    {
+        $qb = $this->createQueryBuilder('evl')
+            ->select('evl')
+            ->join('evl.lockableEntity', 'le')
+            ->where('le.id = :e')
+            ->andWhere('evl.createdAt < :date')
+            ->setParameter('e', $entity->getId())
+            ->setParameter('date', new \DateTime(sprintf('-%s seconds', $threshold)));
+
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Repository/LockableEntityRepository.php
+++ b/src/Kunstmaan/AdminListBundle/Repository/LockableEntityRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Repository;
+
+use Doctrine\ORM\Cache\Lock;
+use Doctrine\ORM\EntityRepository;
+use Kunstmaan\AdminListBundle\Entity\LockableEntity;
+
+/**
+ * LockableEntityRepository
+ */
+class LockableEntityRepository extends EntityRepository
+{
+
+    /**
+     * @param integer $id
+     * @param string $class
+     *
+     * @return LockableEntity
+     */
+    public function getOrCreate($id, $class)
+    {
+        /** @var LockableEntity $lockable */
+        $lockable = $this->findOneBy(['entityId' => $id, 'entityClass' => $class]);
+
+        if($lockable === null) {
+            $lockable = new LockableEntity();
+            $lockable->setEntityClass($class);
+            $lockable->setEntityId($id);
+        }
+
+        return $lockable;
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+kunstmaan_entity_lock_check:
+    resource: '@KunstmaanAdminListBundle/Controller/EntityLockCheckController.php'
+    type:     annotation
+    prefix:   /admin/entity/lock

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -17,3 +17,10 @@ services:
             -  { name: twig.extension }
         arguments:
             -  '@service_container'
+
+    kunstmaan_entity.admin_entity.entity_version_lock_service:
+        class: Kunstmaan\AdminListBundle\Service\EntityVersionLockService
+        arguments:
+            -  '@doctrine.orm.entity_manager'
+            -  '%kunstmaan_entity.lock_threshold%'
+            -  '%kunstmaan_entity.lock_enabled%'

--- a/src/Kunstmaan/AdminListBundle/Resources/doc/AdminListBundle.md
+++ b/src/Kunstmaan/AdminListBundle/Resources/doc/AdminListBundle.md
@@ -224,7 +224,7 @@ To make your Entities sortable, there's the move up and down action method. (aut
         {
             return parent::doMoveUpAction($this->getAdminListConfigurator(), $id, $request);
         }
-    
+
         /**
          * The move down action
          *
@@ -321,3 +321,37 @@ YourBundle_documents:
 The AdminList has by default several filters : String, Boolean, Date and Number
 
 TODO : Add additional documentation
+
+## Locking your entities so that only 1 person may edit it at the same time.
+
+First you have to check your applications configuration.
+
+Add the following lines to your app/config/config.yml:
+
+```YAML
+kunstmaan_admin_list:
+    lock:
+        enabled: true
+        threshold: 35           #This is the default value and defines how long it takes for the lock to expire after saving.
+        check_interval: 15      #This is the default value and defines how often the lock should be refreshed.
+```
+
+Also make sure the routing for the AdminListBundle is included in your
+app/config/routing.yml. This was not necessary on older projects because the
+controller that checks the locking of entities did not exist yet. Add the
+following snippet to your routing.yml.
+
+```YAML
+KunstmaanAdminListBundle:
+    resource: "@KunstmaanAdminListBundle/Resources/config/routing.yml"
+    prefix:   /{_locale}/
+    requirements:
+        _locale: %requiredlocales%
+```
+
+Now that the configuration is finished you only have to do a single thing for
+each entity you want to lock. Implement the Interface LockableEntityInterface
+on each entity you want the AdminListController to lock for you. If the
+AdminListController encounters an entity that implements this interface and
+locking is enabled in the configuration it will make sure no other persons can access that entity at
+the same time.

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
@@ -1,3 +1,7 @@
 kuma_admin_list:
     form:
         export_to: Export to
+    edit:
+        flash:
+            success: The entity has been edited
+            locked: The entity is currently being edited by %user%

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
@@ -1,7 +1,20 @@
 {% extends '@KunstmaanAdmin/Default/layout.html.twig' %}
 {% form_theme form '@KunstmaanAdmin/Form/fields.html.twig' %}
 
+{% block extrabodyclasses %}{{ parent() }}{% if entityVersionLockCheck %} js-entity-version-lock{% endif %}{% endblock %}
+
 {% block header %}
+    {% if entityVersionLockCheck %}
+        <div class="hidden" id="js-entity-version-lock-data" data-check-interval="{{ entityVersionLockInterval }}" data-url="{{ path('KunstmaanAdminListBundle_entity_lock_check', {'id': entity.id, 'repository': adminlistconfigurator.getRepositoryName()}) }}">
+            <div class="alert alert-danger alert-dismissible">
+                <button type="button" class="close" data-dismiss="alert">
+                <i class="fa fa-times"></i>
+                </button>
+                <span class="message"></span>
+            </div>
+        </div>
+    {% endif %}
+
     {{ form_start(form, {'method': 'POST', 'action': path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')), 'attr': {'novalidate': 'novalidate'}}) }}
     {{ parent() }}
 {% endblock %}

--- a/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
+++ b/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Service;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use FOS\UserBundle\Model\User;
+use Kunstmaan\AdminListBundle\Entity\LockableEntity;
+use Kunstmaan\AdminListBundle\Entity\EntityVersionLock;
+use Kunstmaan\AdminListBundle\Entity\LockableEntityInterface;
+use Kunstmaan\AdminListBundle\Repository\EntityVersionLockRepository;
+
+class EntityVersionLockService
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var integer
+     */
+    private $threshold;
+
+    /**
+     * @var boolean
+     */
+    private $lockEnabled;
+
+    public function __construct(ObjectManager $em, $threshold, $lockEnabled)
+    {
+        $this->setObjectManager($em);
+        $this->setThreshold($threshold);
+        $this->setLockEnabled($lockEnabled);
+    }
+
+    /**
+     * @param LockableEntityInterface $entity
+     * @return bool
+     */
+    public function isEntityBelowThreshold(LockableEntityInterface $entity)
+    {
+        /** @var LockableEntity $lockable */
+        $lockable = $this->getLockableEntity($entity);
+
+        if ($this->lockEnabled) {
+            $now = new \DateTime();
+            $thresholdDate = clone $lockable->getUpdated();
+            $thresholdDate->add(new \DateInterval("PT".$this->threshold."S"));
+
+            return $thresholdDate > $now;
+        }
+        return false;
+    }
+
+    /**
+     * @param User $user
+     * @param LockableEntityInterface $entity
+     * @return bool
+     */
+    public function isEntityLocked(User $user, LockableEntityInterface $entity)
+    {
+        /** @var LockableEntity $lockable */
+        $lockable = $this->getLockableEntity($entity);
+
+        if ($this->lockEnabled) {
+            $this->removeExpiredLocks($lockable);
+            $locks = $this->getEntityVersionLocksByLockableEntity($lockable, $user);
+
+            if($locks == null || !count($locks)) {
+                $this->createEntityVersionLock($user, $lockable);
+
+                $lockable->setUpdated(new \DateTime());
+                $this->objectManager->flush();
+
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * When editing the entity, create a new entity translation lock.
+     *
+     * @param User $user
+     * @param LockableEntity $entity
+     */
+    protected function createEntityVersionLock(User $user, LockableEntity $entity)
+    {
+        /** @var EntityVersionLock $lock */
+        $lock = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock')->findOneBy([
+            'owner' => $user->getUsername(),
+            'lockableEntity' => $entity
+        ]);
+        if (! $lock) {
+            $lock = new EntityVersionLock();
+        }
+        $lock->setOwner($user->getUsername());
+        $lock->setLockableEntity($entity);
+        $lock->setCreatedAt(new \DateTime());
+        $this->objectManager->persist($lock);
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @param LockableEntityInterface $entity
+     * @param User $userToExclude
+     * @return array
+     */
+    public function getUsersWithEntityVersionLock(LockableEntityInterface $entity, User $userToExclude = null)
+    {
+        /** @var LockableEntity $lockable */
+        $lockable = $this->getLockableEntity($entity);
+
+        return  array_reduce(
+            $this->getEntityVersionLocksByLockableEntity($lockable, $userToExclude),
+            function ($return, EntityVersionLock $item) {
+                $return[] = $item->getOwner();
+                return $return;
+            },
+            []
+        );
+    }
+
+    /**
+     * @param LockableEntity $entity
+     */
+    protected function removeExpiredLocks(LockableEntity $entity)
+    {
+        $locks = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock')->getExpiredLocks($entity, $this->threshold);
+        foreach ($locks as $lock) {
+            $this->objectManager->remove($lock);
+        }
+    }
+
+    /**
+     * When editing an entity, check if there is a lock for this entity.
+     *
+     * @param LockableEntity $entity
+     * @param User $userToExclude
+     * @return EntityVersionLock[]
+     */
+    protected function getEntityVersionLocksByLockableEntity(LockableEntity $entity, User $userToExclude = null)
+    {
+        /** @var EntityVersionLockRepository $objectRepository */
+        $objectRepository = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock');
+        return $objectRepository->getLocksForLockableEntity($entity, $this->threshold, $userToExclude);
+    }
+
+    /**
+     * Get or create a LockableEntity for an entity with LockableEntityInterface
+     *
+     * @param LockableEntityInterface $entity
+     *
+     * @return LockableEntity
+     */
+    protected function getLockableEntity(LockableEntityInterface $entity)
+    {
+        /** @var LockableEntity $lockable */
+        $lockable = $this->objectManager->getRepository('KunstmaanAdminListBundle:LockableEntity')->getOrCreate($entity->getId(), get_class($entity));
+        $this->objectManager->persist($lockable);
+        $this->objectManager->flush();
+
+        return $lockable;
+    }
+
+    /**
+     * @param ObjectManager $objectManager
+     */
+    public function setObjectManager($objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * @param integer $threshold
+     */
+    public function setThreshold($threshold)
+    {
+        $this->threshold = $threshold;
+    }
+
+    /**
+     * @param boolean lockEnabled
+     */
+    public function setLockEnabled($lockEnabled)
+    {
+        $this->lockEnabled = $lockEnabled;
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Tests/Model/TestLockableEntityInterfaceImplementation.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/Model/TestLockableEntityInterfaceImplementation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Tests\Model;
+
+use Kunstmaan\AdminListBundle\Entity\LockableEntityInterface;
+
+/**
+ * Class TestLockableEntityInterfaceImplementation
+ */
+class TestLockableEntityInterfaceImplementation implements LockableEntityInterface
+{
+   protected $id;
+
+   public function __construct($id)
+   {
+       $this->setId($id);
+   }
+
+    public function setId($id)
+   {
+       $this->id = $id;
+   }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Tests/Service/EntityVersionLockServiceTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/Service/EntityVersionLockServiceTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Tests\Service;
+
+use Kunstmaan\AdminBundle\Entity\User;
+use Kunstmaan\AdminListBundle\Entity\EntityVersionLock;
+use Kunstmaan\AdminListBundle\Entity\LockableEntity;
+use Kunstmaan\AdminListBundle\Service\EntityVersionLockService;
+use Kunstmaan\AdminListBundle\Tests\Model\TestLockableEntityInterfaceImplementation;
+
+/**
+ * class EntityVersionLockServiceTest
+ */
+class EntityVersionLockServiceTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $TEST_CLASS = "Kunstmaan\\AdminListBundle\\Tests\\Model\\TestLockableEntityInterfaceImplementation";
+    protected static $TEST_ENTITY_ID = "5";
+    protected static $ALTERNATIVE_TEST_ENTITY_ID = "391";
+    protected static $USER_ID = "104";
+    protected static $USER_NAME = "Kevin Test";
+    protected static $ALTERNATIVE_USER = "Alternative Test";
+    protected static $THRESHOLD = 35;
+
+    /**
+     * @var EntityVersionLockService
+     */
+    protected $object;
+
+    /**
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $user = new User();
+        $user->setId(self::$USER_ID);
+        $user->setUsername(self::$USER_NAME);
+        $this->user = $user;
+
+        $entity = new LockableEntity();
+        $entity->setEntityClass(self::$TEST_CLASS);
+        $entity->setEntityId(self::$TEST_ENTITY_ID);
+        $entity->setUpdated(new \DateTime());
+
+        $outDatedEntity = new LockableEntity();
+        $outDatedEntity->setEntityClass(self::$TEST_CLASS);
+        $outDatedEntity->setEntityId(self::$ALTERNATIVE_TEST_ENTITY_ID);
+        $outDatedEntity->setUpdated(new \DateTime("-1 days"));
+
+        $entityVersionLock = new EntityVersionLock();
+        $entityVersionLock->setOwner(self::$ALTERNATIVE_USER);
+        $entityVersionLock->setLockableEntity($entity);
+        $entityVersionLock->setCreatedAt(new \DateTime());
+
+        $expiredEntityVersionLock = new EntityVersionLock();
+        $expiredEntityVersionLock->setOwner($user->getUsername());
+        $expiredEntityVersionLock->setLockableEntity($entity);
+        $expiredEntityVersionLock->setCreatedAt(new \DateTime('-1 days'));
+
+        $locksMap = [
+            [$entity, self::$THRESHOLD, $this->user, [$entityVersionLock]],
+            [$outDatedEntity, self::$THRESHOLD, $this->user, []],
+        ];
+        $mockLockRepository = $this->getMockBuilder('Kunstmaan\AdminListBundle\Repository\EntityVersionLockRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockLockRepository
+            ->expects($this->any())
+            ->method('findOneBy')
+            ->will($this->returnValue($entityVersionLock));
+        $mockLockRepository
+            ->expects($this->any())
+            ->method('getExpiredLocks')
+            ->will($this->returnValue([$expiredEntityVersionLock]));
+        $mockLockRepository
+            ->expects($this->any())
+            ->method('getLocksForLockableEntity')
+            ->will($this->returnValueMap($locksMap));
+
+        $lockableMap = [
+            [self::$TEST_ENTITY_ID, self::$TEST_CLASS, $entity],
+            [self::$ALTERNATIVE_TEST_ENTITY_ID, self::$TEST_CLASS, $outDatedEntity],
+        ];
+        $mockLockableRepository = $this->getMockBuilder('Kunstmaan\AdminListBundle\Repository\LockableEntityRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockLockableRepository
+            ->expects($this->any())
+            ->method('getOrCreate')
+            ->will($this->returnValueMap($lockableMap));
+
+        $repositoryMap = [
+            ['KunstmaanAdminListBundle:EntityVersionLock', $mockLockRepository],
+            ['KunstmaanAdminListBundle:LockableEntity', $mockLockableRepository]
+        ];
+        $mockObjectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockObjectManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->will($this->returnValueMap($repositoryMap));
+
+        $this->object = new EntityVersionLockService($mockObjectManager, self::$THRESHOLD, true);
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    public function testIsEntityBelowThresholdReturnsTrueWhenEntityUpdatedAtIsBelowThreshold()
+    {
+        $result = $this->object->isEntityBelowThreshold(new TestLockableEntityInterfaceImplementation(self::$TEST_ENTITY_ID));
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsEntityBelowThresholdReturnsFalseWhenEntityUpdatedAtIsOverTreshold()
+    {
+
+        $result = $this->object->isEntityBelowThreshold(new TestLockableEntityInterfaceImplementation(self::$ALTERNATIVE_TEST_ENTITY_ID));
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsEntityLockedReturnsTrueWhenEntityLocked()
+    {
+        $result = $this->object->isEntityLocked($this->user, new TestLockableEntityInterfaceImplementation(self::$TEST_ENTITY_ID));
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsEntityLockedReturnsFalseWhenEntityIsNotLocked()
+    {
+        $result = $this->object->isEntityLocked($this->user, new TestLockableEntityInterfaceImplementation(self::$ALTERNATIVE_TEST_ENTITY_ID));
+
+        $this->assertFalse($result);
+    }
+
+    public function testGetUsersWithEntityVersionLockReturnsArrayWithOnlyUsernames()
+    {
+        $result = $this->object->getUsersWithEntityVersionLock(new TestLockableEntityInterfaceImplementation(self::$TEST_ENTITY_ID), $this->user);
+
+        $this->assertContains(self::$ALTERNATIVE_USER, $result);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets

Dont forget!  -- if you enable the feature you need to add the routing from AdminListBundle to your app/config/routing.yml or all admin lists will break.

Allows you to implement the LockableEntityInterface on every Entity you have an adminlist for. By doing this, each entity will automatically be locked/unlocked when users are working on them. Only 1 user can work on a locked Entity, all others will get a notification and be redirected back to it's respective overview.

- [x] Small details + rework based on comments from community
- [x] Documentation
- [x] Rebase branch
