### PR TITLE
[RedirectBundle] Prevent redirect loop with trailing slash

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -119,7 +119,7 @@ class RedirectRouter implements RouterInterface
             if ($redirect->getDomain() == $domain || !$redirect->getDomain()) {
                 $this->routeCollection->add(
                     '_redirect_route_' . $redirect->getId(),
-                    new Route($redirect->getOrigin(), array(
+                    new Route(rtrim($redirect->getOrigin(), '/'), array(
                         '_controller' => 'FrameworkBundle:Redirect:urlRedirect',
                         'path' => $redirect->getTarget(),
                         'permanent' => $redirect->isPermanent(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When removing trailing slash (https://symfony.com/doc/current/routing/redirect_trailing_slash.html) and a customer fills in an url with a trailing slash you will get a redirect loop.