### PR TITLE
[GeneratorBundle] fixed datafixtures for default site

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
@@ -14,11 +14,15 @@ use Kunstmaan\PagePartBundle\Helper\Services\PagePartCreatorService;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+{% if demosite %}
 use {{ namespace }}\Entity\Bike;
+{% endif %}
 use {{ namespace }}\Entity\Pages\ContentPage;
 {% if demosite %}
 use {{ namespace }}\Entity\Pages\FormPage;
+{% endif %}
 use {{ namespace }}\Entity\Pages\HomePage;
+{% if demosite %}
 use {{ namespace }}\Entity\Pages\SearchPage;
 {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Due to the deprecation fixer tool it sorted the use statements. Because of that it will generate datafixtures without the correct uses.
