### PR TITLE
[AllBundles]: fix ckeditor media tokens

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
+++ b/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Form;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * Class MediaTokenTransformer.
+ */
+class MediaTokenTransformer implements DataTransformerInterface
+{
+    /**
+     * @param mixed $content
+     *
+     * @return string
+     */
+    public function transform($content)
+    {
+        $html = utf8_encode("<!DOCTYPE html>
+        <html>
+            <body>
+                ".$content."
+            </body>
+        </html>");
+
+        $crawler = new Crawler($html);
+
+        $crawler->filter('img')->each(
+            function (Crawler $node, $i) {
+                $image = $node->getNode($i);
+                if ($image->hasAttribute('data-src')) {
+                    $src = $image->getAttribute('data-src');
+                    $image->setAttribute('src', $src);
+                    $image->removeAttribute('data-src');
+                }
+            }
+        );
+
+        return $crawler->html();
+    }
+
+    /**
+     * @param mixed $content
+     *
+     * @return string
+     */
+    public function reverseTransform($content)
+    {
+        // All on one line because of HTML parsing and empty lines.
+        $html = utf8_encode("<!DOCTYPE html><html><body>".$content."</body></html>");
+
+        $crawler = new Crawler($html);
+
+        // Get all img tags and parse the token.
+        $crawler->filter('img')->each(
+            function (Crawler $node, $i) {
+                $image = $node->getNode($i);
+                $src = $image->getAttribute('src');
+                $parsed = parse_url($src, PHP_URL_QUERY);
+                parse_str($parsed, $query);
+
+                if ($query['token']) {
+                    $image->setAttribute('src', $query['token']);
+                }
+                $image->setAttribute('data-src', $src);
+            }
+        );
+
+        return urldecode($crawler->filter('body')->html());
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Form/WysiwygType.php
+++ b/src/Kunstmaan/AdminBundle/Form/WysiwygType.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 
 /**
@@ -12,6 +13,16 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
  */
 class WysiwygType extends AbstractType
 {
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $transformer = new MediaTokenTransformer();
+        $builder->addModelTransformer($transformer);
+    }
+
     /**
      * @return string
      */

--- a/src/Kunstmaan/FormBundle/Form/AbstractFormPageAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/AbstractFormPageAdminType.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\FormBundle\Form;
 
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -21,12 +22,9 @@ class AbstractFormPageAdminType extends AbstractType
         $builder->add('title', null, array(
             'label' => 'kuma_form.form.page_admin.title.label',
         ));
-        $builder->add('thanks', TextareaType::class, array(
+        $builder->add('thanks', WysiwygType::class, array(
             'label' => 'kuma_form.form.page_admin.thanks.label',
             'required' => false,
-            'attr' => array(
-                'class' => 'js-rich-editor rich-editor'
-            ),
         ));
         $builder->add('subject', null, array(
             'label' => 'kuma_form.form.page_admin.subject.label',

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
@@ -6,7 +6,7 @@ use Kunstmaan\MediaBundle\Form\Type\MediaType;
 use Kunstmaan\NodeBundle\Form\Type\URLChooserType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -34,8 +34,7 @@ class ServicePagePartAdminType extends \Symfony\Component\Form\AbstractType
 	$builder->add('title', TextType::class, array(
 	    'required' => true,
 	));
-	$builder->add('description', TextareaType::class, array(
-	    'attr' => array('rows' => 10, 'cols' => 600, 'class' => 'js-rich-editor rich-editor', 'height' => 140),
+	$builder->add('description', WysiwygType::class, array(
 	    'required' => false,
 	));
 	$builder->add('linkUrl', URLChooserType::class, array(

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/FormPageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/FormPageAdminType.php
@@ -4,7 +4,7 @@ namespace {{ namespace }}\Form\Pages;
 
 use Kunstmaan\NodeBundle\Form\PageAdminType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -31,20 +31,17 @@ class FormPageAdminType extends PageAdminType
     {
         parent::buildForm($builder, $options);
 
-	$builder->add('subject', TextType::class, array(
-	    'required' => false,
-	));
-	$builder->add('fromEmail', EmailType::class, array(
-	    'required' => false,
-	));
-	$builder->add('toEmail', EmailType::class, array(
-	    'required' => false,
-	));
-        $builder->add('thanks', TextareaType::class, array(
-	    'required' => false,
-	    'attr' => array(
-		'class' => 'js-rich-editor rich-editor'
-	    )
+        $builder->add('subject', TextType::class, array(
+            'required' => false,
+        ));
+        $builder->add('fromEmail', EmailType::class, array(
+            'required' => false,
+        ));
+        $builder->add('toEmail', EmailType::class, array(
+            'required' => false,
+        ));
+        $builder->add('thanks', WysiwygType::class, array(
+            'required' => false,
         ));
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/IntroTextPagePart/IntroTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/IntroTextPagePart/IntroTextPagePartAdminType.php
@@ -3,7 +3,7 @@
 namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,9 +26,8 @@ class {{ pagepart }}AdminType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('content', TextareaType::class, array(
+        $builder->add('content', WysiwygType::class, array(
             'required' => true,
-            'attr' => array('rows' => 10, 'cols' => 600, 'class' => 'js-rich-editor rich-editor', 'height' => 120)
         ));
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TextPagePart/TextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TextPagePart/TextPagePartAdminType.php
@@ -3,7 +3,7 @@
 namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -26,9 +26,8 @@ class {{ pagepart }}AdminType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('content', TextareaType::class, array(
+        $builder->add('content', WysiwygType::class, array(
             'required' => true,
-            'attr' => array('rows' => 10, 'cols' => 600, 'class' => 'js-rich-editor rich-editor', 'height' => 140)
         ));
     }
 

--- a/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
@@ -209,7 +209,7 @@
                             {% set path = "[%s]" | format("M" ~ media.id) %}
 
                             <div class="col-sm-6 col-md-4 col-lg-3">
-                                <a href="javascript:void(0)" class="js-url-chooser-media-select thumbnail media-thumbnail" data-thumb-path="{{ imageurl }}" data-path="{{ path }}" data-title="{{ media.name|escape('js') }}" data-id="{{ media.id }}" data-cke="{% if cKEditorFuncNum %}true{% else %}false{% endif %}">
+                                <a href="javascript:void(0)" class="js-url-chooser-media-select thumbnail media-thumbnail" data-thumb-path="{{ imageurl }}" data-path="{{ media.url ~ '?token=' ~ path }}" data-title="{{ media.name|escape('js') }}" data-id="{{ media.id }}" data-cke="{% if cKEditorFuncNum %}true{% else %}false{% endif %}">
                                     <figure>
                                         {% if imageurl %}
                                             <img src="{{ imageurl }}" srcset="{{ imageurl }} 1x, {{ imageurlretina is defined ? ', ' ~ imageurlretina ~ " 2x" }}" alt="{{ media.name }}" class="media-thumbnail__img">

--- a/src/Kunstmaan/PagePartBundle/Form/TextPagePartAdminType.php
+++ b/src/Kunstmaan/PagePartBundle/Form/TextPagePartAdminType.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\PagePartBundle\Form;
 
+use Kunstmaan\AdminBundle\Form\WysiwygType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,14 +19,9 @@ class TextPagePartAdminType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('content', TextareaType::class, array(
+        $builder->add('content', WysiwygType::class, array(
             'label' => 'pagepart.text.content',
             'required' => false,
-            'attr' => array(
-                'rows' => 32,
-                'cols' => 600,
-                'class' => 'js-rich-editor rich-editor',
-            ),
         ));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When we introduced the new url chooser, we had some problems with the ckeditor and the media chooser. When you choose a media item in the ckeditor, the URL of it will be a token. This is our wished behaviour but the ckeditor does not render this token. 

With this PR I've added a Transformer that will do this correctly.

I've also changed all the old TextAreaTypes to the new WysiwygType because the transformer only works on this form type.
