### PR TITLE
[MenuBundle] Fix adminlist to use FQCN instead of object for form type

### DIFF
--- a/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
@@ -40,7 +40,7 @@ class MenuItemAdminListController extends AdminListController
 
             $adminType = $this->getParameter('kunstmaan_menu.form.menuitem_admintype.class');
             $menuItemClass = $this->getParameter('kunstmaan_menu.entity.menuitem.class');
-            $this->configurator->setAdminType(new $adminType($request->getLocale(), $menu, $entityId, $rootNode, $menuItemClass));
+            $this->configurator->setAdminType($adminType);
             $this->configurator->setAdminTypeOptions(array('menu' => $menu, 'rootNode' => $rootNode, 'menuItemClass' => $menuItemClass, 'entityId' => $entityId, 'locale' => $request->getLocale()));
         }
 

--- a/src/Kunstmaan/MenuBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MenuBundle/DependencyInjection/Configuration.php
@@ -26,13 +26,13 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(array())
                     ->prototype('scalar')->end()
                 ->end()
-		->scalarNode('menu_entity')->defaultValue('Kunstmaan\MenuBundle\Entity\Menu')->end()
-		->scalarNode('menuitem_entity')->defaultValue('Kunstmaan\MenuBundle\Entity\MenuItem')->end()
-		->scalarNode('menu_adminlist')->defaultValue('Kunstmaan\MenuBundle\AdminList\MenuAdminListConfigurator')->end()
-		->scalarNode('menuitem_adminlist')->defaultValue('Kunstmaan\MenuBundle\AdminList\MenuItemAdminListConfigurator')->end()
-		->scalarNode('menu_form')->defaultValue('Kunstmaan\MenuBundle\Form\MenuAdminType')->end()
-		->scalarNode('menuitem_form')->defaultValue('Kunstmaan\MenuBundle\Form\MenuItemAdminType')->end()
-	    ->end();
+                ->scalarNode('menu_entity')->defaultValue('Kunstmaan\MenuBundle\Entity\Menu')->end()
+                ->scalarNode('menuitem_entity')->defaultValue('Kunstmaan\MenuBundle\Entity\MenuItem')->end()
+                ->scalarNode('menu_adminlist')->defaultValue('Kunstmaan\MenuBundle\AdminList\MenuAdminListConfigurator')->end()
+                ->scalarNode('menuitem_adminlist')->defaultValue('Kunstmaan\MenuBundle\AdminList\MenuItemAdminListConfigurator')->end()
+                ->scalarNode('menu_form')->defaultValue('Kunstmaan\MenuBundle\Form\MenuAdminType')->end()
+                ->scalarNode('menuitem_form')->defaultValue('Kunstmaan\MenuBundle\Form\MenuItemAdminType')->end()
+            ->end();
 
         return $treeBuilder;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
