### PR TITLE
[Docs] Fixed typo in documentation 06-04-config-bundle.md

### DIFF
--- a/docs/06-04-config-bundle.md
+++ b/docs/06-04-config-bundle.md
@@ -23,7 +23,7 @@ By extending this class you will have to implement some methods from the Configu
     /**
     * This function is optional. Implement it if you would like a other ROLE to access the configuration section.
     **/
-    public function getAccessRoles()
+    public function getRoles()
     {
         return array('ROLE_ADMIN');
     }


### PR DESCRIPTION
getAccessRoles should be getRoles