### PR TITLE
[AdminBundle] Fix MediaTokenTransformer with null values

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
+++ b/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
@@ -17,6 +17,10 @@ class MediaTokenTransformer implements DataTransformerInterface
      */
     public function transform($content)
     {
+        if (!trim($content)) {
+            return '';
+        }
+
         $crawler = new Crawler();
         $crawler->addHtmlContent($content);
 
@@ -41,6 +45,10 @@ class MediaTokenTransformer implements DataTransformerInterface
      */
     public function reverseTransform($content)
     {
+        if (!trim($content)) {
+            return '';
+        }
+
         $crawler = new Crawler();
         $crawler->addHtmlContent($content);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1502

After #1502 the null values are throwing ```InvalidArgumentException``` in ```MediaTokenTransformer```.