### PR TITLE
[MenuBundle] View would not automatically switch to the menuitems of your new locale

### DIFF
--- a/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
@@ -7,10 +7,12 @@ use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractAdminListConfigurat
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
+use Kunstmaan\MenuBundle\Entity\BaseMenu;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class MenuItemAdminListController extends AdminListController
 {
@@ -47,13 +49,27 @@ class MenuItemAdminListController extends AdminListController
 
     /**
      * The index action
+     * @param Request $request
+     * @param int $menuid
+     * @return Response
      *
      * @Route("/{menuid}/items", name="kunstmaanmenubundle_admin_menuitem")
      */
     public function indexAction(Request $request, $menuid)
     {
-        $configurator = $this->getAdminListConfigurator($request, $menuid);
+        $menuRepo = $this->getDoctrine()->getManager()->getRepository(
+            $this->getParameter('kunstmaan_menu.entity.menu.class')
+        );
 
+        /** @var BaseMenu $menu */
+        $menu = $menuRepo->find($menuid);
+        if ($menu->getLocale() != $request->getLocale()) {
+            /** @var BaseMenu $translatedMenu */
+            $translatedMenu = $menuRepo->findOneBy(['locale' => $request->getLocale(), 'name' => $menu->getName()]);
+            $menuid = $translatedMenu->getId();
+        }
+
+        $configurator = $this->getAdminListConfigurator($request, $menuid);
         $itemRoute = function (EntityInterface $item) use ($menuid) {
             return array(
                 'path' => 'kunstmaanmenubundle_admin_menuitem_move_up',


### PR DESCRIPTION
Avoid being stuck in the MenuItems of a menu for a different locale when switching locale at the MenuItemAdminListView.
Finds the correct Menu based on the newly requested locale and name of the current menu.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  #1437 
