### PR TITLE
[GeneratorBundle]: fix classes in fields.html.twig

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/views/Form/fields.html.twig
@@ -56,7 +56,9 @@
 {% block form_widget_simple %}
 {% spaceless %}
     {% set type = type|default('text') %}
-    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %} class="form-control form-control--input">
+    {% set class = (attr.class|default('') ~ ' form-control form-control--input') %}
+    {% set attr = attr|merge({'class': class|trim}) %}
+    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}>
 {% endspaceless %}
 {% endblock form_widget_simple %}
 
@@ -64,7 +66,9 @@
 {# Form widget: Textarea #}
 {% block textarea_widget %}
 {% spaceless %}
-    <textarea {{ block('widget_attributes') }} class="form-control form-control--textarea form-widget--textarea">{{ value }}</textarea>
+    {% set class = (attr.class|default('') ~ ' form-control form-control--textarea form-widget--textarea') %}
+    {% set attr = attr|merge({'class': class|trim}) %}
+    <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 {% endspaceless %}
 {% endblock textarea_widget %}
 
@@ -74,7 +78,9 @@
 {% spaceless %}
     <div {{ block('widget_container_attributes') }} class="form-widget--select">
         <i class="icon icon--triangle-down select__icon"></i>
-        <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %} class="form-control form-control--select">
+        {% set class = (attr.class|default('') ~ ' form-control form-control--select') %}
+        {% set attr = attr|merge({'class': class|trim}) %}
+        <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
             {% if placeholder is not none %}
                 <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder|trans({}, translation_domain) }}</option>
             {% endif %}
@@ -116,7 +122,9 @@
         {% if label is empty %}
             {% set label = name|humanize %}
         {% endif %}
-        <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} class="form-control-choice">
+        {% set class = (attr.class|default('') ~ ' form-control-choice') %}
+        {% set attr = attr|merge({'class': class|trim}) %}
+        <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
         <label for="{{ id }}"{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ label|trans({}, translation_domain)|raw }}{% if required and not compound %}<span class="form-group__required-symbol">*</span>{% endif %}
         </label>
@@ -135,7 +143,9 @@
         {% if label is empty %}
             {% set label = name|humanize %}
         {% endif %}
-        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} class="form-control-choice">
+        {% set class = (attr.class|default('') ~ ' form-control-choice') %}
+        {% set attr = attr|merge({'class': class|trim}) %}
+        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}>
         <label for="{{ id }}"{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ label|trans({}, translation_domain)|raw }}{% if required %}<span class="form-group__required-symbol">*</span>{% endif %}
         </label>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When using the fields.html.twig as form theme, you will get invalid HTML when adding a class to a form input field. This occurs because a class is already added in the twig template. Therefore we need to merge this classes with the ones received from the form type. The block widget_attributes will then render the classes.
