### PR TITLE
[AdminBundle] Remove key for ConsoleExceptionListener argument

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -6,6 +6,6 @@ services:
     kunstmaan_admin.consolelogger.listener:
         class: '%kunstmaan_admin.consoleexception.class%'
         arguments:
-            logger: '@logger'
+            - '@logger'
         tags:
             - { name: kernel.event_listener, event: console.exception }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

Needed for Symfony 3.3 compatibility (see https://github.com/symfony/symfony/pull/21383)
