### PR TITLE
[KunstmaanAdminListBundle]: add new event subscriber

### DIFF
--- a/src/Kunstmaan/AdminListBundle/EventSubscriber/AdminListSubscriber.php
+++ b/src/Kunstmaan/AdminListBundle/EventSubscriber/AdminListSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\EventSubscriber;
+
+use Kunstmaan\AdminListBundle\Entity\OverviewNavigationInterface;
+use Kunstmaan\NodeBundle\Event\Events;
+use Kunstmaan\NodeBundle\Event\NodeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Class AdminListSubscriber.
+ */
+class AdminListSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * ArticleSubscriber constructor.
+     *
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::POST_DELETE => 'postDelete',
+        ];
+    }
+
+    /**
+     * @param NodeEvent $event
+     */
+    public function postDelete(NodeEvent $event)
+    {
+        $page = $event->getPage();
+
+        // Redirect to admin list when deleting a page that implements the OverviewNavigationInterface.
+        if ($page instanceof OverviewNavigationInterface) {
+            $route = $this->router->generate($page->getOverViewRoute());
+            $response = new RedirectResponse($route);
+
+            $event->setResponse($response);
+        }
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -24,3 +24,10 @@ services:
             -  '@doctrine.orm.entity_manager'
             -  '%kunstmaan_entity.lock_threshold%'
             -  '%kunstmaan_entity.lock_enabled%'
+
+    kunstmaan_adminlist.subscriber.adminlist:
+        class: Kunstmaan\AdminListBundle\EventSubscriber\AdminListSubscriber
+        arguments:
+            - "@router"
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When using the new AbstractPageAdminList and implementing the OverviewNavigationInterface, it would be good if you get redirected to the overview page when deleting a node. 
