### PR TITLE
[UtilitiesBundle] Feature transliterator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "twig/extensions": "~1.0",
         "egulias/email-validator": "~1.2",
         "box/spout": "^2.5",
-        "ruflin/elastica": "^5.1"
+        "ruflin/elastica": "^5.1",
+        "behat/transliterator": "~1.2"
     },
     "require-dev": {
         "behat/behat": "3.1.0rc1",

--- a/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
+++ b/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
@@ -52,7 +52,7 @@ class SlugType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
             $nodeTranslation = $form->getParent()->getData();
-            $view->vars['reset'] = $this->slugifier->slugify($nodeTranslation->getTitle(), '');
+            $view->vars['reset'] = $this->slugifier->slugify($nodeTranslation->getTitle());
             $parentNode = $nodeTranslation->getNode()->getParent();
             if ($parentNode !== null) {
                 $nodeTranslation = $parentNode->getNodeTranslation($nodeTranslation->getLang(), true);

--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -13,11 +13,12 @@ final class Slugifier implements SlugifierInterface
      * Slugify a string
      *
      * @param string $text
+     * @param string $delimiter
      *
      * @return string
      */
-    public function slugify($text)
+    public function slugify($text, $delimiter = '-')
     {
-        return Transliterator::transliterate($text);
+        return Transliterator::transliterate($text, $delimiter);
     }
 }

--- a/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/Slugifier.php
@@ -2,41 +2,22 @@
 
 namespace Kunstmaan\UtilitiesBundle\Helper;
 
+use Behat\Transliterator\Transliterator;
+
 /**
  * Sulgifier is a helper to slugify a certain string
  */
-class Slugifier implements SlugifierInterface
+final class Slugifier implements SlugifierInterface
 {
     /**
      * Slugify a string
      *
-     * @param string $text    Text to slugify
-     * @param string $default Default return value (override when slugify would return an empty string)
+     * @param string $text
      *
      * @return string
      */
-    public function slugify($text, $default = '', $replace = array("'"), $delimiter = '-')
+    public function slugify($text)
     {
-        if (!empty($replace)) {
-            $text = str_replace($replace, ' ', $text);
-        }
-
-        // transliterate
-        if (class_exists('Transliterator')) {
-            $text = mb_convert_encoding((string)$text, 'UTF-8', mb_list_encodings());
-
-            $transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
-            $text = $transliterator->transliterate($text);
-        }
-
-        $text = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $text);
-        $text = strtolower(trim($text, $delimiter));
-        $text = preg_replace("/[\/_|+ -]+/", $delimiter, $text);
-
-        if (empty($text)) {
-            return empty($default) ? '' : $default;
-        }
-
-        return $text;
+        return Transliterator::transliterate($text);
     }
 }

--- a/src/Kunstmaan/UtilitiesBundle/Helper/SlugifierInterface.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/SlugifierInterface.php
@@ -12,11 +12,8 @@ interface SlugifierInterface
 
     /**
      * @param $text
-     * @param $default
-     * @param $replace
-     * @param $delimiter
      * @return mixed
      */
-    public function slugify($text, $default = 'n-a', $replace = array("'"), $delimiter = '-');
+    public function slugify($text);
 
 }

--- a/src/Kunstmaan/UtilitiesBundle/Helper/SlugifierInterface.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/SlugifierInterface.php
@@ -11,9 +11,10 @@ interface SlugifierInterface
 {
 
     /**
-     * @param $text
+     * @param string $text
+     * @param string $delimiter
      * @return mixed
      */
-    public function slugify($text);
+    public function slugify($text, $delimiter = '-');
 
 }

--- a/src/Kunstmaan/UtilitiesBundle/Tests/Helper/SlugifierTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/Helper/SlugifierTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Kunstmaan\NodeBundle\Tests;
+
 use Kunstmaan\UtilitiesBundle\Helper\Slugifier;
 use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
 
@@ -25,18 +26,13 @@ class SlugifierTest extends \PHPUnit_Framework_TestCase
     }
     /**
      * @param string $text    The text to slugify
-     * @param string $default The default alternative
      * @param string $result  The slug it should generate
      *
      * @dataProvider getSlugifyData
      */
-    public function testSlugify($text, $default, $result)
+    public function testSlugify($text,  $result)
     {
-        if (!is_null($default)) {
-            $this->assertEquals($result, $this->slugifier->slugify($text, $default));
-        } else {
-            $this->assertEquals($result, $this->slugifier->slugify($text));
-        }
+        $this->assertEquals($result, $this->slugifier->slugify($text));
     }
 
     /**
@@ -46,16 +42,15 @@ class SlugifierTest extends \PHPUnit_Framework_TestCase
      */
     public function getSlugifyData()
     {
-        return array(
-            array('', '', ''),
-            array('', null, ''),
-            array('test', '', 'test'),
-            array('een titel met spaties', '', 'een-titel-met-spaties'),
-            array('à partir d\'aujourd\'hui', null, 'a-partir-d-aujourd-hui'),
-            array('CaPs ShOulD be LoweRCasEd', null, 'caps-should-be-lowercased'),
-            array('áàäåéèëíìïóòöúùüñßæ', null, 'aaaaeeeiiiooouuunssae'),
-            array('polish-ążśźęćńół', null, 'polish-azszecnol'),
-        );
+        return [
+            ['', ''],
+            ['test', 'test'],
+            ['een titel met spaties', 'een-titel-met-spaties'],
+            ['à partir d\'aujourd\'hui', 'a-partir-daujourdhui'],
+            ['CaPs ShOulD be LoweRCasEd', 'caps-should-be-lowercased'],
+            ['áàäåéèëíìïóòöúùüñßæ', 'aaaaeeeiiiooouuunssae'],
+            ['polish-ążśźęćńół', 'polish-azszecnol']
+        ];
     }
 
     /**

--- a/src/Kunstmaan/UtilitiesBundle/Twig/UtilitiesTwigExtension.php
+++ b/src/Kunstmaan/UtilitiesBundle/Twig/UtilitiesTwigExtension.php
@@ -3,10 +3,9 @@
 namespace Kunstmaan\UtilitiesBundle\Twig;
 
 use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
-use Twig_Extension;
 
 
-class UtilitiesTwigExtension extends Twig_Extension
+class UtilitiesTwigExtension extends \Twig_Extension
 {
     /**
      * @var SlugifierInterface
@@ -16,7 +15,7 @@ class UtilitiesTwigExtension extends Twig_Extension
     /**
      * @param $slugifier
      */
-    function __construct($slugifier)
+    public function __construct($slugifier)
     {
         $this->slugifier = $slugifier;
     }
@@ -29,7 +28,7 @@ class UtilitiesTwigExtension extends Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('slugify', array($this, 'slugify')),
+            new \Twig_SimpleFilter('slugify', [$this, 'slugify']),
         );
     }
 
@@ -40,6 +39,6 @@ class UtilitiesTwigExtension extends Twig_Extension
      */
     public function slugify($text)
     {
-        return $this->slugifier->slugify($text, '');
+        return $this->slugifier->slugify($text);
     }
 }

--- a/src/Kunstmaan/UtilitiesBundle/composer.json
+++ b/src/Kunstmaan/UtilitiesBundle/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.5.0",
         "symfony/symfony": "~2.8",
-        "doctrine/orm": "~2.2,>=2.2.3"
+        "doctrine/orm": "~2.2,>=2.2.3",
+        "behat/transliterator": "~1.2"
     },
     "suggest": {
         "ekino/newrelic-bundle": "To use the UrlTransactionNamingStrategy"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | improvment
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | no

I think we should use `Behat/Transliterator` is more accurate. It's made some BC breaks, but the second argument in slugify function never been used.