### PR TITLE
[Composer] update php minimum requirement to be able to install version 4 again

### DIFF
--- a/.sensiolabs.yml
+++ b/.sensiolabs.yml
@@ -1,0 +1,70 @@
+php_version: 5.6
+
+# Configure the failure conditions for your commit status.
+# If at least one of these conditions is verified, the commit status is displayed as failed.
+commit_failure_conditions:
+    # By severities count (default configuration, any change will override it)
+    - "project.severity.critical > 0"
+    - "project.severity.major > 0"
+
+    # # By other severities count
+    # - "project.severity.minor > 0"
+    # - "project.severity.info >= 15"
+    
+    # # By categories count
+    # - "project.category.architecture > 0"
+    # - "project.category.bugrisk > 0"
+    # - "project.category.codestyle > 0"
+    # - "project.category.deadcode > 0"
+    # - "project.category.performance > 0"
+    # - "project.category.readability > 0"
+    # - "project.category.security > 0"
+
+    # # By project grade (none, bronze, silver, gold, platinum)
+    # - "project.grade < gold"
+
+    # # By total violations count
+    # - "project.violations > 150"
+
+    # By severities count, limited to the violations concerning files edited by the current PR
+    # - "pr.severity.critical > 0"
+    # - "pr.severity.major > 0"
+    # - "pr.severity.minor > 0"
+    # - "pr.severity.info >= 15"
+
+    # # By categories count, limited to the violations concerning files edited by the current PR
+    - "pr.category.architecture > 0"
+    - "pr.category.bugrisk > 0"
+    - "pr.category.codestyle > 0"
+    - "pr.category.deadcode > 0"
+    - "pr.category.performance > 0"
+    - "pr.category.readability > 0"
+    - "pr.category.security > 0"
+
+    # # By total violations count, limited to the violations concerning files edited by the current PR
+    # - "pr.violations > 150"
+
+# Configure the directories excluded from the analysis. By default,
+# this setting excldues directories commonly used to store tests
+# and third-party libraries.
+global_exclude_dirs:
+    - vendor
+    - vendors
+    - vendor_bower
+    - test
+    - tests
+    - Tests
+    - spec
+    - features
+    - Fixtures
+    - DataFixtures
+    - var
+    - skeleton
+
+# Configure patterns used by SensioLabsInsight to exclude specific
+# files and directories.
+exclude_patterns:
+    - app/check.php
+    - app/SymfonyRequirements.php
+    - web/config.php
+    - web/app_*.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "symfony/symfony": "~3.0",
         "doctrine/orm": "^2.5",
         "doctrine/dbal": "^2.5",
@@ -30,7 +30,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
 
-        "friendsofsymfony/user-bundle": "2.0.0-beta1",
+        "friendsofsymfony/user-bundle": "~2.0",
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",
@@ -42,8 +42,7 @@
         "liip/imagine-bundle": "v1.4.3",
         "imagine/imagine": "v0.5.0",
         "knplabs/knp-gaufrette-bundle": "~0.1",
-        "symfony-cmf/routing-bundle": "dev-master#09a74726050e02eb5eafb5d3d40fe411ab934a37 as 2.0",
-        "symfony-cmf/routing": "dev-master#b93704ca098334f56e9b317932f21a4362e620db as 2.0",
+        "symfony-cmf/routing-bundle": "~2.0",
         "fpn/doctrine-extensions-taggable": "~0.9",
         "sensio/generator-bundle": "~3.0",
         "twig/extensions": "~1.0",

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
@@ -13,6 +13,12 @@ framework:
     session:         ~
     fragments:       ~
 
+services:
+    translation.loader.yml:
+        class: Symfony\Component\Translation\Loader\YamlFileLoader
+        tags:
+            - { name: translation.loader, alias: yml }
+
 kunstmaan_translator:
     managed_locales: ['nl','en','de']
     cache_dir: "%kernel.cache_dir%/translations"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 

We are not able anymore to install V4 due to the php 5.5 minimum requirement and the dependency of cmf-routing that does not mix well. So we are bending the rules a bit to fix this, otherwise it would be uninstallable for the rest of ages.
