### PR TITLE
[SearchBundle] Convert analyzer languages config to lowercase …

### DIFF
--- a/src/Kunstmaan/SearchBundle/DependencyInjection/KunstmaanSearchExtension.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/KunstmaanSearchExtension.php
@@ -26,7 +26,7 @@ class KunstmaanSearchExtension extends Extension
         if (count($config['analyzer_languages']) <= 0) {
             $config['analyzer_languages'] = $this->getDefaultAnalyzerLanguages();
         }
-        $container->setParameter('analyzer_languages', $config['analyzer_languages']);
+        $container->setParameter('analyzer_languages', \array_change_key_case($config['analyzer_languages']), \CASE_LOWER);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');


### PR DESCRIPTION
Convert analyzer languages config to lowercase to prevent config mismatch because of case sensitivity

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1704 
