### PR TITLE
[AllBundles] - Set composer minimum PHP version to >=7.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1.0",
         "symfony/symfony": "~3.0",
         "doctrine/orm": "^2.5",
         "doctrine/dbal": "^2.5",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #1445 
