### PR TITLE
[AdminListBundle] Fixed doctrine Index for LockableEntity 

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
+++ b/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
@@ -32,14 +32,14 @@ class LockableEntity extends AbstractEntity
     /**
      * @var string
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", name="entity_class")
      */
     protected $entityClass;
 
     /**
      * @var integer
      *
-     * @ORM\Column(type="bigint")
+     * @ORM\Column(type="bigint", name="entity_id")
      */
     protected $entityId;
 

--- a/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
+++ b/src/Kunstmaan/AdminListBundle/Entity/LockableEntity.php
@@ -9,8 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ORM\Entity(repositoryClass="Kunstmaan\AdminListBundle\Repository\LockableEntityRepository")
  * @ORM\Table(name="kuma_lockable_entity",
- *    uniqueConstraints={@ORM\UniqueConstraint(name="ix_kuma_lockable_entity_id_class", columns={"entityId", "entityClass"})},
- *    indexes={@ORM\Index(name="idx__lockable_entity_id_class", columns={"entityId", "entityClass"})}
+ *    uniqueConstraints={@ORM\UniqueConstraint(name="ix_kuma_lockable_entity_id_class", columns={"entity_id", "entity_class"})},
+ *    indexes={@ORM\Index(name="idx__lockable_entity_id_class", columns={"entity_id", "entity_class"})}
  * )
  */
 class LockableEntity extends AbstractEntity


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Originated from #1623

Fixed column names in doctrine index

    [Doctrine\DBAL\Schema\SchemaException]
    There is no column with name 'entityId' on table 'kuma_lockable_entity'.

Couldn't create LockableEntity using doctrine:schema:create when using AdminListBundle
Column names are seperated by underscore

