### PR TITLE
[UI] Added buildGroundControlSkeleton task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 *~
 *test.db
 .vscode
+src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ before_install:
   - composer selfupdate
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   - wget https://scrutinizer-ci.com/ocular.phar
+  - nvm install
+  - npm install
+  - gem install bundler
+  - bundle install --gemfile=./src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/gems/Gemfile
 
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
@@ -30,7 +34,10 @@ before_script:
 
 script: ./vendor/bin/phpunit --coverage-clover=coverage.clover
 
-after_script: php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+after_script:
+    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+    - npm run build -- --continueAfterTestError=true
+    - npm run buildGroundControlSkeleton
 
 notifications:
   email:

--- a/groundcontrol/admin-bundle.tasks.js
+++ b/groundcontrol/admin-bundle.tasks.js
@@ -35,23 +35,6 @@ adminBundle.tasks.cssLocal = createCssLocalTask({src: adminBundle.config.srcPath
 
 adminBundle.tasks.cssOptimized = createCssOptimizedTask({src: adminBundle.config.srcPath + 'scss/*.scss', dest: adminBundle.config.distPath + 'css'});
 
-adminBundle.tasks.server = createServerTask({
-    config: {
-        ui: false,
-        ghostMode: false,
-        files: [
-            './src/Kunstmaan/*Bundle/Resources/public/css/*.css',
-            './src/Kunstmaan/*Bundle/Resources/public/js/*.js'
-        ],
-        open: false,
-        reloadOnRestart: true,
-        proxy: {
-            target: 'http://myproject.dev'
-        },
-        notify: true
-    }
-});
-
 adminBundle.tasks.scripts = createScriptsTask({
     src: [
         adminBundle.config.srcPath + 'vendor_bower/jquery/dist/jquery.js',

--- a/groundcontrol/gulp-plugins/twig.js
+++ b/groundcontrol/gulp-plugins/twig.js
@@ -1,0 +1,37 @@
+import through from 'through2';
+import gutil from 'gulp-util';
+import Twig from 'twig';
+
+export default function twig(options) {
+
+    return through.obj(function (file, enc, cb) {
+        if (file.isNull()) {
+            cb(null, file);
+            return;
+        }
+
+        if (file.isStream()) {
+            cb(new gutil.PluginError('twig', 'Streaming not supported'));
+            return;
+        }
+
+        try {
+            let contents = file.contents.toString();
+
+            // Twig.js uses different escaping compared to the PHP version
+            // This line was failing the renderering, as we don't put backlashes in the testdata it could be removed
+            contents = contents.replace(/\|replace\(\{\'\\\\\'\:\'\/\'\}\)/gmi, '');
+            
+            const template = Twig.twig({
+                data: contents
+            });
+            const result = template.render(options);
+            file.contents = new Buffer(result);
+
+            cb(null, file);
+        } catch (e) {
+            cb(e.message);
+        }
+    });
+
+};

--- a/groundcontrol/tasks/build-gc-skeleton.js
+++ b/groundcontrol/tasks/build-gc-skeleton.js
@@ -1,0 +1,93 @@
+import gulp from 'gulp';
+import del from 'del';
+import fs from 'fs-extra';
+import { spawn } from 'child_process';
+import twig from '../gulp-plugins/twig';
+
+const runChildProcess = (executable, args, cwd, cb) => {
+    const ls = spawn(executable, args, { cwd });
+
+    ls.stdout.on('data', (data) => {
+        console.log(`${data}`);
+    });
+
+    ls.stderr.on('data', (data) => {
+        console.log(`err: ${data}`);
+    });
+
+    ls.on('close', (code) => {
+        cb(code !== 0 ? new Error('Execution failed.') : undefined);
+    });
+};
+
+export default function createBuildGroundControlSkeletonTask(skeletonPath, namespace = 'kuma/my-project') {
+    const distPath = skeletonPath + '/dist';
+    const appPath = distPath + '/src/' + namespace;
+    const jsPath = appPath + '/Resources/ui/js';
+    const scssPath = appPath + '/Resources/ui/scss';
+    const adminJsPath = appPath + '/Resources/admin/js';
+
+    return [
+        function cleanGroundControlSkeleton() {
+            return del([
+                distPath + '/**/*',
+                '!' + distPath + '/node_modules',
+                '!' + distPath + '/node_modules/**'
+            ]);
+        },
+        function renderGroundControlSkeleton() {
+            return gulp.src([skeletonPath + '/**/*', `!${distPath}`, `!${distPath}/**/*`], { dot: true })
+                .pipe(twig({
+                    bundle: {
+                        getName: () => 'test-bundle',
+                        namespace
+                    },
+                    demosite: false
+                }))
+                .pipe(gulp.dest(distPath));
+        },
+        function renameGroundControlSkeletonBinDir(cb) {
+            fs.move(distPath + '/bin', distPath + '/groundcontrol', cb);
+        },
+        function addGroundControlSkeletonExampleFiles(cb) {
+            fs.ensureDirSync(jsPath);
+            fs.writeFileSync(jsPath + '/app.js', 'console.log(\'Hello world\');\n');
+            fs.ensureDirSync(adminJsPath);
+            fs.writeFileSync(adminJsPath + '/admin-bundle-extra.js', 'console.log(\'Hello world from admin\');\n');
+            fs.ensureDirSync(scssPath);
+            fs.writeFileSync(scssPath + '/style.scss', 'body { font-size: 20px; }\n');
+            // Style guide
+            fs.copySync(skeletonPath + '/../gems/Gemfile', distPath + '/Gemfile');
+            fs.copySync(skeletonPath + '/../Resources/ui/styleguide', appPath + '/Resources/ui/styleguide');
+            // Index.html
+            const html = `
+                <!DOCTYPE html>
+                <html>
+
+                <head>
+                    <title>Test page</title>
+
+                    <meta charset="utf-8">
+                    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <link rel="stylesheet" href="web/frontend/css/style.css"/>
+                </head>
+
+                <body>
+                    <h1>Test page</h1>
+                    <script src="web/frontend/js/bundle.js"></script>
+                    <script src="web/frontend/js/admin-bundle-extra.js"></script>
+                </body>
+
+                </html>`;
+
+            fs.writeFile(distPath + '/index.html', html, cb);
+        },
+        function installGroundControlSkeletonNpmPackages(cb) {
+            runChildProcess('npm', ['install'], distPath, cb);
+        },
+        function builGroundControlSkeletonExample(cb) {
+            runChildProcess('npm', ['run', 'build'], distPath, cb);
+        }
+    ];
+};

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,6 +6,8 @@ import { dashboardBundle } from './groundcontrol/dashboard-bundle.tasks';
 import { mediaBundle } from './groundcontrol/media-bundle.tasks';
 import { translatorBundle } from './groundcontrol/translator-bundle.tasks';
 import startLocalTask, { buildOnChange } from './groundcontrol/start-local.task';
+import createBuildGroundControlSkeletonTask from './groundcontrol/tasks/build-gc-skeleton';
+
 
 // AdminBundle Tasks
 const analyzeAdminBundle = gulp.series(
@@ -109,5 +111,8 @@ const startLocal = gulp.series(
     buildOnChange
 );
 
+// Development sepcific tasks
+const buildGroundControlSkeleton = gulp.series(createBuildGroundControlSkeletonTask('./src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol'));
+
 // Export public tasks
-export { test, buildOptimized, testAndBuildOptimized, startLocal };
+export { test, buildOptimized, testAndBuildOptimized, startLocal, buildGroundControlSkeleton };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "startOptimized": "gulp startOptimized",
     "test": "gulp test",
     "build": "gulp buildOptimized",
-    "testAndBuild": "gulp testAndBuildOptimized"
+    "testAndBuild": "gulp testAndBuildOptimized",
+    "buildGroundControlSkeleton": "gulp buildGroundControlSkeleton"
   },
   "author": "Kunstmaan",
   "license": "ISC",
@@ -20,9 +21,11 @@
     "browser-sync": "^2.18.8",
     "chalk": "^1.1.3",
     "cssnano": "^3.10.0",
+    "del": "^3.0.0",
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0",
     "exports-loader": "^0.6.4",
+    "fs-extra": "^4.0.0",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-cached": "^1.1.1",
@@ -42,6 +45,7 @@
     "stylelint": "^7.9.0",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-order": "^0.3.0",
+    "twig": "^1.10.5",
     "webpack": "^2.2.1",
     "yargs": "^7.0.2"
   },

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/configured-tasks.js
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/configured-tasks.js
@@ -186,6 +186,10 @@ export const server = createServerTask({
         proxy: {
             target: '{{ browserSyncUrl }}'
         },
+{% else %}
+        server: {
+            baseDir: '.'
+        },
 {% endif %}
         notify: true
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

In some file in groundcontrol twig syntax is used, this makes it very hard to test this. I've added a new task to parse the groundcontrol files and turn it into a rendered template using dummy values. This makes it a lot easier to build and test groundcontrol. No need to run `kuma:generate:bundle` anymore :-)

Added a new task which allows you to generate a processed ground control skeleton.

Under the hood uses "twig.js" for processing the twig templates.

Run `npm run generateGcExample` to generate the example.
To run the generated example itself go to `KunstmaanBundlesCMS/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/dist` and run `npm start`
