### PR TITLE
[PagePartBundle]: check if preview is defined

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/modal.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/modal.html.twig
@@ -12,7 +12,7 @@
                 <div class="row">
                     {% for pagePartType in pagepartadmin.possiblePagePartTypes %}
                         <div class="col-sm-6 col-md-4">
-                            {% if pagePartType.preview %}
+                            {% if pagePartType.preview is defined %}
                                 {% set background = asset(pagePartType.preview) %}
                             {% else %}
                                 {% set background = asset('bundles/kunstmaanadmin/default-theme/img/kunstmaan/guy.svg') %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When creating a custom PagePartAdminConfigurator, can be not defined.
