### PR TITLE
[KunstmaanAdminBundle]: reinit modules javascript on nested forms

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
@@ -162,20 +162,8 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
 
         showOrHideActions($form);
 
-        // Init new rich editors
-        kunstmaanbundles.richEditor.init();
-
-        kunstmaanbundles.nestedForm.init();
-        kunstmaanbundles.advancedSelect.init();
-
-        // Init new tooltips
-        kunstmaanbundles.tooltip.init();
-
-        // Init new colorpickers
-        kunstmaanbundles.colorpicker.init();
-
-        // Init new datepickers
-        kunstmaanbundles.datepicker.reInit();
+        // Reinit all modules
+        kunstmaanbundles.pagepartEditor.reInit($newItem);
 
         // Init Ajax Modals
         kunstmaanbundles.ajaxModal.resetAjaxModals();

--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_pagepart-editor.js
@@ -309,7 +309,8 @@ kunstmaanbundles.pagepartEditor = function (window) {
     return {
         init: init,
         subscribeToEvent: subscribeToEvent,
-        unSubscribeToEvent: unSubscribeToEvent
+        unSubscribeToEvent: unSubscribeToEvent,
+        reInit: reInit
     };
 
 }(window);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | |no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When creating nested pagepart forms, not all javascript modules are reinitialised. When you create a form with a text field with 'maxlength', the charactersLeft library is not reinitialised. 

There is already a function in the pagepart-editor.js file that I reused now for this. Now all form items in the nested forms will be checked and reinitialised correctly.
