### PR TITLE
[NodeBundle]: remove request stack injection

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -164,7 +164,6 @@ services:
             - "@doctrine.orm.entity_manager"
             - "@router"
             - "@logger"
-            - "@request_stack"
             - "@kunstmaan_admin.domain_configuration"
 
     kunstmaan_node.url_replace.controller:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | o
| BC breaks?    | yes
| Deprecations? |no
| Fixed tickets | #1684

Because off the removal of the request stack in the constructor call in PR #1684, the injection needs to be removed to.
