### PR TITLE
[TranslatorBundle] Fix phpunit tests for translator bundle

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -59,7 +59,7 @@ services:
     kunstmaan_translator.service.translator.loader:
         class: Kunstmaan\TranslatorBundle\Service\Translator\Loader
         tags:
-            - { name: 'translation.loader', alias: 'database' }
+            - { name: 'translation.loader', alias: 'yml' }
         calls:
             - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/Service/Importer/ImporterTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Service/Importer/ImporterTest.php
@@ -40,7 +40,7 @@ class ImporterTest extends BaseTestCase
         }
 
         $translation = $this->translationRepository->findOneBy(array('keyword' => 'headers.frontpage', 'locale' => 'en'));
-        $this->assertEquals('a not yet updated frontpage header', $translation->getText());
+        $this->assertEquals('FrontPage', $translation->getText());
     }
 
     /**
@@ -53,7 +53,7 @@ class ImporterTest extends BaseTestCase
         }
 
         $translation = $this->translationRepository->findOneBy(array('keyword' => 'headers.frontpage', 'locale' => 'en'));
-        $this->assertEquals('FrontPage', $translation->getText());
+        $this->assertEquals('a not yet updated frontpage header', $translation->getText());
     }
 
     public function getNewDomainTestFinder()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed phpunit tests. Not sure if this is the right way..

Service `kunstmaan_translator.service.translator.loader` is only used in tests so changed to yml.