### PR TITLE
Fix error "[] operator not supported for strings"

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -616,7 +616,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
             return $result->format('Y-m-d H:i:s');
         } else {
             if ($result instanceof PersistentCollection) {
-                $results = "";
+                $results = [];
                 /* @var Object $entry */
                 foreach ($result as $entry) {
                     $results[] = $entry->getName();


### PR DESCRIPTION
I got this error when running PHP 7.1.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

