### PR TITLE
Change FosUserBundle to stable branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
 
-        "friendsofsymfony/user-bundle": "2.0.0-beta1",
+        "friendsofsymfony/user-bundle": "~2.0",
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",


### PR DESCRIPTION
Is there any reason why we cannot depend on FOS UserBundle 2.0 stable?

| Q             | A
| ------------- | ---
| Bug fix?      | yes|no
| New feature?  | yes|no
| BC breaks?    | yes|no
| Deprecations? | yes|no
| Fixed tickets | comma separated list of tickets fixed by the PR
