### PR TITLE
[SensiolabsInsight] Changed method visibility for non-action methods in controller classes

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
@@ -19,7 +19,7 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
     /**
      * @return AdminListConfiguratorInterface
      */
-    public function createAdminListConfigurator()
+    protected function createAdminListConfigurator()
     {
         return new {{ entity_class }}AuthorAdminListConfigurator($this->getEntityManager(), $this->aclHelper, $this->locale, PermissionMap::PERMISSION_EDIT);
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
@@ -19,7 +19,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
     /**
      * @return AdminListConfiguratorInterface
      */
-    public function createAdminListConfigurator()
+    protected function createAdminListConfigurator()
     {
         return new {{ entity_class }}PageAdminListConfigurator($this->getEntityManager(), $this->aclHelper, $this->locale, PermissionMap::PERMISSION_EDIT);
     }

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/PopupsAdminListController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/PopupsAdminListController.php
@@ -19,9 +19,11 @@ class PopupsAdminListController extends AdminListController
     private $configurator;
 
     /**
+     * @param bool $listAction
+     * 
      * @return AdminListConfiguratorInterface
      */
-    public function getAdminListConfigurator($listAction = false)
+    protected function getAdminListConfigurator($listAction = false)
     {
         if (!isset($this->configurator)) {
             $this->configurator = new PopupAdminListConfigurator($this->getEntityManager());

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/RulesAdminListController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/RulesAdminListController.php
@@ -17,9 +17,11 @@ class RulesAdminListController extends AdminListController
     private $configurator;
 
     /**
+     * @param $id
+     *
      * @return AdminListConfiguratorInterface
      */
-    public function getAdminListConfigurator($id)
+    protected function getAdminListConfigurator($id)
     {
         if (!isset($this->configurator)) {
             $this->configurator = new RulesAdminListConfigurator($this->getEntityManager(), null, $id);

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -443,33 +443,4 @@ class MediaController extends Controller
             true
         );
     }
-
-    /**
-     * @param Request $request
-     *
-     * @Route("move/", name="KunstmaanMediaBundle_media_move")
-     * @Method({"POST"})
-     *
-     * @return string
-     */
-    public function moveMedia(Request $request)
-    {
-        $mediaId = $request->request->get('mediaId');
-        $folderId = $request->request->get('folderId');
-
-        if (empty($mediaId) || empty($folderId)) {
-            return new JsonResponse(['error' => ['title' => 'Missing media id or folder id']], 400);
-        }
-
-        $em = $this->getDoctrine()->getManager();
-        $mediaRepo = $em->getRepository('KunstmaanMediaBundle:Media');
-
-        $media = $mediaRepo->getMedia($mediaId);
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
-
-        $media->setFolder($folder);
-        $mediaRepo->save($media);
-
-        return new JsonResponse();
-    }
 }

--- a/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
@@ -22,7 +22,7 @@ class MenuAdminListController extends AdminListController
      *
      * @return AbstractAdminListConfigurator
      */
-    public function getAdminListConfigurator(Request $request)
+    protected function getAdminListConfigurator(Request $request)
     {
         if (!isset($this->configurator)) {
             $configuratorClass = $this->getParameter('kunstmaan_menu.adminlist.menu_configurator.class');

--- a/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
@@ -27,7 +27,7 @@ class MenuItemAdminListController extends AdminListController
      * @param int $entityId
      * @return AbstractAdminListConfigurator
      */
-    public function getAdminListConfigurator(Request $request, $menuid, $entityId = null)
+    protected function getAdminListConfigurator(Request $request, $menuid, $entityId = null)
     {
         if (!isset($this->configurator)) {
             $menu = $this->getDoctrine()->getManager()->getRepository(

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -56,46 +56,12 @@ class WidgetsController extends Controller
     /**
      * Select a link
      *
-     * @Route("/select-nodes-lazy_search", name="KunstmaanNodeBundle_nodes_lazy_search")
-     *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @return JsonResponse
-     */
-    public function selectNodesLazySearch(Request $request)
-    {
-        /* @var EntityManagerInterface $em */
-        $em = $this->getDoctrine()->getManager();
-        $locale = $request->getLocale();
-        $search = $request->query->get('str');
-
-        $results = [];
-        if ($search) {
-            $nts = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getNodeTranslationsLikeTitle($search, $locale);
-            /** @var NodeTranslation $nt */
-            foreach ($nts as $nt) {
-                $node = $nt->getNode();
-                $results[] = $node->getId();
-                while ($node->getParent()) {
-                    $node = $node->getParent();
-                    $results[] = $node->getId();
-                }
-            }
-            $results = array_unique($results);
-            sort($results);
-        }
-
-        return new JsonResponse($results);
-    }
-
-    /**
-     * Select a link
-     *
      * @Route("/select-nodes-lazy", name="KunstmaanNodeBundle_nodes_lazy")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return JsonResponse
      */
-    public function selectNodesLazy(Request $request)
+    public function selectNodesLazyAction(Request $request)
     {
         /* @var EntityManagerInterface $em */
         $em = $this->getDoctrine()->getManager();

--- a/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
+++ b/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
@@ -20,7 +20,7 @@ class RedirectAdminListController extends AdminListController
     /**
      * @return AdminListConfiguratorInterface
      */
-    public function getAdminListConfigurator()
+    protected function getAdminListConfigurator()
     {
         if (!isset($this->configurator)) {
             $this->configurator = new RedirectAdminListConfigurator($this->getEntityManager(), null, $this->get('kunstmaan_admin.domain_configuration'));

--- a/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
@@ -20,7 +20,7 @@ class TagAdminListController extends AdminListController
     /**
      * @return AdminListConfiguratorInterface
      */
-    public function getAdminListConfigurator()
+    protected function getAdminListConfigurator()
     {
         if (!isset($this->configurator)) {
             $this->configurator = new TagAdminListConfigurator($this->getEntityManager());

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -250,7 +250,7 @@ class TranslatorController extends AdminListController
     /**
      * @return AbstractAdminListConfigurator
      */
-    public function getAdminListConfigurator()
+    protected function getAdminListConfigurator()
     {
         $locales = $this->getParameter('kuma_translator.managed_locales');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 

Changing method visibility is a BC break imo. Should I add "symfony style" deprecations to 4.0/5.0 branches when extending the controllers and calling these methods?

Fixes the sensiolabs insight "Public methods in controller classes should only be actions" error