### PR TITLE
[Composer]: removing acl dependency, already provided by symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/assetic-bundle": "~2.7.1",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "^2.8",
-        "symfony/security-acl": "^2.8",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Upgrading to a version of symfony later then 3.0.9 will not work because of an old dependency to "symfony/security-acl".

