### PR TITLE
[MultiDomainBundle] Add option to disable host override notice

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
@@ -22,6 +22,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('host_override_notice')
+                    ->defaultTrue()
+                ->end()
                 ->arrayNode('hosts')
                     ->isRequired()
                     ->requiresAtLeastOneElement()

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
@@ -23,6 +23,8 @@ class KunstmaanMultiDomainExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('kunstmaan_multi_domain.host_override_notice', $config['host_override_notice']);
+
         $hostConfigurations = $this->getHostConfigurations($config['hosts']);
 
         $container->setParameter(

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -34,21 +34,31 @@ class HostOverrideListener
     protected $adminRouteHelper;
 
     /**
-     * @param Session                      $session
-     * @param TranslatorInterface          $translator
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
+     * HostOverrideListener constructor.
+     *
+     * @param Session $session
+     * @param TranslatorInterface $translator
      * @param DomainConfigurationInterface $domainConfiguration
      * @param AdminRouteHelper $adminRouteHelper
+     * @param bool $enabled
      */
     public function __construct(
         Session $session,
         TranslatorInterface $translator,
         DomainConfigurationInterface $domainConfiguration,
-        AdminRouteHelper $adminRouteHelper
+        AdminRouteHelper $adminRouteHelper,
+        $enabled
     ) {
-        $this->session             = $session;
-        $this->translator          = $translator;
+        $this->session = $session;
+        $this->translator = $translator;
         $this->domainConfiguration = $domainConfiguration;
-        $this->adminRouteHelper    = $adminRouteHelper;
+        $this->adminRouteHelper = $adminRouteHelper;
+        $this->enabled = $enabled;
     }
 
     /**
@@ -56,6 +66,10 @@ class HostOverrideListener
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        if (false === $this->enabled) {
+            return;
+        }
+
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
         }

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -16,7 +16,12 @@ services:
 
     kunstmaan_multi_domain.host_override_listener:
         class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
-        arguments: ['@session', '@translator', '@kunstmaan_admin.domain_configuration', '@kunstmaan_admin.adminroute.helper']
+        arguments:
+            - '@session'
+            - '@translator'
+            - '@kunstmaan_admin.domain_configuration'
+            - '@kunstmaan_admin.adminroute.helper'
+            - '%kunstmaan_multi_domain.host_override_notice%'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | n/a

BC: any class that extends the current HostOverrideListener will need the extra parameter injected.
