### PR TITLE
[AdminListBundle][5.1] Deprecate direct container access in controllers

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -29,6 +29,31 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 abstract class AdminListController extends Controller
 {
     /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get($id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
+
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter($name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
+
+
+    /**
      * You can override this method to return the correct entity manager when using multiple databases ...
      *
      * @return \Doctrine\Common\Persistence\ObjectManager|object
@@ -50,7 +75,7 @@ abstract class AdminListController extends Controller
     {
         $em = $this->getEntityManager();
         /* @var AdminList $adminList */
-        $adminList = $this->get("kunstmaan_adminlist.factory")->createList($configurator, $em);
+        $adminList = $this->container->get("kunstmaan_adminlist.factory")->createList($configurator, $em);
         $adminList->bindRequest($request);
 
         $this->buildSortableFieldActions($configurator);
@@ -83,10 +108,10 @@ abstract class AdminListController extends Controller
         $em = $this->getEntityManager();
 
         /* @var AdminList $adminList */
-        $adminList = $this->get("kunstmaan_adminlist.factory")->createExportList($configurator, $em);
+        $adminList = $this->container->get("kunstmaan_adminlist.factory")->createExportList($configurator, $em);
         $adminList->bindRequest($request);
 
-        return $this->get("kunstmaan_adminlist.service.export")->getDownloadableResponse($adminList, $_format);
+        return $this->container->get("kunstmaan_adminlist.service.export")->getDownloadableResponse($adminList, $_format);
     }
 
     /**
@@ -217,10 +242,10 @@ abstract class AdminListController extends Controller
                 // Don't redirect to listing when coming from ajax request, needed for url chooser.
                 if (!$request->isXmlHttpRequest()) {
                     /** @var EntityVersionLockService $entityVersionLockService*/
-                    $entityVersionLockService = $this->get('kunstmaan_entity.admin_entity.entity_version_lock_service');
+                    $entityVersionLockService = $this->container->get('kunstmaan_entity.admin_entity.entity_version_lock_service');
 
                     $user = $entityVersionLockService->getUsersWithEntityVersionLock($helper, $this->getUser());
-                    $message = $this->get('translator')->trans('kuma_admin_list.edit.flash.locked', array('%user%' => implode(', ', $user)));
+                    $message = $this->container->get('translator')->trans('kuma_admin_list.edit.flash.locked', array('%user%' => implode(', ', $user)));
                     $this->addFlash(
                         FlashTypes::WARNING,
                         $message
@@ -484,7 +509,7 @@ abstract class AdminListController extends Controller
     protected function isLockableEntityLocked(LockableEntityInterface $entity)
     {
         /** @var EntityVersionLockService $entityVersionLockService */
-        $entityVersionLockService = $this->get('kunstmaan_entity.admin_entity.entity_version_lock_service');
+        $entityVersionLockService = $this->container->get('kunstmaan_entity.admin_entity.entity_version_lock_service');
 
         return $entityVersionLockService->isEntityBelowThreshold($entity) && $entityVersionLockService->isEntityLocked(
                 $this->getUser(),

--- a/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
@@ -25,7 +25,7 @@ class MenuAdminListController extends AdminListController
     public function getAdminListConfigurator(Request $request)
     {
         if (!isset($this->configurator)) {
-            $configuratorClass = $this->getParameter('kunstmaan_menu.adminlist.menu_configurator.class');
+            $configuratorClass = $this->container->getParameter('kunstmaan_menu.adminlist.menu_configurator.class');
             $this->configurator = new $configuratorClass(
                 $this->getEntityManager()
             );
@@ -55,7 +55,7 @@ class MenuAdminListController extends AdminListController
     public function indexAction(Request $request)
     {
         // Make sure we have a menu for each possible locale
-        $this->get('kunstmaan_menu.menu.service')->makeSureMenusExist();
+        $this->container->get('kunstmaan_menu.menu.service')->makeSureMenusExist();
 
         return parent::doIndexAction(
             $this->getAdminListConfigurator($request),

--- a/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
@@ -31,15 +31,15 @@ class MenuItemAdminListController extends AdminListController
     {
         if (!isset($this->configurator)) {
             $menu = $this->getDoctrine()->getManager()->getRepository(
-                $this->getParameter('kunstmaan_menu.entity.menu.class')
+                $this->container->getParameter('kunstmaan_menu.entity.menu.class')
             )->find($menuid);
-            $rootNode = $this->get('kunstmaan_admin.domain_configuration')->getRootNode();
+            $rootNode = $this->container->get('kunstmaan_admin.domain_configuration')->getRootNode();
 
-            $configuratorClass = $this->getParameter('kunstmaan_menu.adminlist.menuitem_configurator.class');
+            $configuratorClass = $this->container->getParameter('kunstmaan_menu.adminlist.menuitem_configurator.class');
             $this->configurator = new $configuratorClass($this->getEntityManager(), null, $menu);
 
-            $adminType = $this->getParameter('kunstmaan_menu.form.menuitem_admintype.class');
-            $menuItemClass = $this->getParameter('kunstmaan_menu.entity.menuitem.class');
+            $adminType = $this->container->getParameter('kunstmaan_menu.form.menuitem_admintype.class');
+            $menuItemClass = $this->container->getParameter('kunstmaan_menu.entity.menuitem.class');
             $this->configurator->setAdminType($adminType);
             $this->configurator->setAdminTypeOptions(array('menu' => $menu, 'rootNode' => $rootNode, 'menuItemClass' => $menuItemClass, 'entityId' => $entityId, 'locale' => $request->getLocale()));
         }
@@ -58,7 +58,7 @@ class MenuItemAdminListController extends AdminListController
     public function indexAction(Request $request, $menuid)
     {
         $menuRepo = $this->getDoctrine()->getManager()->getRepository(
-            $this->getParameter('kunstmaan_menu.entity.menu.class')
+            $this->container->getParameter('kunstmaan_menu.entity.menu.class')
         );
 
         /** @var BaseMenu $menu */
@@ -147,7 +147,7 @@ class MenuItemAdminListController extends AdminListController
     public function moveUpAction(Request $request, $menuid, $item)
     {
         $em = $this->getEntityManager();
-        $repo = $em->getRepository($this->getParameter('kunstmaan_menu.entity.menuitem.class'));
+        $repo = $em->getRepository($this->container->getParameter('kunstmaan_menu.entity.menuitem.class'));
         $item = $repo->find($item);
 
         if ($item) {
@@ -169,7 +169,7 @@ class MenuItemAdminListController extends AdminListController
     public function moveDownAction(Request $request, $menuid, $item)
     {
         $em = $this->getEntityManager();
-        $repo = $em->getRepository($this->getParameter('kunstmaan_menu.entity.menuitem.class'));
+        $repo = $em->getRepository($this->container->getParameter('kunstmaan_menu.entity.menuitem.class'));
         $item = $repo->find($item);
 
         if ($item) {

--- a/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
+++ b/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
@@ -23,7 +23,7 @@ class RedirectAdminListController extends AdminListController
     public function getAdminListConfigurator()
     {
         if (!isset($this->configurator)) {
-            $this->configurator = new RedirectAdminListConfigurator($this->getEntityManager(), null, $this->get('kunstmaan_admin.domain_configuration'));
+            $this->configurator = new RedirectAdminListConfigurator($this->getEntityManager(), null, $this->container->get('kunstmaan_admin.domain_configuration'));
         }
 
         return $this->configurator;

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -44,16 +44,16 @@ class TranslatorController extends AdminListController
         $configurator = $this->getAdminListConfigurator();
 
         /* @var AdminList $adminList */
-        $adminList = $this->get("kunstmaan_adminlist.factory")->createList($configurator);
+        $adminList = $this->container->get("kunstmaan_adminlist.factory")->createList($configurator);
         $adminList->bindRequest($request);
 
-        $cacheFresh = $this->get('kunstmaan_translator.service.translator.cache_validator')->isCacheFresh();
-        $debugMode = $this->getParameter('kuma_translator.debug') === true;
+        $cacheFresh = $this->container->get('kunstmaan_translator.service.translator.cache_validator')->isCacheFresh();
+        $debugMode = $this->container->getParameter('kuma_translator.debug') === true;
 
         if (!$cacheFresh && !$debugMode) {
             $this->addFlash(
                 FlashTypes::INFO,
-                $this->get('translator')->trans('settings.translator.not_live_warning')
+                $this->container->get('translator')->trans('settings.translator.not_live_warning')
             );
         }
 
@@ -81,10 +81,10 @@ class TranslatorController extends AdminListController
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
         $configurator = $this->getAdminListConfigurator();
-        $translator = $this->get('translator');
+        $translator = $this->container->get('translator');
 
         $translation = new \Kunstmaan\TranslatorBundle\Model\Translation();
-        $locales = $this->getParameter('kuma_translator.managed_locales');
+        $locales = $this->container->getParameter('kuma_translator.managed_locales');
         foreach ($locales as $locale) {
             $translation->addText($locale, '');
         }
@@ -108,7 +108,7 @@ class TranslatorController extends AdminListController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('settings.translator.succesful_added')
+                    $this->container->get('translator')->trans('settings.translator.succesful_added')
                 );
 
                 $indexUrl = $configurator->getIndexUrl();
@@ -152,7 +152,7 @@ class TranslatorController extends AdminListController
         $translation = new \Kunstmaan\TranslatorBundle\Model\Translation();
         $translation->setDomain($translations[0]->getDomain());
         $translation->setKeyword($translations[0]->getKeyword());
-        $locales = $this->getParameter('kuma_translator.managed_locales');
+        $locales = $this->container->getParameter('kuma_translator.managed_locales');
         foreach ($locales as $locale) {
             $found = false;
             foreach ($translations as $t) {
@@ -178,7 +178,7 @@ class TranslatorController extends AdminListController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('settings.translator.succesful_edited')
+                    $this->container->get('translator')->trans('settings.translator.succesful_edited')
                 );
 
                 $indexUrl = $configurator->getIndexUrl();
@@ -252,7 +252,7 @@ class TranslatorController extends AdminListController
      */
     public function getAdminListConfigurator()
     {
-        $locales = $this->getParameter('kuma_translator.managed_locales');
+        $locales = $this->container->getParameter('kuma_translator.managed_locales');
 
         if (!isset($this->adminListConfigurator)) {
             $this->adminListConfigurator = new TranslationAdminListConfigurator($this->getDoctrine()->getManager()
@@ -280,7 +280,7 @@ class TranslatorController extends AdminListController
         /**
          * @var TranslatorInterface $translator
          */
-        $translator = $this->get('translator');
+        $translator = $this->container->get('translator');
 
         try {
             if ($id !== 0) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

I left the upgrade guide for now, let's do that after 5.0 is released and before the PR gets merged.

This PR prepares the code to move away from direct container access in controllers. All `$this->get()` usages are replaced by `$this->container->get()` to avoid triggering deprecations in non-user code. In 6.0 we should:
- remove the `get` and `getParameter` overrides
- extend from the symfony `AbstractController`
- override the `getSubscribedServices` method to extend the list of services to make sure we have all the "default" symfony services and the ones the kuma adminstlist controller needs in the service locator. Users extending from our base controller should just register their controllers as services.
  - I think for 6.0 we should support sf4.1+ so we can use the newly introduced "parameter bag" to access the parameters-as-a-service. See [symfony/symfony#25288](https://github.com/symfony/symfony/pull/25288)

This is just for the adminlist "base" controller. I will open a separate PR to do the changes for the other controllers just extending from the symfony controller class.