### PR TITLE
[Toolbar]: return empty array when no data can be collected

### DIFF
--- a/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
@@ -46,7 +46,7 @@ class BundleVersionDataCollector extends AbstractDataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         if (!$this->isEnabled()) {
-            $this->data = false;
+            $this->data = [];
         } else {
             $this->data = $this->collectData();
         }

--- a/src/Kunstmaan/NodeBundle/Toolbar/NodeDataCollector.php
+++ b/src/Kunstmaan/NodeBundle/Toolbar/NodeDataCollector.php
@@ -60,7 +60,7 @@ class NodeDataCollector extends AbstractDataCollector
             return ['data' => $data];
         }
 
-        return null;
+        return [];
     }
 
     /**


### PR DESCRIPTION
This is needed for the ToolbarTwigExtension to work.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
