### PR TITLE
[FixturesBundle] fixed parser for array

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Parser/Parser.php
+++ b/src/Kunstmaan/FixturesBundle/Parser/Parser.php
@@ -74,7 +74,7 @@ class Parser
 
         foreach ($array as $key => $item) {
             if (is_array($item)) {
-                $array[$key] = $this->parseArray($item, $providers, $fixtures);
+                $array[$key] = $this->parseArray($item, $providers, $fixtures, $additional);
             } else {
                 $array[$key] = $this->parse($item, $providers, $fixtures, $additional);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | NA

When using the node provider of the fixtures in an array of a property in the fixtures.yml additional should be passed through.

`propertyName: ["<getNode(@fixture_1)>"]`

Pair coded with @sandergo90 