### PR TITLE
[SearchBundle] add punctuation to kuma_ngram tokenizer

### DIFF
--- a/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
+++ b/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
@@ -104,7 +104,7 @@ abstract class AbstractAnalysisFactory implements AnalysisFactoryInterface
             'type'     => 'nGram',
             'min_gram' => 4,
             'max_gram' => 30,
-            'token_chars' => [ "letter", "digit" ]
+            'token_chars' => [ "letter", "digit", "punctuation" ]
         );
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | /

If you have this-is-a-test it will be split into this, is, a, test and when you search for this-is-a-test you will get no results. The punctuation token_chars prevent tokens from being split on those chars.
