### PR TITLE
[MediaBundle]: check if file exists

### DIFF
--- a/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
+++ b/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
@@ -80,7 +80,7 @@ class DoctrineMediaListener
                 if ($deleted || $reverted) {
                     $oldFileUrl = $entity->getUrl();
                     $newFileName = ($reverted ? $entity->getOriginalFilename() : uniqid());
-                    $newFileUrl = dirname($oldFileUrl) . '/' . $newFileName . '.' . pathinfo($oldFileUrl, PATHINFO_EXTENSION);
+                    $newFileUrl = dirname($oldFileUrl).'/'.$newFileName.'.'.pathinfo($oldFileUrl, PATHINFO_EXTENSION);
                     $entity->setUrl($newFileUrl);
                     $this->fileUrlMap[$newFileUrl] = $oldFileUrl;
                 }
@@ -98,7 +98,7 @@ class DoctrineMediaListener
 
     /**
      * @param object $entity The entity
-     * @param bool $new Is new
+     * @param bool   $new    Is new
      */
     private function saveMedia($entity, $new = false)
     {
@@ -110,10 +110,15 @@ class DoctrineMediaListener
         $url = $entity->getUrl();
         $handler = $this->mediaManager->getHandler($entity);
         if (isset($this->fileUrlMap[$url]) && $handler instanceof FileHandler) {
-            $handler->fileSystem->rename(
-                preg_replace('~^' . preg_quote($handler->mediaPath, '~') . '~', '/', $this->fileUrlMap[$url]),
-                preg_replace('~^' . preg_quote($handler->mediaPath, '~') . '~', '/', $url)
-            );
+            $regex = '~^'.preg_quote($handler->mediaPath, '~').'~';
+            $originalFileName = preg_replace($regex, '/', $this->fileUrlMap[$url]);
+            // Check if file exists on filesystem.
+            if ($handler->fileSystem->has($originalFileName)) {
+                $handler->fileSystem->rename(
+                    $originalFileName,
+                    preg_replace($regex, '/', $url)
+                );
+            }
             unset($this->fileUrlMap[$url]);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When deleting a file that no longer exists on the filesystem you will get an error that the file does not exists. This check will verify that the file exists on the filesystem and will not do the rename action when it does not exists. This way the delete process can continue.

