### PR TITLE
[GeneratorBundle]: add replace_url by default

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/IntroTextPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/IntroTextPagePart/view.html.twig
@@ -1,3 +1,3 @@
 <div class="introtext-pp text--intro">
-    {{ resource.content|raw }}
+    {{ resource.content|replace_url|raw }}
 </div>

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/TextPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/TextPagePart/view.html.twig
@@ -1,3 +1,3 @@
 <div class="text-pp">
-    {{ resource.content|raw }}
+    {{ resource.content|replace_url|raw }}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When generation a new default site, the text and intro text pagepart should contain the replace_url twig function by default for the URL Chooser to work properly. 
