### PR TITLE
Bump knpBundles dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "incenteev/composer-parameter-handler": "^2.0",
 
         "friendsofsymfony/user-bundle": "~2.0",
-        "knplabs/knp-menu-bundle": "~2.0",
+        "knplabs/knp-menu-bundle": "~2.2",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",
         "kunstmaan/google-api-custom": "~1.0",


### PR DESCRIPTION
Bump knpBundles dependency to get rid of deprecation warnings. Tested with my local installation of 5.0.0-RC1

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

