### PR TITLE
[NodeSearchBundle] fixes for elasticsearch 5.0

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
         $properties = $rootNode->children()->arrayNode('mapping')->useAttributeAsKey('name')->prototype('array');
 
         $properties->children()->scalarNode('type')->beforeNormalization()->ifNotInArray($types = [
-            'string', 'token_count',
+            'string', 'token_count', 'text',
             'float', 'double', 'byte', 'short', 'integer', 'long',
             'date',
             'boolean',

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -72,7 +72,6 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
                 ],
                 'title' => [
                     'type' => 'string',
-                    'boost' => 2,
                     'include_in_all' => true
                 ],
                 'slug' => [

--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -93,7 +93,9 @@ class NodeSearcher extends AbstractElasticaSearcher
             $elasticaQueryTitle = new Match();
             $elasticaQueryTitle
               ->setFieldQuery('title', $query)
-              ->setFieldMinimumShouldMatch('title', '80%');
+              ->setFieldMinimumShouldMatch('title', '80%')
+              ->setFieldBoost(2);
+
         } else {
             $elasticaQueryTitle = new QueryString();
             $elasticaQueryTitle


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Elasticsearch does not use string anymore so we need to allow the new `text` type. Also the boost is not allowed anymore at mapping level but instead needs to be done at query time. This is recommended by elasticsearch because it's more flexible.