### PR TITLE
[KunstmaanPagePartBundle]: check if add pagepart button is the first one

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/add_pagepart.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/add_pagepart.html.twig
@@ -1,12 +1,12 @@
 <div class="pp-container__add">
     {% if extended is defined and extended == true %}
-        <a href="#" class="btn btn-default js-add-pp-select js-add-pp-select--first js-pp-modal-button"
+        <a href="#" class="btn btn-default js-add-pp-select{% if first is defined and first %} js-add-pp-select--first{% endif %} js-pp-modal-button"
            data-toggle="modal" data-target="#pagePartModal{{ pagepartadmin.context }}"
            data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
             {{ 'kuma_pagepart.select.add' | trans }}
         </a>
     {% else %}
-        <select class="js-add-pp-select js-add-pp-select--first form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
+        <select class="js-add-pp-select {% if first is defined and first %}js-add-pp-select--first{% endif %} form-control input-sm pp-container__add__select" data-url="{{ path('KunstmaanPagePartBundle_admin_newpagepart') }}">
             <option value="">{{ 'Add a pagepart' | trans }}</option>
             {% for pagePartType in pagepartadmin.possiblePagePartTypes %}
                 <option value="{{ pagePartType.class }}">{{ pagePartType.name|trans }}</option>

--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/widget.html.twig
@@ -2,7 +2,7 @@
 
     {% if pagepartadmin.possiblePagePartTypes | length > 0 %}
         <!-- First New PP select -->
-        {% include '@KunstmaanPagePart/PagePartAdminTwigExtension/add_pagepart.html.twig' %}
+        {% include '@KunstmaanPagePart/PagePartAdminTwigExtension/add_pagepart.html.twig' with {first: true} %}
     {% endif %}
 
     <!-- Sortable container -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When adding a new pagepart below an existing, it's always added as the first pagepart. In the javascript the classname "js-add-pp-select--first" will be checked.
