### PR TITLE
Update _input-range-slider.js

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_input-range-slider.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_input-range-slider.js
@@ -16,7 +16,7 @@ kunstmaanbundles.rangeslider = (function(window, undefined) {
     //Initialize
     initRangePercentage = function($el) {
 
-        $('.range--value')
+        $el.find('.range--value')
             .text($el.val());
     };
 


### PR DESCRIPTION
Currently initRangePercentage sets all range fields on the page.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none that I could find
