### PR TITLE
[POC] Final commands and commands as services

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
@@ -3,13 +3,38 @@
 namespace Kunstmaan\TranslatorBundle\Command;
 
 use Kunstmaan\TranslatorBundle\Model\Import\ImportCommand;
+use Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @final since 5.0
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
+ */
 class ImportTranslationsCommand extends ContainerAwareCommand
 {
+    /**
+     * @var ImportCommandHandler
+     */
+    private $importCommandHandler;
+
+    public function __construct($importCommandHandler = null)
+    {
+        parent::__construct();
+
+        if (!$importCommandHandler instanceof ImportCommandHandler) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $importCommandHandler ? 'kuma:translator:import' : $importCommandHandler);
+
+            return;
+        }
+
+        $this->importCommandHandler = $importCommandHandler;
+    }
+
     protected function configure()
     {
         $this
@@ -30,6 +55,9 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         $globals        = $input->getOption('globals');
         $defaultBundle  = $input->getOption('defaultbundle') ;
         $bundles        = $input->hasOption('bundles') ? array_map('trim', explode(',', $input->getOption('bundles'))) : array();
+        if (null === $this->importCommandHandler) {
+            $this->importCommandHandler = $this->getContainer()->get('kunstmaan_translator.service.importer.command_handler');
+        }
 
         $importCommand = new ImportCommand();
         $importCommand
@@ -39,7 +67,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
             ->setDefaultBundle($defaultBundle)
             ->setBundles($bundles);
 
-        $imported = $this->getContainer()->get('kunstmaan_translator.service.importer.command_handler')->executeImportCommand($importCommand);
+        $imported = $this->importCommandHandler->executeImportCommand($importCommand);
         
         $output->writeln(sprintf("Translation imported: %d", $imported));
 

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -41,6 +41,7 @@ class KunstmaanTranslatorExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('repositories.yml');
+        $loader->load('commands.yml');
 
         $this->setTranslationConfiguration($config, $container);
         $container->getDefinition('kunstmaan_translator.datacollector')->setDecoratedService('translator');

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
@@ -1,0 +1,6 @@
+services:
+    Kunstmaan\TranslatorBundle\Command\ImportTranslationsCommand:
+        class: Kunstmaan\TranslatorBundle\Command\ImportTranslationsCommand
+        arguments: '@kunstmaan_translator.service.importer.command_handler'
+        tags:
+            - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes(ish)
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

As discussed last week I would look into ways of closing the class api a bit more (Final classes, private properties, etc).
This is a POC with multiple fixes combined:

- Mark the class final with the annotation.
This way it isn't a hard BC break but users in dev environment will receive a deprecation that the class is not supposed to be extended from. But still they can extend the class until the next major version. This way we allow the users (our we internally) some time to migrate extended classes or re-open the the class to be extended (just remove the annotation and deprecation notice).

Users will see this kind of deprecation:

```
User Deprecated: The "FQCN" class is considered final since version 5.0. It may change without further notice as of its next major version. You should not extend it from "FQCN".
```

- By closing the command we can do already some work for the future
  - Register commands as services (will be the default way in SF4)
  - Tag the commands as "console.command" because the auto-registration was deprecated in 3.4

This is just a POC so please give some feedback on this proposal. In a first phase we could start with commands and then move to another part of the bundles.