### PR TITLE
[AdminBundle]: fix fos user enabled state

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -64,7 +64,7 @@ abstract class BaseUser extends AbstractUser
      *
      * @param int $id
      *
-     * @return User
+     * @return BaseUser
      */
     public function setId($id)
     {
@@ -118,7 +118,7 @@ abstract class BaseUser extends AbstractUser
      *
      * @param string $adminLocale
      *
-     * @return User
+     * @return BaseUser
      */
     public function setAdminLocale($adminLocale)
     {
@@ -192,4 +192,13 @@ abstract class BaseUser extends AbstractUser
      * @return string
      */
     abstract public function getFormTypeClass();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAccountNonLocked()
+    {
+        return $this->isEnabled();
+    }
+
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Use case: 

- Disable a user in the CMS
- Request a new password for this user
- Click on the link you received in your email
- Set a new password
- User is enabled again

FOSUserBundle has created a new eventlistener for this:

https://github.com/FriendsOfSymfony/FOSUserBundle/pull/2076

I've added the isAccountNonLocked function to our BaseUser and this should check the enabled status of a user in our purpose.
