### PR TITLE
[NodeSearchBundle] strip all javascript including the script tags

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -640,8 +640,11 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     protected function removeHtml($text)
     {
+        // Strip all javascript including the script tags
+        $result = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', "", $text);
+        
         // Remove HTML markup
-        $result = strip_tags($text);
+        $result = strip_tags($result);
 
         // Decode HTML entities
         $result = trim(html_entity_decode($result, ENT_QUOTES));

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -640,8 +640,8 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     protected function removeHtml($text)
     {
-        // Strip all javascript including the script tags
-        $result = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', "", $text);
+        // Strip all javascript and styling including the script / style tags
+        $result = preg_replace('/<(script|style)\b[^>]*>(.*?)<\/(script|style)>/is', "", $text);
         
         // Remove HTML markup
         $result = strip_tags($result);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When you have javascript in a pagepart, the search provider will index a node with the javascript (without the script tags). When you search it will return the javascript code.

This fix will strip all the javascript inside the script tag.
