### PR TITLE
[KunstmaanGeneratorBundle]: add default values while generating page

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/KunstmaanGenerateCommand.php
@@ -521,6 +521,10 @@ abstract class KunstmaanGenerateCommand extends GenerateDoctrineCommand
                     'type' => $typeStrings [$typeId],
                     'extra' => $extra,
                     'mimeTypes' => $mimeTypes,
+                    'minHeight' => null,
+                    'maxHeight' => null,
+                    'minWidth' => null,
+                    'maxWidth' => null
                 );
 
                 if ($extra == 'image') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When creating a new page with a video, the default values are not set so an error will appear. 
