### PR TITLE
[AdminListBundle] fix lockable entity denied access upon first edit

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
+++ b/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
@@ -40,9 +40,9 @@ class EntityVersionLockService
     public function isEntityBelowThreshold(LockableEntityInterface $entity)
     {
         /** @var LockableEntity $lockable */
-        $lockable = $this->getLockableEntity($entity);
+        $lockable = $this->getLockableEntity($entity, false);
 
-        if ($this->lockEnabled) {
+        if ($this->lockEnabled && $lockable->getId() !== null) {
             $now = new \DateTime();
             $thresholdDate = clone $lockable->getUpdated();
             $thresholdDate->add(new \DateInterval("PT".$this->threshold."S"));
@@ -154,12 +154,15 @@ class EntityVersionLockService
      *
      * @return LockableEntity
      */
-    protected function getLockableEntity(LockableEntityInterface $entity)
+    protected function getLockableEntity(LockableEntityInterface $entity, $create = true)
     {
         /** @var LockableEntity $lockable */
         $lockable = $this->objectManager->getRepository('KunstmaanAdminListBundle:LockableEntity')->getOrCreate($entity->getId(), get_class($entity));
-        $this->objectManager->persist($lockable);
-        $this->objectManager->flush();
+
+        if ($create === true && $lockable->getId() === null) {
+            $this->objectManager->persist($lockable);
+            $this->objectManager->flush();
+        }
 
         return $lockable;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In the new Lockable Entity feature there is a bug that prevents you to edit upon first install. This is because there is not lock present in the database and during the check it makes a new lock. This results in an access denied because the new lock did not yet expire. The solution is to verify during the expire check if the lock is newly created or not. 
