### PR TITLE
[PagePartBundle]: add post persist event

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Event/Events.php
+++ b/src/Kunstmaan/PagePartBundle/Event/Events.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kunstmaan\PagePartBundle\Event;
+
+/**
+ * Events
+ */
+class Events
+{
+    /**
+     * The postPersist event occurs for a given pagePart, after the pagePart is persisted.
+     *
+     * @var string
+     */
+    const POST_PERSIST = 'kunstmaan_pagepart.postPersist';
+}

--- a/src/Kunstmaan/PagePartBundle/Event/PagePartEvent.php
+++ b/src/Kunstmaan/PagePartBundle/Event/PagePartEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kunstmaan\PagePartBundle\Event;
+
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\NodeVersion;
+use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * PagePartEvent
+ */
+class PagePartEvent extends Event
+{
+    /**
+     * @var PagePartInterface
+     */
+    protected $pagePart;
+
+    /**
+     * @var Response
+     */
+    private $response = null;
+
+    /**
+     * PagePartEvent constructor.
+     *
+     * @param PagePartInterface $pagePart
+     */
+    public function __construct(PagePartInterface $pagePart)
+    {
+        $this->pagePart = $pagePart;
+    }
+
+    /**
+     * @return PagePartInterface
+     */
+    public function getPagePart()
+    {
+        return $this->pagePart;
+    }
+
+    /**
+     * @param PagePartInterface $pagePart
+     */
+    public function setPagePart(PagePartInterface $pagePart)
+    {
+        $this->pagePart = $pagePart;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Kunstmaan/TaggingBundle/EventListener/TagsListener.php
+++ b/src/Kunstmaan/TaggingBundle/EventListener/TagsListener.php
@@ -4,13 +4,12 @@ namespace Kunstmaan\TaggingBundle\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use DoctrineExtensions\Taggable\Taggable;
-
 use Kunstmaan\NodeBundle\Event\NodeEvent;
+use Kunstmaan\PagePartBundle\Event\PagePartEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class TagsListener
 {
-
     /**
      * @var ContainerInterface
      */
@@ -63,6 +62,15 @@ class TagsListener
 
         if ($page instanceof Taggable) {
             $this->getTagManager()->saveTagging($page);
+        }
+    }
+
+    public function postPagePartPersist(PagePartEvent $event)
+    {
+        $pagePart = $event->getPagePart();
+
+        if ($pagePart instanceof Taggable) {
+            $this->getTagManager()->saveTagging($pagePart);
         }
     }
 

--- a/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - { name: doctrine.event_listener, event: postPersist }
             - { name: doctrine.event_listener, event: postLoad }
             - { name: kernel.event_listener, event: kunstmaan_node.postPersist, method: postNodePersist }
+            - { name: kernel.event_listener, event: kunstmaan_pagepart.postPersist, method: postPagePartPersist }
 
     kuma_tagging.clone.listener:
         class: Kunstmaan\TaggingBundle\EventListener\CloneListener


### PR DESCRIPTION
[PagePartBundle]: add post persist event

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When using the TaggingBundle and adding tags on a pagePart, the tags are not persisted in the database when saving the node. Therefore I've added a post persist event for the PageParts that can be used in the TaggingListener for each pagePart.
