### PR TITLE
[NodeBundle] Remove default for is_homepage

### DIFF
--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('indexable')->end()
                             ->scalarNode('icon')->defaultNull()->end()
                             ->scalarNode('hidden_from_tree')->end()
-                            ->booleanNode('is_homepage')->defaultFalse()->end()
+                            ->booleanNode('is_homepage')->end()
                             ->arrayNode('allowed_children')
                                 ->prototype('array')
                                     ->beforeNormalization()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | n/a

If a default value is applied the PagesConfiguration will never fallback to checking wether or node `HomePageInterface` is implemented. See https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/master/src/Kunstmaan/NodeBundle/Helper/PagesConfiguration.php#L110