### PR TITLE
[KunstmaanNodeSearchBundle]: upgrade elastica to 5.1

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,0 +1,14 @@
+# UPGRADE FROM 4.* to 5.0
+
+## Elastica
+
+The ruflin/elastica bundle has been upgraded to the latest 5.1 version.
+This version is compatible with the latest elasticsearch version.
+
+The only change that should be made is when you override the NodeSearcher that comes by default from the bundles:
+
+**The setMinimumNumberShouldMatch function is now replaced by the setMinimumShouldMatch function**
+
+When you have created some extra extensions on elastica you should read the changelog:
+
+https://github.com/ruflin/Elastica/blob/master/CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "twig/extensions": "~1.0",
         "egulias/email-validator": "~1.2",
         "box/spout": "^2.5",
-        "ruflin/elastica": "^3.2"
+        "ruflin/elastica": "^5.1"
     },
     "require-dev": {
         "behat/behat": "3.1.0rc1",

--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -3,6 +3,12 @@
 namespace Kunstmaan\NodeSearchBundle\Search;
 
 use Doctrine\ORM\EntityManager;
+use Elastica\Query;
+use Elastica\Query\BoolQuery;
+use Elastica\Query\Match;
+use Elastica\Query\QueryString;
+use Elastica\Query\Term;
+use Elastica\Util;
 use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\NodeSearchBundle\Helper\SearchBoostInterface;
@@ -76,42 +82,42 @@ class NodeSearcher extends AbstractElasticaSearcher
      */
     public function defineSearch($query, $type)
     {
-        $query = \Elastica\Util::escapeTerm($query);
+        $query = Util::escapeTerm($query);
 
-        $elasticaQueryString = new \Elastica\Query\Match();
+        $elasticaQueryString = new Match();
         $elasticaQueryString
             ->setFieldMinimumShouldMatch('content', '80%')
             ->setFieldQuery('content', $query);
 
         if ($this->useMatchQueryForTitle) {
-            $elasticaQueryTitle = new \Elastica\Query\Match();
+            $elasticaQueryTitle = new Match();
             $elasticaQueryTitle
               ->setFieldQuery('title', $query)
               ->setFieldMinimumShouldMatch('title', '80%');
         } else {
-            $elasticaQueryTitle = new \Elastica\Query\QueryString();
+            $elasticaQueryTitle = new QueryString();
             $elasticaQueryTitle
               ->setDefaultField('title')
               ->setQuery($query);
         }
 
-        $elasticaQueryBool = new \Elastica\Query\BoolQuery();
+        $elasticaQueryBool = new BoolQuery();
         $elasticaQueryBool
             ->addShould($elasticaQueryTitle)
             ->addShould($elasticaQueryString)
-            ->setMinimumNumberShouldMatch(1);
+            ->setMinimumShouldMatch(1);
 
         $this->applySecurityFilter($elasticaQueryBool);
 
         if (!is_null($type)) {
-            $elasticaQueryType = new \Elastica\Query\Term();
+            $elasticaQueryType = new Term();
             $elasticaQueryType->setTerm('type', $type);
             $elasticaQueryBool->addMust($elasticaQueryType);
         }
 
         $rootNode = $this->domainConfiguration->getRootNode();
         if (!is_null($rootNode)) {
-            $elasticaQueryRoot = new \Elastica\Query\Term();
+            $elasticaQueryRoot = new Term();
             $elasticaQueryRoot->setTerm('root_id', $rootNode->getId());
             $elasticaQueryBool->addMust($elasticaQueryRoot);
         }
@@ -145,7 +151,7 @@ class NodeSearcher extends AbstractElasticaSearcher
     {
         $roles = $this->getCurrentUserRoles();
 
-        $elasticaQueryRoles = new \Elastica\Query\Terms();
+        $elasticaQueryRoles = new Query\Terms();
         $elasticaQueryRoles
             ->setTerms('view_roles', $roles);
         $elasticaQueryBool->addMust($elasticaQueryRoles);
@@ -179,7 +185,7 @@ class NodeSearcher extends AbstractElasticaSearcher
      */
     protected function getPageBoosts()
     {
-        $rescoreQueryBool = new \Elastica\Query\BoolQuery();
+        $rescoreQueryBool = new BoolQuery();
 
         //Apply page type boosts
         $pageClasses = $this->em->getRepository('KunstmaanNodeBundle:Node')->findAllDistinctPageClasses();
@@ -187,7 +193,7 @@ class NodeSearcher extends AbstractElasticaSearcher
             $page = new $pageClass['refEntityName']();
 
             if($page instanceof SearchBoostInterface) {
-                $elasticaQueryTypeBoost = new \Elastica\Query\QueryString();
+                $elasticaQueryTypeBoost = new QueryString();
                 $elasticaQueryTypeBoost
                     ->setBoost($page->getSearchBoost())
                     ->setDefaultField('page_class')
@@ -200,7 +206,7 @@ class NodeSearcher extends AbstractElasticaSearcher
         //Apply page specific boosts
         $nodeSearches = $this->em->getRepository('KunstmaanNodeSearchBundle:NodeSearch')->findAll();
         foreach ($nodeSearches as $nodeSearch) {
-            $elasticaQueryNodeId = new \Elastica\Query\QueryString();
+            $elasticaQueryNodeId = new QueryString();
             $elasticaQueryNodeId
                 ->setBoost($nodeSearch->getBoost())
                 ->setDefaultField('node_id')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Fixed tickets |

# UPGRADE FROM 4.* to 5.0

## Elastica

The ruflin/elastica bundle has been upgraded to the latest 5.1 version.
This version is compatible with the latest elasticsearch version.

The only change that should be made is when you override the NodeSearcher that comes by default from the bundles:

**The setMinimumNumberShouldMatch function is now replaced by the setMinimumShouldMatch function**

When you have created some extra extensions on elastica you should read the changelog:

https://github.com/ruflin/Elastica/blob/master/CHANGELOG.md
