### PR TITLE
[AllBundles][5.0] Fix JavaScript loading errors

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -12,7 +12,9 @@
         '{{ asset('bundles/kunstmaanadmin/js/admin-bundle.min.js') }}',
         '{{ asset('bundles/kunstmaanadmin/js/admin-bundle.next.js') }}',
 
-        {%- set jsPath = 'frontend/js/admin-bundle-extra.js' %}
+        {%- block extra_async_javascripts %}{% endblock -%}
+
+        {%- set jsPath = 'frontend/js/admin-bundle-extra.js' -%}
         {% if file_exists(jsPath) %}'{{ asset('/' ~ jsPath) }}'{% endif %}
     ];
 

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -142,9 +142,10 @@
     {% endblock %}
 {% endblock %}
 
-
-    <!-- JS -->
-    {% include "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+    {% block js_footer %}
+        <!-- JS -->
+        {% include "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+    {% endblock %}
 
 
     <!-- JS - Extra -->

--- a/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/setupcontainer.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/GoogleAnalytics/setupcontainer.html.twig
@@ -25,6 +25,12 @@
     %}
 {% endblock %}
 
-{% block extrajavascript %}
-    <script src="{{ asset('bundles/kunstmaandashboard/js/dashboard-bundle-setup.min.js') }}"></script>
+{% block js_footer %}
+    <!-- JS -->
+    {% embed "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+        {% block extra_async_javascripts %}
+            {{ parent() }}
+            '{{ asset('bundles/kunstmaandashboard/js/dashboard-bundle-setup.min.js') }}',
+        {% endblock %}
+    {% endembed %}
 {% endblock %}

--- a/src/Kunstmaan/MediaBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Default/layout.html.twig
@@ -1,7 +1,11 @@
 {% extends '@KunstmaanAdmin/Default/layout.html.twig' %}
 
-{% block extrajavascript %}
-    {{ parent() }}
-
-    <script src="{{ asset('bundles/kunstmaanmedia/js/media-bundle.min.js') }}"></script>
+{% block js_footer %}
+    <!-- JS -->
+    {% embed "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+        {% block extra_async_javascripts %}
+            {{ parent() }}
+            '{{ asset('bundles/kunstmaanmedia/js/media-bundle.min.js') }}',
+        {% endblock %}
+    {% endembed %}
 {% endblock %}

--- a/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
@@ -317,9 +317,12 @@
 
 {% endblock %}
 
-
-{% block extrajavascript %}
-    {{ parent() }}
-
-    <script src="{{ asset('bundles/kunstmaanmedia/js/media-bundle.min.js') }}"></script>
+{% block js_footer %}
+    <!-- JS -->
+    {% embed "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+        {% block extra_async_javascripts %}
+            {{ parent() }}
+            '{{ asset('bundles/kunstmaanmedia/js/media-bundle.min.js') }}',
+        {% endblock %}
+    {% endembed %}
 {% endblock %}

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
@@ -83,9 +83,12 @@
 
 {% endblock %}
 
-
-{% block extrajavascript %}
-    {{ parent() }}
-
-    <script src="{{ asset('bundles/kunstmaantranslator/js/translator-bundle.min.js') }}"></script>
+{% block js_footer %}
+    <!-- JS -->
+    {% embed "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+        {% block extra_async_javascripts %}
+            {{ parent() }}
+            '{{ asset('bundles/kunstmaantranslator/js/translator-bundle.min.js') }}',
+        {% endblock %}
+    {% endembed %}
 {% endblock %}


### PR DESCRIPTION
A previous commit changed the way bundle scripts are loaded, but only did this for the admin bundle.

This fixes the script loading for the:
- DashboardBundle
- MediaBudle
- TranslatorBundle

If this is not the proper way to fix this, or it can be optimized, please let me know.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1670 
