### PR TITLE
[TranslatorBundle][5.1] Commands as services and mark commands as final

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
+        "doctrine/doctrine-migrations-bundle": "^1.3",
         "symfony/assetic-bundle": "~2.7",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "~2.8|~3.0",

--- a/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
@@ -3,14 +3,42 @@
 namespace Kunstmaan\TranslatorBundle\Command;
 
 use Kunstmaan\TranslatorBundle\Model\Export\ExportCommand;
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
+/**
+ * @final since 5.1
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
+ */
 class ExportTranslationsCommand extends ContainerAwareCommand
 {
+    /**
+     * @var ExportCommandHandler
+     */
+    private $exportCommandHandler;
+
+    /**
+     * @param ExportCommandHandler|null $exportCommandHandler
+     */
+    public function __construct(/* ExportCommandHandler */ $exportCommandHandler = null)
+    {
+        parent::__construct();
+
+        if (!$exportCommandHandler instanceof ExportCommandHandler) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $exportCommandHandler ? 'kuma:translator:export' : $exportCommandHandler);
+
+            return;
+        }
+
+        $this->exportCommandHandler = $exportCommandHandler;
+    }
+
     protected function configure()
     {
         $this
@@ -28,8 +56,12 @@ class ExportTranslationsCommand extends ContainerAwareCommand
         $format =       $input->getOption('format');
         $locales =      $input->getOption('locales');
 
-        if (is_null($format)) {
+        if (null === $format) {
             throw new InvalidArgumentException('A format should be defined, e.g --format yml');
+        }
+
+        if (null === $this->exportCommandHandler) {
+            $this->exportCommandHandler = $this->getContainer()->get('kunstmaan_translator.service.exporter.command_handler');
         }
 
         $exportCommand = new ExportCommand();
@@ -38,7 +70,6 @@ class ExportTranslationsCommand extends ContainerAwareCommand
             ->setFormat($format === null ? false : $format)
             ->setLocales($locales === null ? false : $locales);
 
-        $this->getContainer()->get('kunstmaan_translator.service.exporter.command_handler')->executeExportCommand($exportCommand);
-
+        $this->exportCommandHandler->executeExportCommand($exportCommand);
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/MigrationsDiffCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/MigrationsDiffCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for generate migration classes by checking the translation flag value
+ *
+ * @final since 5.1
  */
 class MigrationsDiffCommand extends DiffCommand
 {

--- a/src/Kunstmaan/TranslatorBundle/Command/TranslationCacheCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/TranslationCacheCommand.php
@@ -2,14 +2,50 @@
 
 namespace Kunstmaan\TranslatorBundle\Command;
 
+use Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator;
+use Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
+/**
+ * @final since 5.1
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
+ */
 class TranslationCacheCommand extends ContainerAwareCommand
 {
+    /**
+     * @var ResourceCacher
+     */
+    private $resourceCacher;
+
+    /**
+     * @var CacheValidator
+     */
+    private $cacheValidator;
+
+    /**
+     * @param ResourceCacher|null $resourceCacher
+     * @param CacheValidator|null $cacheValidator
+     */
+    public function __construct(/* ResourceCacher */ $resourceCacher = null, /* CacheValidator */ $cacheValidator = null)
+    {
+        parent::__construct();
+
+        if (!$resourceCacher instanceof ResourceCacher) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $resourceCacher ? 'kuma:translator:cache' : $resourceCacher);
+
+            return;
+        }
+
+        $this->resourceCacher = $resourceCacher;
+        $this->cacheValidator = $cacheValidator;
+    }
+
     protected function configure()
     {
         $this
@@ -34,17 +70,24 @@ class TranslationCacheCommand extends ContainerAwareCommand
 
     public function flushTranslationCache(InputInterface $input, OutputInterface $output)
     {
-        if ( $this->getContainer()->get('kunstmaan_translator.service.translator.resource_cacher')->flushCache() ) {
+        if (null === $this->resourceCacher) {
+            $this->resourceCacher = $this->getContainer()->get('kunstmaan_translator.service.translator.resource_cacher');
+        }
+
+        if ($this->resourceCacher->flushCache()) {
             $output->writeln('<info>Translation cache succesfully flushed</info>');
         }
     }
 
     public function showTranslationCacheStatus(InputInterface $input, OutputInterface $output)
     {
-        $cacheValidator = $this->getContainer()->get('kunstmaan_translator.service.translator.cache_validator');
-        $oldestFile = $cacheValidator->getOldestCachefileDate();
-        $newestTranslation = $cacheValidator->getLastTranslationChangeDate();
-        $isFresh = $cacheValidator->isCacheFresh();
+        if (null === $this->cacheValidator) {
+            $this->cacheValidator = $this->getContainer()->get('kunstmaan_translator.service.translator.cache_validator');
+        }
+
+        $oldestFile = $this->cacheValidator->getOldestCachefileDate();
+        $newestTranslation = $this->cacheValidator->getLastTranslationChangeDate();
+        $isFresh = $this->cacheValidator->isCacheFresh();
 
         $output->writeln(sprintf('Oldest file mtime: <info>%s</info>', $oldestFile instanceof \DateTime ? $oldestFile->format('Y-m-d H:i:s') : 'none found'));
         $output->writeln(sprintf('Newest translation (in stash): <info>%s</info>', $newestTranslation instanceof \DateTime ? $newestTranslation->format('Y-m-d H:i:s') : 'none found'));

--- a/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Kunstmaan\TranslatorBundle\Command;
 
+use Kunstmaan\TranslatorBundle\Repository\TranslationRepository;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -8,9 +9,35 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to reset/request translation flags from the stash
+ *
+ * @final since 5.1
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
  */
 class TranslationFlagCommand extends ContainerAwareCommand
 {
+    /**
+     * @var TranslationRepository
+     */
+    private $translationRepository;
+
+    /**
+     * @param TranslationRepository|null $translationRepository
+     */
+    public function __construct(/* TranslationRepository */ $translationRepository = null)
+    {
+        parent::__construct();
+
+        if (!$translationRepository instanceof TranslationRepository) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $translationRepository ? 'kuma:translator:flag' : $translationRepository);
+
+            return;
+        }
+
+        $this->translationRepository = $translationRepository;
+    }
+
     protected function configure()
     {
         parent::configure();
@@ -36,6 +63,10 @@ class TranslationFlagCommand extends ContainerAwareCommand
      */
     public function resetAllTranslationFlags()
     {
-        $this->getContainer()->get('kunstmaan_translator.repository.translation')->resetAllFlags();
+        if (null === $this->translationRepository) {
+            $this->translationRepository = $this->getContainer()->get('kunstmaan_translator.repository.translation');
+        }
+
+        $this->translationRepository->resetAllFlags();
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -41,6 +41,7 @@ class KunstmaanTranslatorExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('repositories.yml');
+        $loader->load('commands.yml');
 
         $this->setTranslationConfiguration($config, $container);
         $container->getDefinition('kunstmaan_translator.datacollector')->setDecoratedService('translator');

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
@@ -1,0 +1,24 @@
+services:
+    Kunstmaan\TranslatorBundle\Command\ImportTranslationsCommand:
+        arguments: ['@kunstmaan_translator.service.importer.command_handler']
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\TranslatorBundle\Command\ExportTranslationsCommand:
+        arguments: ['@kunstmaan_translator.service.exporter.command_handler']
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\TranslatorBundle\Command\TranslationCacheCommand:
+        arguments: ['@kunstmaan_translator.service.translator.resource_cacher', '@kunstmaan_translator.service.translator.cache_validator']
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\TranslatorBundle\Command\TranslationFlagCommand:
+        arguments: ['@kunstmaan_translator.repository.translation']
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\TranslatorBundle\Command\MigrationsDiffCommand:
+        tags:
+            - { name: console.command }

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -18,6 +18,7 @@
         "symfony/symfony": "~2.8",
         "doctrine/orm": "^2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-migrations-bundle": "^1.3",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

**Changes**
- Mark the class final with the annotation.
This way it isn't a hard BC break but users in dev environment will receive a deprecation that the class is not supposed to be extended from. But still they can extend the class until the next major version. This way we allow the users (our we internally) some time to migrate extended classes or re-open the the class to be extended (just remove the annotation and deprecation notice).

Users will see this kind of deprecation:

```
User Deprecated: The "FQCN" class is considered final since version 5.0. It may change without further notice as of its next major version. You should not extend it from "FQCN".
```

- By closing the command we can do already some work for the future
  - Register commands as services (will be the default way in SF4)
  - Tag the commands as "console.command" because the auto-registration was deprecated in 3.4

**Extra**

I've also added `doctrine/doctrine-migration-bundle` as a dependency because there is a command depending on this bundle. 

**Next up**

In version 6 we should replace the `extend ContainerAwareCommand` by just `extend Command`, remove the `$this->getContainer()` usages and remove the BC layer from the constructor of the commands. I've added `NEXT_MAJOR` docblocks to easily search things we should change/cleanup in version 6
