### PR TITLE
[AdminBundle] Also use replacedUrl in CKEDITOR instance

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_url-chooser.js
@@ -131,7 +131,7 @@ kunstmaanbundles.urlChooser = (function (window, undefined) {
             var funcNum = getUrlParam('CKEditorFuncNum');
 
             // Set val
-            window.opener.CKEDITOR.tools.callFunction(funcNum, itemUrl);
+            window.opener.CKEDITOR.tools.callFunction(funcNum, replacedUrl);
 
             // Close window
             window.close();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Otherwise you will get something like `[NT8]`.