### PR TITLE
[PagePartBundle]: make page variable available inside pagepart admin

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
+++ b/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
@@ -91,6 +91,7 @@ class PagePartAdminController extends Controller
             'form'          => $formview,
             'pagepart'      => $pagePart,
             'pagepartadmin' => $pagePartAdmin,
+            'page'          => $pagePartAdmin->getPage(),
             'editmode'      => true
         ];
     }

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
@@ -51,6 +51,7 @@ class PagePartAdminTwigExtension extends \Twig_Extension
 
         return $template->render(array_merge($parameters, array(
             'pagepartadmin' => $ppAdmin,
+            'page' => $ppAdmin->getPage(),
             'form' => $form
         )));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

We are using the page variable very frequently inside our pagepart twig templates. The page variable is not available when editing a node. Therefor you need to create a admin view template for this issue. By adding the page variable always, we can use it also in the admin views.
