### PR TITLE
[SensiolabsInsight] Throw AccessDeniedException instead of AccessDeniedHttpException

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -77,7 +77,7 @@ abstract class AdminListController extends Controller
     protected function doExportAction(AbstractAdminListConfigurator $configurator, $_format, Request $request = null)
     {
         if (!$configurator->canExport()) {
-            throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
+            throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
         $em = $this->getEntityManager();
@@ -103,7 +103,7 @@ abstract class AdminListController extends Controller
     protected function doAddAction(AbstractAdminListConfigurator $configurator, $type = null, Request $request)
     {
         if (!$configurator->canAdd()) {
-            throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
+            throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
         /* @var EntityManager $em */
@@ -211,7 +211,7 @@ abstract class AdminListController extends Controller
         }
 
         if (!$configurator->canEdit($helper)) {
-            throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
+            throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
         if ($helper instanceof LockableEntityInterface) {
@@ -326,7 +326,7 @@ abstract class AdminListController extends Controller
         }
 
         if (!$configurator->canView($helper)) {
-            throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
+            throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
         $MetaData = $em->getClassMetadata($configurator->getRepositoryName());
@@ -366,7 +366,7 @@ abstract class AdminListController extends Controller
             throw new NotFoundHttpException("Entity not found.");
         }
         if (!$configurator->canDelete($helper)) {
-            throw new AccessDeniedHttpException('You do not have sufficient rights to access this page.');
+            throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
         $indexUrl = $configurator->getIndexUrl();

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -272,7 +272,7 @@ class TranslatorController extends AdminListController
 
         $adminListConfigurator = $this->getAdminListConfigurator();
         if (!$adminListConfigurator->canEditInline($values)) {
-            throw new AccessDeniedHttpException("Not allowed to edit this translation");
+            throw $this->createAccessDeniedException('Not allowed to edit this translation');
         }
 
         $id = isset($values['pk']) ? (int) $values['pk'] : 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no-ish (different exception class as before)
| Deprecations? | no
| Fixed tickets | 

Fixes the sensiolabs insight error "Symfony applications should not throw AccessDeniedHttpException". Not sure if this is a "real" BC break, if so I can rebase this against 5.0!