### PR TITLE
[AdminListBundle] Use getStringValue for adminlist view template

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/view.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/view.html.twig
@@ -10,13 +10,7 @@
                 {{ key }}
             </td>
             <td>
-                {% if value.timezone is defined %}
-                    {{ value|date() }}
-                {% elseif value.id is defined %}
-                    OBJECT
-                {% else %}
-                    {{ value }}
-                {% endif %}
+                {{ adminlistconfigurator.getStringValue(entity, key) }}
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

Left the code that creates values in the controller so there are no breaking changes.
