### PR TITLE
[UtilitiesBundle][5.1] Commands as services and mark commands as final

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
+++ b/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\UtilitiesBundle\Command;
 
+use Kunstmaan\UtilitiesBundle\Helper\Cipher\CipherInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -9,8 +10,15 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @final since 5.1
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
+ */
 class CipherCommand extends ContainerAwareCommand
 {
+    /**
+     * @var CipherInterface
+     */
     private $cipher;
 
     private static $methods = [
@@ -20,6 +28,24 @@ class CipherCommand extends ContainerAwareCommand
         3 => 'Decrypt file'
     ];
 
+    /**
+     * @param CipherInterface|null $cipher
+     */
+    public function __construct(/* CipherInterface */ $cipher = null)
+    {
+        parent::__construct();
+
+        if (!$cipher instanceof CipherInterface) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $cipher ? 'kuma:cipher' : $cipher);
+
+            return;
+        }
+
+        $this->cipher = $cipher;
+    }
+
     protected function configure()
     {
         $this->setName('kuma:cipher')->setDescription('Cipher utilities commands.');
@@ -27,7 +53,9 @@ class CipherCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->cipher = $this->getContainer()->get('kunstmaan_utilities.cipher');
+        if (null === $this->cipher) {
+            $this->cipher = $this->getContainer()->get('kunstmaan_utilities.cipher');
+        }
         $helper = $this->getHelper('question');
 
         $question = new ChoiceQuestion(

--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
@@ -23,6 +23,7 @@ class KunstmaanUtilitiesExtension extends Extension
         $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('commands.yml');
         $loader->load('services.yml');
     }
 }

--- a/src/Kunstmaan/UtilitiesBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/UtilitiesBundle/Resources/config/commands.yml
@@ -1,0 +1,5 @@
+services:
+    Kunstmaan\UtilitiesBundle\Command\CipherCommand:
+        arguments: ['@kunstmaan_utilities.cipher']
+        tags:
+            - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

**Changes**
- Mark the class final with the annotation.
This way it isn't a hard BC break but users in dev environment will receive a deprecation that the class is not supposed to be extended from. But still they can extend the class until the next major version. This way we allow the users (our we internally) some time to migrate extended classes or re-open the the class to be extended (just remove the annotation and deprecation notice).

Users will see this kind of deprecation:

```
User Deprecated: The "FQCN" class is considered final since version 5.0. It may change without further notice as of its next major version. You should not extend it from "FQCN".
```

- By closing the command we can do already some work for the future
  - Register commands as services (will be the default way in SF4)
  - Tag the commands as "console.command" because the auto-registration was deprecated in 3.4

**Next up**

In version 6 we should replace the `extend ContainerAwareCommand` by just `extend Command`, remove the `$this->getContainer()` usages and remove the BC layer from the constructor of the commands. I've added `NEXT_MAJOR` docblocks to easily search things we should change/cleanup in version 6
