### PR TITLE
[KunstmaanAdminBundle]: fix nested forms

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/js/_nested-form.js
@@ -130,25 +130,33 @@ kunstmaanbundles.nestedForm = (function(window, undefined) {
     // Add new item
     addNewItem = function($form) {
         var prototype = $form.data('prototype'),
+            prototypeName = $form.data('prototype-name'),
             currentIndex = $form.data('index'),
             sortable = $form.data('sortable'),
             $newItem;
 
         // Update prototype with new index
-        var nestedLevelProtoName = prototype.match(/__[a-z]+__/g)[0];
+        var regex = new RegExp(prototypeName + '___[a-z]+__', 'g');
+        var nestedLevelProtoName = prototype.match(regex)[0];
         var regExpName = new RegExp(nestedLevelProtoName, 'g');
-        prototype = prototype.replace(regExpName, currentIndex);
+        prototype = prototype.replace(regExpName, prototypeName + '_' + currentIndex);
 
         // Increase the index with one for the next item
         $form.data('index', currentIndex + 1);
 
         // Make item template
-        if(sortable) {
-            var sortKey = $form.data('sortkey').replace(regExpName, currentIndex);
+        if (sortable) {
+            var sortKey = $form.data('sortkey').replace(regExpName, prototypeName + '_' + currentIndex);
             $newItem = $('<div class="js-nested-form__item nested-form__item js-sortable-item sortable-item" data-sortkey="' + sortKey + '"><header class="js-sortable-item__handle nested-form__item__header"><i class="fa fa-arrows nested-form__item__header__move-icon"></i><div class="js-nested-form__item__header__actions nested-form__item__header__actions"></div></header><div class="js-nested-form__item__view nested-form__item__view"></div></div>');
         } else {
             $newItem = $('<div class="js-nested-form__item nested-form__item"><header class="nested-form__item__header"><div class="js-nested-form__item__header__actions nested-form__item__header__actions"></div></header><div class="js-nested-form__item__view nested-form__item__view"></div></div>');
         }
+
+        // Update prototype again.
+        regex = new RegExp('\\[' + prototypeName + '\\]\\[__[a-z]+__\\]', 'g');
+        nestedLevelProtoName = prototype.match(regex)[0].replace(new RegExp('\\[', 'g'), '\\[').replace(new RegExp('\\]', 'g'), '\\]');
+        regExpName = new RegExp(nestedLevelProtoName, 'g');
+        prototype = prototype.replace(regExpName, '[' + prototypeName + '][' + currentIndex + ']');
 
         $newItem.find('.js-nested-form__item__view').append(prototype);
 

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -176,6 +176,7 @@
                 {% if sortable %} data-sortkey="{{ form.vars.id }}___name___{{ sortableField }}"{% endif %}
                 {% if form.vars.allow_add %}
                     data-prototype="{{ form_widget(form.vars.prototype)|e }}"
+                    data-prototype-name="{{ form.vars.name }}"
                     data-add-button-label="{{ attr['nested_add_button_label']|default('form.add')|trans }}"
                 {% endif %}
                 data-initialized="false" data-initializing="false" data-reinit-js='["nestedForm"]'>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When having a collection form type inside another collection type with the "Add new" button it will not work because the replace of the prototype for the nested collection is already done in the replace of the parent prototype so you will get a javascript error.

Solution is to only change the parts of the current collection.

**If someone has a better solution for this, or a nicer way, please say so ;)**

@Devolicious is it also a BC-break by introducing the data-prototype-name here ?