### PR TITLE
[AdminBundle]: fix permissionadmin for sf3

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
@@ -233,7 +233,7 @@ class PermissionAdmin
             $user = $this->tokenStorage->getToken()->getUser();
             $this->createAclChangeSet($this->resource, $changes, $user);
 
-            $cmd = 'php ' . $this->kernel->getRootDir() . '/console kuma:acl:apply';
+            $cmd = 'php bin/console kuma:acl:apply';
             $cmd .= ' --env=' . $this->kernel->getEnvironment();
 
             $this->shellHelper->runInBackground($cmd);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When using bundles with symfony 2 version, the kernel root dir was the same as the console directory. This is not the case anymore in symfony 3  so we need to change this piece of code.

When updating the permissions of a node and recursively updating the children, it wil not work anymore.
