### PR TITLE
[SensiolabsInsight] Removed unused constructor parameter

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -15,8 +15,6 @@ services:
         class: Kunstmaan\AdminListBundle\Twig\AdminListTwigExtension
         tags:
             -  { name: twig.extension }
-        arguments:
-            -  '@service_container'
 
     kunstmaan_entity.admin_entity.entity_version_lock_service:
         class: Kunstmaan\AdminListBundle\Service\EntityVersionLockService

--- a/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
+++ b/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
@@ -14,19 +14,6 @@ use Symfony\Component\Routing\Router;
 class AdminListTwigExtension extends \Twig_Extension
 {
     /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * @param ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
      * Returns a list of functions to add to the existing list.
      *
      * @return array An array of functions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (if users extend this class it's a BC break)
| Deprecations? | no
| Fixed tickets | 

Fixes a warning from sensiolabs insight ("The Symfony Dependency Injection Container should not be passed as an argument") and also some leftover code of the cleanup in #1255
