### PR TITLE
[NodeBundle] fix overwrite of original breadcrumb

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
@@ -109,6 +109,8 @@
         <a href="{{ path(getOverviewRoute(page)) }}" class="btn btn-default" style="margin:20px 0 20px 0;"><i class="fa fa-arrow-left"></i>
             Back to overview
         </a>
+    {% else %}
+        {{ parent() }}
     {%  endif %}
 
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Original breadcrumb got overwritten in `NodeAdmin/edit.html.twig` for the new abstract page adminlist. This fixes layout and original breadcrumb when not in an adminlist.