### PR TITLE
[KunstmaanAdminListBundle]: always get latest overviewpage

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractPageAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractPageAdminListConfigurator.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminListBundle\AdminList\Configurator;
 
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Kunstmaan\AdminBundle\Entity\EntityInterface;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\BooleanFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\DateTimeFilterType;
@@ -161,13 +162,16 @@ abstract class AbstractPageAdminListConfigurator extends AbstractDoctrineDBALAdm
      */
     public function getOverviewPage()
     {
+        /** @var EntityRepository $repository */
         $repository = $this->em->getRepository($this->getOverviewPageClass());
-        $pages = $repository->findAll();
-        if (isset($pages) and count($pages) > 0) {
-            return $pages[0];
-        }
 
-        return null;
+        $overviewPage = $repository->createQueryBuilder('o')
+            ->orderBy('o.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $overviewPage;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Always get the latest overviewpage. Otherwise children will not be added to the right parent.
