### PR TITLE
[DashboardBundle] fix javascript error

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/layout.html.twig
@@ -146,9 +146,5 @@
         <!-- JS -->
         {% include "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
     {% endblock %}
-
-
-    <!-- JS - Extra -->
-    {% block extrajavascript %}{% endblock %}
 </body>
 </html>

--- a/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig
@@ -13,6 +13,12 @@
     {% endfor %}
 {% endblock %}
 
-{% block extrajavascript %}
-    <script src="{{ asset('bundles/kunstmaandashboard/js/dashboard-bundle.min.js') }}"></script>
+{% block js_footer %}
+    <!-- JS -->
+    {% embed "KunstmaanAdminBundle:Default:_js_footer.html.twig" %}
+        {% block extra_async_javascripts %}
+            {{ parent() }}
+            '{{ asset('bundles/kunstmaandashboard/js/dashboard-bundle.min.js') }}',
+        {% endblock %}
+    {% endembed %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

A previously commit added the block extrajavascript. This block is not needed because we can embed the js_footer and add our extra javascript here. TranslatorBundle also used this method. 
