### PR TITLE
[FormBundle] Default file upload label required to false

### DIFF
--- a/src/Kunstmaan/FormBundle/Form/FileUploadPagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/FileUploadPagePartAdminType.php
@@ -22,7 +22,7 @@ class FileUploadPagePartAdminType extends AbstractType
     {
         $builder
             ->add('label', null, array(
-                'required' => true,
+                'required' => false,
                 'label' => 'kuma_form.form.file_upload_page_part.label.label',
             ))
             ->add('required', CheckboxType::class, array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1607 
