### PR TITLE
[TranslatorBundle] revert fix #1562 with new solution

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -59,7 +59,7 @@ services:
     kunstmaan_translator.service.translator.loader:
         class: Kunstmaan\TranslatorBundle\Service\Translator\Loader
         tags:
-            - { name: 'translation.loader', alias: 'yml' }
+            - { name: 'translation.loader', alias: 'database' }
         calls:
             - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/Service/Importer/ImporterTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Service/Importer/ImporterTest.php
@@ -40,7 +40,7 @@ class ImporterTest extends BaseTestCase
         }
 
         $translation = $this->translationRepository->findOneBy(array('keyword' => 'headers.frontpage', 'locale' => 'en'));
-        $this->assertEquals('FrontPage', $translation->getText());
+        $this->assertEquals('a not yet updated frontpage header', $translation->getText());
     }
 
     /**
@@ -53,7 +53,7 @@ class ImporterTest extends BaseTestCase
         }
 
         $translation = $this->translationRepository->findOneBy(array('keyword' => 'headers.frontpage', 'locale' => 'en'));
-        $this->assertEquals('a not yet updated frontpage header', $translation->getText());
+        $this->assertEquals('FrontPage', $translation->getText());
     }
 
     public function getNewDomainTestFinder()

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
@@ -13,6 +13,12 @@ framework:
     session:         ~
     fragments:       ~
 
+services:
+    translation.loader.yml:
+        class: Symfony\Component\Translation\Loader\YamlFileLoader
+        tags:
+            - { name: translation.loader, alias: yml }
+
 kunstmaan_translator:
     managed_locales: ['nl','en','de']
     cache_dir: "%kernel.cache_dir%/translations"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Fix #1562 broke the translator bundle so instead of changing the service to yml, we added the default yml definition to the test app.
