### PR TITLE
Add pagepart_index to pagepart templates

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartTwigExtension/widget.html.twig
@@ -1,4 +1,5 @@
 {% for box in pageparts %}
     {% set resource = box %}
+    {% set pagepart_index = loop.index0 %}
     {% include box.getView(page) %}
 {% endfor %}


### PR DESCRIPTION
I know you can access the loop.index0 variable directly within the PagePart template, but I think it's worth adding it as an explicit API point.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR
