### PR TITLE
[NodeSearchBundle][SearchBundle] Multi domain/language search population fix

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -126,6 +126,26 @@ class NodePagesConfiguration implements SearchConfigurationInterface
     }
 
     /**
+     * @param $locale
+     * @return array
+     */
+    public function checkAnalyzerLanguages()
+    {
+        $errors = [];
+        foreach ($this->locales as $locale) {
+            if (preg_match('/[a-z]{2}_?+[a-zA-Z]{2}/', $locale)) {
+                $locale = strtolower($locale);
+            }
+
+            if ( false === array_key_exists($locale, $this->analyzerLanguages) ) {
+                $errors[] = $locale;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
      * Create node index
      */
     public function createIndex()
@@ -137,7 +157,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
 
         foreach ($this->locales as $locale) {
             // Multilanguage check
-            if (count(preg_grep('/[a-z]{2}_?+[a-zA-Z]{2}/', [$locale])) > 0) {
+            if (preg_match('/[a-z]{2}_?+[a-zA-Z]{2}/', $locale)) {
                 $locale = strtolower($locale);
             }
 
@@ -151,7 +171,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
                 // Create index with analysis
                 $this->setAnalysis($index, $localeAnalysis->setupLanguage($language));
             } else {
-                $index->create([]);
+                $index->create();
             }
 
             $this->setMapping($index, $locale);

--- a/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
@@ -46,7 +46,7 @@ class SetupIndexCommand extends ContainerAwareCommand
                     ['No', 'Yes']
                 );
                 $question->setErrorMessage('Answer %s is invalid.');
-                if ( $helper->ask($input, $output, $question) === 'no' ) {
+                if ( $helper->ask($input, $output, $question) === 'No' ) {
                     return;
                 }
             }

--- a/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
@@ -45,7 +45,7 @@ class SetupIndexCommand extends ContainerAwareCommand
                     ),
                     ['No', 'Yes']
                 );
-                $question->setErrorMessage('Answear %s is invalid.');
+                $question->setErrorMessage('Answer %s is invalid.');
                 if ( $helper->ask($input, $output, $question) === 'no' ) {
                     return;
                 }

--- a/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
@@ -6,6 +6,7 @@ use Kunstmaan\SearchBundle\Configuration\SearchConfigurationInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * Command to create the indexes
@@ -29,12 +30,27 @@ class SetupIndexCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $helper = $this->getHelper('question');
         $searchConfigurationChain = $this->getContainer()->get('kunstmaan_search.search_configuration_chain');
         /**
          * @var string                       $alias
          * @var SearchConfigurationInterface $searchConfiguration
          */
         foreach ($searchConfigurationChain->getConfigurations() as $alias => $searchConfiguration) {
+
+            if (count($searchConfiguration->checkAnalyzerLanguages()) > 0) {
+                $question = new ChoiceQuestion(
+                    sprintf('Languages analyzer is not available for: %s. Do you want continue?',
+                        implode(', ', $searchConfiguration->checkAnalyzerLanguages())
+                    ),
+                    ['No', 'Yes']
+                );
+                $question->setErrorMessage('Answear %s is invalid.');
+                if ( $helper->ask($input, $output, $question) === 'no' ) {
+                    return;
+                }
+            }
+
             $searchConfiguration->createIndex();
             $output->writeln('Index created : ' . $alias);
         }

--- a/src/Kunstmaan/SearchBundle/Search/Search.php
+++ b/src/Kunstmaan/SearchBundle/Search/Search.php
@@ -77,6 +77,8 @@ class Search implements SearchProviderInterface
      */
     public function createDocument($uid, $document, $indexName = '', $indexType = '')
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->createDocument(
             $uid,
             $document,
@@ -90,6 +92,8 @@ class Search implements SearchProviderInterface
      */
     public function addDocument($uid, $document, $indexType, $indexName)
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->addDocument(
             $this->indexNamePrefix . $indexName,
             $indexType,
@@ -103,6 +107,8 @@ class Search implements SearchProviderInterface
      */
     public function addDocuments($documents, $indexName = '', $indexType = '')
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->addDocuments($documents, $indexName, $indexType);
     }
 
@@ -111,6 +117,8 @@ class Search implements SearchProviderInterface
      */
     public function deleteDocument($indexName, $indexType, $uid)
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->deleteDocument($this->indexNamePrefix . $indexName, $indexType, $uid);
     }
 
@@ -119,6 +127,8 @@ class Search implements SearchProviderInterface
      */
     public function deleteDocuments($indexName, $indexType, array $ids)
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->deleteDocuments($this->indexNamePrefix . $indexName, $indexType, $ids);
     }
 
@@ -127,6 +137,8 @@ class Search implements SearchProviderInterface
      */
     public function deleteIndex($indexName)
     {
+        $indexName = strtolower($indexName);
+
         return $this->getActiveProvider()->deleteIndex($this->indexNamePrefix . $indexName);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1246

Now we can use language names like "en", "en_US", "en_us", also fixes error mentioned in #1246 ticket.

--edited by numkil
Also with new feature to check for unavailable language analyzers and prompt the user.