### PR TITLE
[FixturesBundle] Add provider to get Node by fixture

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Provider/Node.php
+++ b/src/Kunstmaan/FixturesBundle/Provider/Node.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\FixturesBundle\Provider;
+
+use Kunstmaan\FixturesBundle\Loader\Fixture;
+
+class Node
+{
+    /**
+     * @param string $fixtureId
+     * @param array $fixtures
+     *
+     * @return \Kunstmaan\NodeBundle\Entity\Node|null
+     */
+    public function getNode($fixtureId, array $fixtures)
+    {
+        /** strip @ */
+        $fixtureId = substr($fixtureId, 1);
+
+        if (!array_key_exists($fixtureId, $fixtures)) {
+            return null;
+        }
+
+        /** @var Fixture $fixture */
+        $fixture = $fixtures[$fixtureId];
+        $additionalEntities = $fixture->getAdditionalEntities();
+
+        if (array_key_exists('rootNode', $additionalEntities)) {
+            return $additionalEntities['rootNode'];
+        }
+
+        return null;
+    }
+}

--- a/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
@@ -90,3 +90,8 @@ services:
             - '@doctrine.orm.entity_manager'
         tags:
             - { name: kunstmaan_fixtures.provider, alias: NodeTranslation }
+
+    kunstmaan_fixtures.provider.node:
+        class: Kunstmaan\FixturesBundle\Provider\Node
+        tags:
+            - { name: kunstmaan_fixtures.provider, alias: Node }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

Can be used to refer to a node inside a fixture: `node: <getNode(@homepage)>`
