### PR TITLE
[AdminBundle] Fix docblock so child entities fluent setters wont break

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/AbstractEntity.php
+++ b/src/Kunstmaan/AdminBundle/Entity/AbstractEntity.php
@@ -31,7 +31,7 @@ abstract class AbstractEntity implements EntityInterface
      *
      * @param int $id The unique identifier
      *
-     * @return AbstractEntity
+     * @return $this
      */
     public function setId($id)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/Kunstmaan/KunstmaanBundlesCMS/issues/1609
