### PR TITLE
[Form-bundle] Fixed form export when using same labels for multiple fields - #1427

### DIFF
--- a/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
@@ -130,11 +130,10 @@ class FormSubmissionExportListConfigurator implements ExportListConfiguratorInte
                 'language' => $submission->getLang()
             );
             foreach ($submission->getFields() as $field) {
-                $header = $this->translator->trans($field->getLabel());
                 if (!$isHeaderWritten) {
-                    $this->addExportField($header, $header);
+                    $this->addExportField($field->getFieldName(), $this->translator->trans($field->getLabel()));
                 }
-                $data[$header] = $field->__toString();
+                $data[$field->getFieldName()] = $field->__toString();
             }
             $isHeaderWritten = true;
             $collection->add(array($data));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 1427

See #1427. When using 2 of the same labels, the export functionality would not work correctly.