### PR TITLE
[KunstmaanCacheBundle]: add new caching bundle

### DIFF
--- a/UPGRADE-4.1.md
+++ b/UPGRADE-4.1.md
@@ -7,3 +7,11 @@ Added note to the RedirectBundle:
 https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/1490
 
 Please be sure to execute database migrations after upgrading.
+
+## KunstmaanCacheBundle
+
+We added a new caching bundle.
+
+https://github.com/Kunstmaan/KunstmaanBundlesCMS/tree/master/docs/05-14-using-the-cache-bundle.md
+
+This bundle allows you to do stuff with caching. For now it's a starting bundle with the possibility to ban stuff from varnish.

--- a/docs/05-14-using-the-cache-bundle.md
+++ b/docs/05-14-using-the-cache-bundle.md
@@ -1,0 +1,45 @@
+#  Using the Cache bundle
+
+
+## Installation
+
+This bundle is compatible with all Symfony 3.* releases. More information about installing can be found in this line by line walkthrough of installing Symfony and all our bundles, please refer to the [Getting Started guide](http://bundles.kunstmaan.be/getting-started) and enjoy the full blown experience.
+
+## Usage
+
+This bundle allows you to do stuff with caching. For now it's a starting bundle with the possibility
+to ban stuff from varnish.
+
+### Configure bundle in config.yml
+
+This bundle works with the fos http cache bundle. Therefore you need to add the following configuration, of course with your own varnish path.
+```YAML
+fos_http_cache:
+    proxy_client:
+        varnish:
+            servers:
+                - 127.0.0.1:6081
+    cache_manager:
+        enabled: true
+    invalidation:
+        enabled: true
+```
+
+### Add the kunstmaan_cache routing to your routing.yml
+
+```YAML
+# KunstmaanCacheBundle
+KunstmaanCacheBundle:
+    resource: "@KunstmaanCacheBundle/Resources/config/routing.yml"
+    prefix:   /{_locale}/
+    requirements:
+        _locale: "%requiredlocales%"
+```
+    
+### Result
+
+When you browse to "Settings" in the main menu, you will see that there is a new menu item available with the label of "Varnish ban".
+There you can add a path that you would like to ban from varnish. When you check the all domains option and you are using a multidomain website,
+the path will be banned from all hosts of your multidomain.
+
+On nodes you have a new menu actions to clear the cache for that node.

--- a/src/Kunstmaan/CacheBundle/Controller/VarnishController.php
+++ b/src/Kunstmaan/CacheBundle/Controller/VarnishController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\Controller;
+
+use Kunstmaan\CacheBundle\Form\Varnish\BanType;
+use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Class VarnishController.
+ */
+class VarnishController extends Controller
+{
+    /**
+     * Generates the varnish ban form.
+     *
+     * @Route("/settings/varnish", name="kunstmaancachebundle_varnish_settings_ban")
+     * @Template("KunstmaanCacheBundle:Varnish:ban.html.twig")
+     *
+     *
+     * @param Request $request
+     *
+     * @return array
+     */
+    public function indexAction(Request $request)
+    {
+        $this->checkPermission();
+
+        $form = $this->createForm(BanType::class);
+
+        if ($request->isMethod('POST')) {
+            $form->handleRequest($request);
+
+            if ($form->isValid()) {
+                $path = $form['path']->getData();
+
+                $this->get('kunstmaan_cache.helper.varnish')->banPath($path, $form['allDomains']->getData());
+
+                $this->addFlash('success', 'kunstmaan_cache.varnish.ban.success');
+            }
+        }
+
+        return [
+            'form' => $form->createView(),
+        ];
+    }
+
+    /**
+     * Ban route from varnish
+     *
+     * @Route("/varnish/ban/{node}", name="kunstmaancachebundle_varnish_ban")
+     *
+     * @param Node $node
+     *
+     * @return RedirectResponse
+     */
+    public function banAction(Node $node)
+    {
+        $this->checkPermission();
+
+        /** @var NodeTranslation $nodeTranslation */
+        foreach ($node->getNodeTranslations() as $nodeTranslation) {
+            $route = $this->generateUrl('_slug', ['url' => $nodeTranslation->getUrl(), '_locale' => $nodeTranslation->getLang()]);
+            $this->get('kunstmaan_cache.helper.varnish')->banPath($route);
+        }
+        $this->addFlash('success', 'kunstmaan_cache.varnish.ban.success');
+
+        return $this->redirect($this->generateUrl('KunstmaanNodeBundle_nodes_edit', ['id' => $node->getId()]));
+    }
+
+    /**
+     * Check permission
+     *
+     * @param string $roleToCheck
+     *
+     * @throws AccessDeniedException
+     */
+    private function checkPermission($roleToCheck = 'ROLE_SUPER_ADMIN')
+    {
+        if (false === $this->isGranted($roleToCheck)) {
+            throw new AccessDeniedException();
+        }
+    }
+}

--- a/src/Kunstmaan/CacheBundle/DependencyInjection/KunstmaanCacheExtension.php
+++ b/src/Kunstmaan/CacheBundle/DependencyInjection/KunstmaanCacheExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class KunstmaanCacheExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/Kunstmaan/CacheBundle/EventListener/VarnishListener.php
+++ b/src/Kunstmaan/CacheBundle/EventListener/VarnishListener.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\EventListener;
+
+use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\Tab;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMapInterface;
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\NodeBundle\Event\AdaptFormEvent;
+use Kunstmaan\NodeBundle\Event\ConfigureActionMenuEvent;
+use Kunstmaan\NodeBundle\Helper\FormWidgets\PermissionsFormWidget;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class VarnishListener
+{
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * VarnishListener constructor.
+     *
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param RouterInterface               $router
+     */
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, RouterInterface $router)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->router = $router;
+    }
+
+    /**
+     * @param ConfigureActionMenuEvent $event
+     */
+    public function onActionMenuConfigure(ConfigureActionMenuEvent $event)
+    {
+        $menu = $event->getMenu();
+        $activeNodeVersion = $event->getActiveNodeVersion();
+
+        if ($activeNodeVersion !== null && $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN')) {
+            $activeNode = $activeNodeVersion->getNodeTranslation()->getNode();
+
+            $menu->addChild(
+                'kunstmaan_cache.varnish.ban.menu',
+                [
+                    'uri' => $this->router->generate(
+                        'kunstmaancachebundle_varnish_ban',
+                        [
+                            'node' => $activeNode->getId()
+                        ]
+                    ),
+                    'linkAttributes' => [
+                        'class' => 'btn btn-default btn--raise-on-hover'
+                    ]
+                ]
+            );
+        }
+    }
+}

--- a/src/Kunstmaan/CacheBundle/Form/Varnish/BanType.php
+++ b/src/Kunstmaan/CacheBundle/Form/Varnish/BanType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\Form\Varnish;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class BanType.
+ */
+class BanType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('path', TextType::class, [
+            'label' => 'kunstmaan_cache.varnish.ban.path',
+        ]);
+        $builder->add('allDomains', CheckboxType::class, [
+            'label' => 'kunstmaan_cache.varnish.ban.all_domains',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'kunstmaan_cache_varnish_ban';
+    }
+}

--- a/src/Kunstmaan/CacheBundle/Helper/Menu/VarnishMenuAdaptor.php
+++ b/src/Kunstmaan/CacheBundle/Helper/Menu/VarnishMenuAdaptor.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\Helper\Menu;
+
+use Kunstmaan\AdminBundle\Helper\Menu\MenuAdaptorInterface;
+use Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder;
+use Kunstmaan\AdminBundle\Helper\Menu\MenuItem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class VarnishMenuAdaptor implements MenuAdaptorInterface
+{
+    /**
+     * In this method you can add children for a specific parent, but also remove and change the already created children
+     *
+     * @param MenuBuilder $menu      The MenuBuilder
+     * @param MenuItem[]  &$children The current children
+     * @param MenuItem    $parent    The parent Menu item
+     * @param Request     $request   The Request
+     */
+    public function adaptChildren(MenuBuilder $menu, array &$children, MenuItem $parent = null, Request $request = null)
+    {
+        if (!is_null($parent) && 'KunstmaanAdminBundle_settings' == $parent->getRoute()) {
+            $menuItem = new MenuItem($menu);
+            $menuItem
+                ->setRoute('kunstmaancachebundle_varnish_settings_ban')
+                ->setLabel('Varnish ban')
+                ->setUniqueId('varnish_ban')
+                ->setParent($parent);
+
+            if (stripos($request->attributes->get('_route'), $menuItem->getRoute()) === 0) {
+                $menuItem->setActive(true);
+                $parent->setActive(true);
+            }
+            $children[] = $menuItem;
+        }
+    }
+}

--- a/src/Kunstmaan/CacheBundle/Helper/VarnishHelper.php
+++ b/src/Kunstmaan/CacheBundle/Helper/VarnishHelper.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\Helper;
+
+use FOS\HttpCache\CacheInvalidator;
+use FOS\HttpCache\Exception\InvalidArgumentException;
+use FOS\HttpCache\ProxyClient\Varnish;
+use FOS\HttpCacheBundle\CacheManager;
+use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
+
+/**
+ * Class VarnishHelper.
+ */
+class VarnishHelper
+{
+    /**
+     * @var CacheManager
+     */
+    private $cacheManager;
+
+    /**
+     * @var DomainConfigurationInterface
+     */
+    private $domainConfiguration;
+
+    /**
+     * VarnishHelper constructor.
+     *
+     * @param CacheManager                 $cacheManager
+     * @param DomainConfigurationInterface $domainConfiguration
+     */
+    public function __construct(CacheManager $cacheManager, DomainConfigurationInterface $domainConfiguration)
+    {
+        $this->cacheManager = $cacheManager;
+        $this->domainConfiguration = $domainConfiguration;
+    }
+
+    /**
+     * @param string $path
+     * @param bool   $allDomains
+     *
+     * @return CacheInvalidator
+     */
+    public function banPath($path, $allDomains = false)
+    {
+        $hosts = $this->getHosts($allDomains);
+
+        return $this->cacheManager->invalidateRegex($path, null, $hosts);
+    }
+
+    protected function getHosts($allDomains = false)
+    {
+        if ($allDomains) {
+            return $this->domainConfiguration->getHosts();
+        }
+
+        return $this->domainConfiguration->getHost();
+    }
+}

--- a/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
+++ b/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kunstmaan\CacheBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class KunstmaanCacheBundle extends Bundle
+{
+}

--- a/src/Kunstmaan/CacheBundle/LICENSE
+++ b/src/Kunstmaan/CacheBundle/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2012 Kunstmaan (http://www.kunstmaan.be)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Kunstmaan/CacheBundle/README.md
+++ b/src/Kunstmaan/CacheBundle/README.md
@@ -1,0 +1,45 @@
+#  Using the Cache bundle
+
+
+## Installation
+
+This bundle is compatible with all Symfony 3.* releases. More information about installing can be found in this line by line walkthrough of installing Symfony and all our bundles, please refer to the [Getting Started guide](http://bundles.kunstmaan.be/getting-started) and enjoy the full blown experience.
+
+## Usage
+
+This bundle allows you to do stuff with caching. For now it's a starting bundle with the possibility
+to ban stuff from varnish.
+
+### Configure bundle in config.yml
+
+This bundle works with the fos http cache bundle. Therefore you need to add the following configuration, of course with your own varnish path.
+```YAML
+fos_http_cache:
+    proxy_client:
+        varnish:
+            servers:
+                - 127.0.0.1:6081
+    cache_manager:
+        enabled: true
+    invalidation:
+        enabled: true
+```
+
+### Add the kunstmaan_cache routing to your routing.yml
+
+```YAML
+# KunstmaanCacheBundle
+KunstmaanCacheBundle:
+    resource: "@KunstmaanCacheBundle/Resources/config/routing.yml"
+    prefix:   /{_locale}/
+    requirements:
+        _locale: "%requiredlocales%"
+```
+    
+### Result
+
+When you browse to "Settings" in the main menu, you will see that there is a new menu item available with the label of "Varnish ban".
+There you can add a path that you would like to ban from varnish. When you check the all domains option and you are using a multidomain website,
+the path will be banned from all hosts of your multidomain.
+
+On nodes you have a new menu actions to clear the cache for that node.

--- a/src/Kunstmaan/CacheBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/CacheBundle/Resources/config/routing.yml
@@ -1,0 +1,5 @@
+################ VARNISH ################
+kunstmaancachebundle_varnish:
+    resource: "@KunstmaanCacheBundle/Controller/VarnishController.php"
+    type:     annotation
+    prefix:   /admin

--- a/src/Kunstmaan/CacheBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/CacheBundle/Resources/config/services.yml
@@ -1,0 +1,23 @@
+parameters:
+    kunstmaan_cache.menu_adaptor.varnish.class: Kunstmaan\CacheBundle\Helper\Menu\VarnishMenuAdaptor
+    kunstmaan_cache.helper.varnish.class: Kunstmaan\CacheBundle\Helper\VarnishHelper
+
+services:
+  kunstmaan_cache.menu_adaptor.varnish:
+    class: "%kunstmaan_cache.menu_adaptor.varnish.class%"
+    tags:
+      -  { name: "kunstmaan_admin.menu.adaptor" }
+
+  kunstmaan_cache.helper.varnish:
+    class: "%kunstmaan_cache.helper.varnish.class%"
+    arguments:
+      - "@fos_http_cache.cache_manager"
+      - "@kunstmaan_admin.domain_configuration"
+
+  kunstmaan_cache.listener.varnish:
+    class: Kunstmaan\CacheBundle\EventListener\VarnishListener
+    arguments:
+        - "@security.authorization_checker"
+        - "@router"
+    tags:
+        - { name: 'kernel.event_listener', event: 'kunstmaan_node.configureActionMenu', method: 'onActionMenuConfigure' }

--- a/src/Kunstmaan/CacheBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/CacheBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,8 @@
+kunstmaan_cache:
+    varnish:
+        ban:
+            path: Path
+            submit: Ban!
+            all_domains: Ban on all domains
+            success: Banned successfully!
+            menu: Remove from cache

--- a/src/Kunstmaan/CacheBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/CacheBundle/Resources/translations/messages.nl.yml
@@ -1,0 +1,8 @@
+kunstmaan_cache:
+    varnish:
+        ban:
+            path: Pad
+            submit: Ban!
+            all_domains: Ban op elk domein
+            success: Banned werd met succes uitgevoerd!
+            menu: Verwijder uit cache

--- a/src/Kunstmaan/CacheBundle/Resources/views/Varnish/ban.html.twig
+++ b/src/Kunstmaan/CacheBundle/Resources/views/Varnish/ban.html.twig
@@ -1,0 +1,41 @@
+{% extends '@KunstmaanAdmin/Settings/index.html.twig' %}
+{% form_theme form '@KunstmaanAdmin/Form/fields.html.twig' %}
+
+{% block header %}{% endblock %}
+
+{% block content %}
+    {{ form_start(form, {'attr': {'novalidate': 'novalidate'}}) }}
+    <!-- Header -->
+    <header class="app__content__header">
+        <div class="row">
+            {% if adminmenu.current %}
+                <div class="col-sm-6 col-md-8">
+                    <h1 class="app__content__header__title">
+                        {{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}
+                    </h1>
+                </div>
+            {% endif %}
+        </div>
+    </header>
+
+    <!-- Scroll-actions -->
+    <div class="page-main-actions page-main-actions--top" id="page-main-actions-top">
+        <div class="btn-group">
+            {{ block('actions') }}
+            <button type="button" class="js-scroll-to-top btn btn-default btn--raise-on-hover">
+                <i class="fa fa-caret-up"></i>
+            </button>
+        </div>
+    </div>
+
+    <!-- Fields -->
+    <fieldset class="form__fieldset--padded">
+        {{ form_rest(form) }}
+        <button type="submit" name="submit" class="btn btn-primary btn--raise-on-hover">
+            {{ 'kunstmaan_cache.varnish.ban.submit'|trans() }}
+        </button>
+    </fieldset>
+
+    {{ form_end(form) }}
+
+{% endblock %}

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -58,11 +58,11 @@ class ActionsMenuBuilder
 
 
     /**
-     * @param FactoryInterface              $factory               The factory
-     * @param EntityManager                 $em                    The entity manager
-     * @param RouterInterface               $router                The router
-     * @param EventDispatcherInterface      $dispatcher            The event dispatcher
-     * @param AuthorizationCheckerInterface $authorizationChecker  The security authorization checker
+     * @param FactoryInterface              $factory              The factory
+     * @param EntityManager                 $em                   The entity manager
+     * @param RouterInterface               $router               The router
+     * @param EventDispatcherInterface      $dispatcher           The event dispatcher
+     * @param AuthorizationCheckerInterface $authorizationChecker The security authorization checker
      * @param PagesConfiguration            $pagesConfiguration
      */
     public function __construct(
@@ -72,13 +72,14 @@ class ActionsMenuBuilder
         EventDispatcherInterface $dispatcher,
         AuthorizationCheckerInterface $authorizationChecker,
         PagesConfiguration $pagesConfiguration
-    ) {
-        $this->factory              = $factory;
-        $this->em                   = $em;
-        $this->router               = $router;
-        $this->dispatcher           = $dispatcher;
+    )
+    {
+        $this->factory = $factory;
+        $this->em = $em;
+        $this->router = $router;
+        $this->dispatcher = $dispatcher;
         $this->authorizationChecker = $authorizationChecker;
-        $this->pagesConfiguration   = $pagesConfiguration;
+        $this->pagesConfiguration = $pagesConfiguration;
     }
 
     /**
@@ -87,19 +88,19 @@ class ActionsMenuBuilder
     public function createSubActionsMenu()
     {
         $activeNodeVersion = $this->getActiveNodeVersion();
-        $menu              = $this->factory->createItem('root');
+        $menu = $this->factory->createItem('root');
         $menu->setChildrenAttribute('class', 'page-sub-actions');
 
         if (null !== $activeNodeVersion && $this->isEditableNode) {
             $menu->addChild(
                 'subaction.versions',
-                array(
-                    'linkAttributes' => array(
-                        'data-toggle'   => 'modal',
+                [
+                    'linkAttributes' => [
+                        'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target'   => '#versions'
-                    )
-                )
+                        'data-target' => '#versions'
+                    ]
+                ]
             );
         }
 
@@ -130,7 +131,7 @@ class ActionsMenuBuilder
             }
         }
 
-        $menu              = $this->factory->createItem('root');
+        $menu = $this->factory->createItem('root');
         $menu->setChildrenAttribute(
             'class',
             'page-main-actions js-auto-collapse-buttons'
@@ -153,41 +154,41 @@ class ActionsMenuBuilder
             return $menu;
         }
 
-        $activeNodeTranslation       = $activeNodeVersion->getNodeTranslation();
-        $node                        = $activeNodeTranslation->getNode();
+        $activeNodeTranslation = $activeNodeVersion->getNodeTranslation();
+        $node = $activeNodeTranslation->getNode();
         $queuedNodeTranslationAction = $this->em->getRepository(
             'KunstmaanNodeBundle:QueuedNodeTranslationAction'
-        )->findOneBy(array('nodeTranslation' => $activeNodeTranslation));
+        )->findOneBy(['nodeTranslation' => $activeNodeTranslation]);
 
-        $isFirst    = true;
-        $canEdit    = $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_EDIT, $node);
+        $isFirst = true;
+        $canEdit = $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_EDIT, $node);
         $canPublish = $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_PUBLISH, $node);
 
         if ($activeNodeVersion->isDraft() && $this->isEditableNode) {
             if ($canEdit) {
                 $menu->addChild(
                     'action.saveasdraft',
-                    array(
-                        'linkAttributes' => array(
-                            'type'  => 'submit',
+                    [
+                        'linkAttributes' => [
+                            'type' => 'submit',
                             'class' => 'js-save-btn btn btn--raise-on-hover btn-primary',
                             'value' => 'save',
-                            'name'  => 'save'
-                        ),
-                        'extras'         => array('renderType' => 'button')
-                    )
+                            'name' => 'save'
+                        ],
+                        'extras' => ['renderType' => 'button']
+                    ]
                 );
                 if ($canRecopy) {
                     $menu->addChild(
                         'action.recopyfromlanguage',
-                        array(
-                            'linkAttributes' => array(
+                        [
+                            'linkAttributes' => [
                                 'class' => 'btn btn-default btn--raise-on-hover',
                                 'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
                                 'data-target' => '#recopy'
-                            ),
-                        )
+                            ],
+                        ]
                     );
                 }
                 $isFirst = false;
@@ -195,31 +196,31 @@ class ActionsMenuBuilder
 
             $menu->addChild(
                 'action.preview',
-                array(
-                    'uri'            => $this->router->generate(
+                [
+                    'uri' => $this->router->generate(
                         '_slug_preview',
-                        array(
-                            'url'     => $activeNodeTranslation->getUrl(),
+                        [
+                            'url' => $activeNodeTranslation->getUrl(),
                             'version' => $activeNodeVersion->getId()
-                        )
+                        ]
                     ),
-                    'linkAttributes' => array(
+                    'linkAttributes' => [
                         'target' => '_blank',
-                        'class'  => 'btn btn-default btn--raise-on-hover'
-                    )
-                )
+                        'class' => 'btn btn-default btn--raise-on-hover'
+                    ]
+                ]
             );
 
             if (empty($queuedNodeTranslationAction) && $canPublish) {
                 $menu->addChild(
                     'action.publish',
-                    array(
-                        'linkAttributes' => array(
+                    [
+                        'linkAttributes' => [
                             'data-toggle' => 'modal',
                             'data-target' => '#pub',
-                            'class'       => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default')
-                        )
-                    )
+                            'class' => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default')
+                        ]
+                    ]
                 );
             }
 
@@ -227,15 +228,15 @@ class ActionsMenuBuilder
             if ($canEdit && $canPublish) {
                 $menu->addChild(
                     'action.save',
-                    array(
-                        'linkAttributes' => array(
-                            'type'  => 'submit',
+                    [
+                        'linkAttributes' => [
+                            'type' => 'submit',
                             'class' => 'js-save-btn btn btn--raise-on-hover btn-primary',
                             'value' => 'save',
-                            'name'  => 'save'
-                        ),
-                        'extras'         => array('renderType' => 'button')
-                    )
+                            'name' => 'save'
+                        ],
+                        'extras' => ['renderType' => 'button']
+                    ]
                 );
                 $isFirst = false;
             }
@@ -243,16 +244,16 @@ class ActionsMenuBuilder
             if ($this->isEditableNode) {
                 $menu->addChild(
                     'action.preview',
-                    array(
-                        'uri'            => $this->router->generate(
+                    [
+                        'uri' => $this->router->generate(
                             '_slug_preview',
-                            array('url' => $activeNodeTranslation->getUrl())
+                            ['url' => $activeNodeTranslation->getUrl()]
                         ),
-                        'linkAttributes' => array(
+                        'linkAttributes' => [
                             'target' => '_blank',
-                            'class'  => 'btn btn-default btn--raise-on-hover'
-                        )
-                    )
+                            'class' => 'btn btn-default btn--raise-on-hover'
+                        ]
+                    ]
                 );
 
                 if (empty($queuedNodeTranslationAction)
@@ -264,14 +265,14 @@ class ActionsMenuBuilder
                 ) {
                     $menu->addChild(
                         'action.unpublish',
-                        array(
-                            'linkAttributes' => array(
-                                'class'         => 'btn btn-default btn--raise-on-hover',
-                                'data-toggle'   => 'modal',
+                        [
+                            'linkAttributes' => [
+                                'class' => 'btn btn-default btn--raise-on-hover',
+                                'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target'   => '#unpub'
-                            )
-                        )
+                                'data-target' => '#unpub'
+                            ]
+                        ]
                     );
                 } elseif (empty($queuedNodeTranslationAction)
                     && !$activeNodeTranslation->isOnline()
@@ -279,41 +280,41 @@ class ActionsMenuBuilder
                 ) {
                     $menu->addChild(
                         'action.publish',
-                        array(
-                            'linkAttributes' => array(
-                                'class'         => 'btn btn-default btn--raise-on-hover',
-                                'data-toggle'   => 'modal',
+                        [
+                            'linkAttributes' => [
+                                'class' => 'btn btn-default btn--raise-on-hover',
+                                'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target'   => '#pub'
-                            )
-                        )
+                                'data-target' => '#pub'
+                            ]
+                        ]
                     );
                 }
 
                 if ($canEdit) {
                     $menu->addChild(
                         'action.saveasdraft',
-                        array(
-                            'linkAttributes' => array(
-                                'type'  => 'submit',
+                        [
+                            'linkAttributes' => [
+                                'type' => 'submit',
                                 'class' => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default'),
                                 'value' => 'saveasdraft',
-                                'name'  => 'saveasdraft'
-                            ),
-                            'extras'         => array('renderType' => 'button')
-                        )
+                                'name' => 'saveasdraft'
+                            ],
+                            'extras' => ['renderType' => 'button']
+                        ]
                     );
                     if ($canRecopy) {
                         $menu->addChild(
                             'action.recopyfromlanguage',
-                            array(
-                                'linkAttributes' => array(
+                            [
+                                'linkAttributes' => [
                                     'class' => 'btn btn-default btn--raise-on-hover',
                                     'data-toggle' => 'modal',
                                     'data-keyboard' => 'true',
                                     'data-target' => '#recopy'
-                                ),
-                            )
+                                ],
+                            ]
                         );
                     }
                 }
@@ -326,32 +327,32 @@ class ActionsMenuBuilder
         ) {
             $menu->addChild(
                 'action.addsubpage',
-                array(
-                    'linkAttributes' => array(
-                        'type'          => 'button',
-                        'class'         => 'btn btn-default btn--raise-on-hover',
-                        'data-toggle'   => 'modal',
+                [
+                    'linkAttributes' => [
+                        'type' => 'button',
+                        'class' => 'btn btn-default btn--raise-on-hover',
+                        'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target'   => '#add-subpage-modal'
-                    ),
-                    'extras'         => array('renderType' => 'button')
-                )
+                        'data-target' => '#add-subpage-modal'
+                    ],
+                    'extras' => ['renderType' => 'button']
+                ]
             );
         }
 
         if (null !== $node->getParent() && $canEdit) {
             $menu->addChild(
                 'action.duplicate',
-                array(
-                    'linkAttributes' => array(
-                        'type'          => 'button',
-                        'class'         => 'btn btn-default btn--raise-on-hover',
-                        'data-toggle'   => 'modal',
+                [
+                    'linkAttributes' => [
+                        'type' => 'button',
+                        'class' => 'btn btn-default btn--raise-on-hover',
+                        'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target'   => '#duplicate-page-modal'
-                    ),
-                    'extras'         => array('renderType' => 'button')
-                )
+                        'data-target' => '#duplicate-page-modal'
+                    ],
+                    'extras' => ['renderType' => 'button']
+                ]
             );
         }
 
@@ -363,17 +364,17 @@ class ActionsMenuBuilder
         ) {
             $menu->addChild(
                 'action.delete',
-                array(
-                    'linkAttributes' => array(
-                        'type'          => 'button',
-                        'class'         => 'btn btn-default btn--raise-on-hover',
-                        'onClick'       => 'oldEdited = isEdited; isEdited=false',
-                        'data-toggle'   => 'modal',
+                [
+                    'linkAttributes' => [
+                        'type' => 'button',
+                        'class' => 'btn btn-default btn--raise-on-hover',
+                        'onClick' => 'oldEdited = isEdited; isEdited=false',
+                        'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target'   => '#delete-page-modal'
-                    ),
-                    'extras'         => array('renderType' => 'button')
-                )
+                        'data-target' => '#delete-page-modal'
+                    ],
+                    'extras' => ['renderType' => 'button']
+                ]
             );
         }
 
@@ -416,16 +417,16 @@ class ActionsMenuBuilder
         );
         $menu->addChild(
             'action.addhomepage',
-            array(
-                'linkAttributes' => array(
-                    'type'          => 'button',
-                    'class'         => 'btn btn-default btn--raise-on-hover',
-                    'data-toggle'   => 'modal',
+            [
+                'linkAttributes' => [
+                    'type' => 'button',
+                    'class' => 'btn btn-default btn--raise-on-hover',
+                    'data-toggle' => 'modal',
                     'data-keyboard' => 'true',
-                    'data-target'   => '#add-homepage-modal'
-                ),
-                'extras'         => array('renderType' => 'button')
-            )
+                    'data-target' => '#add-homepage-modal'
+                ],
+                'extras' => ['renderType' => 'button']
+            ]
         );
 
         return $menu;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 1331

#  Using the Cache bundle

## Installation

This bundle is compatible with all Symfony 3.* releases. More information about installing can be found in this line by line walkthrough of installing Symfony and all our bundles, please refer to the [Getting Started guide](http://bundles.kunstmaan.be/getting-started) and enjoy the full blown experience.

## Usage

This bundle allows you to do stuff with caching. For now it's a starting bundle with the possibility
to ban stuff from varnish.

### Configure bundle in config.yml

This bundle works with the fos http cache bundle. Therefore you need to add the following configuration, of course with your own varnish path.
```YAML
fos_http_cache:
    proxy_client:
        varnish:
            servers:
                - 127.0.0.1:6081
    cache_manager:
        enabled: true
    invalidation:
        enabled: true
```

### Add the kunstmaan_cache routing to your routing.yml

```YAML
# KunstmaanCacheBundle
KunstmaanCacheBundle:
    resource: "@KunstmaanCacheBundle/Resources/config/routing.yml"
    prefix:   /{_locale}/
    requirements:
        _locale: "%requiredlocales%"
```
    
### Result

When you browse to "Settings" in the main menu, you will see that there is a new menu item available with the label of "Varnish ban".
There you can add a path that you would like to ban from varnish. When you check the all domains option and you are using a multidomain website,
the path will be banned from all hosts of your multidomain.

**On nodes you have a new menu actions to clear the cache for that node.**


If your varnish configuration does not support purging or banning yet, please take a look at the following configuration:

https://github.com/FriendsOfSymfony/FOSHttpCache/blob/master/doc/varnish-configuration.rst