### PR TITLE
[GeneratorBundle] Article generator fix

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -114,16 +114,19 @@ EOT
             // Generate a blog
             $command = $this->getApplication()->find('kuma:generate:article');
             $arguments = array(
-                'command'      => 'kuma:generate:article',
-                '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
-                '--prefix'     => $this->prefix,
-                '--entity'     => 'Blog',
-                '--dummydata'  => true,
-                '--quiet'      => true
+                'command'           => 'kuma:generate:article',
+                '--namespace'       => str_replace('\\', '/', $this->bundle->getNamespace()),
+                '--prefix'          => $this->prefix,
+                '--entity'          => 'Blog',
+                '--with-author'     => true,
+                '--with-category'   => true,
+                '--with-tag'        => true,
+                '--dummydata'       => true,
             );
-            $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_QUIET);
+            $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL);
             $input = new ArrayInput($arguments);
             $command->run($input, $output);
+
             $this->assistant->writeLine('Generating blog : <info>OK</info>');
         }
 

--- a/src/Kunstmaan/GeneratorBundle/Generator/ArticleGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/ArticleGenerator.php
@@ -121,15 +121,15 @@ class ArticleGenerator extends KunstmaanGenerator
 
         if ($parameters['uses_author']) {
             $twigParameters['type'] = 'Author';
-            $partial .= $this->render('/menuAdaptorPartial.php.twig', $twigParameters);
+            $partial .= $this->render('/MenuAdaptorPartial.php.twig', $twigParameters);
         }
         if ($parameters['uses_category']) {
             $twigParameters['type'] = 'Category';
-            $partial .= $this->render('/menuAdaptorPartial.php.twig', $twigParameters);
+            $partial .= $this->render('/MenuAdaptorPartial.php.twig', $twigParameters);
         }
         if ($parameters['uses_tag']) {
             $twigParameters['type'] = 'Tag';
-            $partial .= $this->render('/menuAdaptorPartial.php.twig', $twigParameters);
+            $partial .= $this->render('/MenuAdaptorPartial.php.twig', $twigParameters);
         }
         GeneratorUtils::replace('//%menuAdaptorPartial.php.twig%', $partial, $dirPath . '/' . $this->entity . $filename);
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
@@ -19,7 +19,7 @@ class {{ entity_class }}CategoryAdminListConfigurator extends AbstractArticleCat
     public function __construct(EntityManagerInterface $em, AclHelper $aclHelper)
     {
         parent::__construct($em, $aclHelper);
-        $this->setAdminType(new {{ entity_class }}CategoryAdminType());
+        $this->setAdminType({{ entity_class }}CategoryAdminType::class);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
@@ -18,7 +18,7 @@ class {{ entity_class }}TagAdminListConfigurator extends AbstractArticleTagAdmin
     public function __construct(EntityManagerInterface $em, AclHelper $aclHelper)
     {
         parent::__construct($em, $aclHelper);
-        $this->setAdminType(new {{ entity_class }}TagAdminType());
+        $this->setAdminType({{ entity_class }}TagAdminType::class);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

1. We can't create new article because path to _MenuAdaptorPartial_ is incorrect.
2. We can't using _--demosite_ param in _kuma:generate:article_ because param _--namespacehomepage_ in article command generator can't be null. Quiet verbose mode don't gave a choice so task never ending.
3. Bad FQCN in _AdminListConfigurator_