### PR TITLE
[AdminBundle] Fix the extended ppchooser search for IE11

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/jsnext/PagePartChooser.js
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/jsnext/PagePartChooser.js
@@ -44,7 +44,7 @@ const initSearch = (ppChooser) => {
     });
 
     const searchField = ppChooser.querySelector(SELECTORS.PP_SEARCH_FIELD);
-    ppList = ppChooser.querySelectorAll(SELECTORS.PP_SEARCH_ITEM);
+    ppList = Array.prototype.slice.call(ppChooser.querySelectorAll(SELECTORS.PP_SEARCH_ITEM));
 
     const fuse = new Fuse(ppTypes, {
         keys: [{


### PR DESCRIPTION
Searching for pageparts was broken in IE11

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
