### PR TITLE
[NodeBundle][5.1] Commands as services and mark commands as final

### DIFF
--- a/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
+++ b/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
@@ -2,14 +2,59 @@
 
 namespace Kunstmaan\NodeBundle\Command;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Entity\QueuedNodeTranslationAction;
+use Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
+/**
+ * @final since 5.1
+ * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
+ */
 class CronUpdateNodeCommand extends ContainerAwareCommand
 {
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
+    /**
+     * @var TokenStorage
+     */
+    private $tokenStorage;
+
+    /**
+     * @var NodeAdminPublisher
+     */
+    private $nodePublisher;
+
+    /**
+     * @param EntityManagerInterface|null $em
+     * @param TokenStorage|null           $tokenStorage
+     * @param NodeAdminPublisher|null     $nodePublisher
+     */
+    public function __construct(/* EntityManagerInterface */ $em = null, /* TokenStorage */$tokenStorage = null, /* NodeAdminPublisher */ $nodePublisher = null)
+    {
+        parent::__construct();
+
+        if (!$em instanceof EntityManagerInterface) {
+            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+
+            $this->setName(null === $em ? 'kuma:nodes:cron' : $em);
+
+            return;
+        }
+
+        $this->em = $em;
+        $this->tokenStorage = $tokenStorage;
+        $this->nodePublisher = $nodePublisher;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -27,9 +72,13 @@ class CronUpdateNodeCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        if (null === $this->em) {
+            $this->em = $this->getContainer()->get('doctrine.orm.entity_manager');
+            $this->tokenStorage = $this->getContainer()->get('security.token_storage');
+            $this->nodePublisher = $this->getContainer()->get('kunstmaan_node.admin_node.publisher');
+        }
 
-        $queuedNodeTranslationActions = $em->getRepository('KunstmaanNodeBundle:QueuedNodeTranslationAction')->findAll();
+        $queuedNodeTranslationActions = $this->em->getRepository('KunstmaanNodeBundle:QueuedNodeTranslationAction')->findAll();
 
         if (count($queuedNodeTranslationActions)) {
             foreach ($queuedNodeTranslationActions as $queuedNodeTranslationAction) {
@@ -40,16 +89,16 @@ class CronUpdateNodeCommand extends ContainerAwareCommand
                         // Set user security context
                         $user = $queuedNodeTranslationAction->getUser();
                         $runAsToken = new UsernamePasswordToken($user, null, 'foo', $user->getRoles());
-                        $this->getContainer()->get('security.token_storage')->setToken($runAsToken);
+                        $this->tokenStorage->setToken($runAsToken);
                     }
                     $nodeTranslation = $queuedNodeTranslationAction->getNodeTranslation();
                     switch ($action) {
                         case QueuedNodeTranslationAction::ACTION_PUBLISH:
-                            $this->getContainer()->get('kunstmaan_node.admin_node.publisher')->publish($nodeTranslation, $user);
+                            $this->nodePublisher->publish($nodeTranslation, $user);
                             $output->writeln("Published the page " . $nodeTranslation->getTitle());
                             break;
                         case QueuedNodeTranslationAction::ACTION_UNPUBLISH:
-                            $this->getContainer()->get('kunstmaan_node.admin_node.publisher')->unPublish($nodeTranslation);
+                            $this->nodePublisher->unPublish($nodeTranslation);
                             $output->writeln("Unpublished the page " . $nodeTranslation->getTitle());
                             break;
                         default:

--- a/src/Kunstmaan/NodeBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/commands.yml
@@ -1,0 +1,16 @@
+services:
+    Kunstmaan\NodeBundle\Command\InitAclCommand:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@security.acl.provider'
+            - '@security.acl.object_identity_retrieval_strategy'
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\NodeBundle\Command\CronUpdateNodeCommand:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@security.token_storage'
+            - '@kunstmaan_node.admin_node.publisher'
+        tags:
+            - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

**Changes**
- Mark the class final with the annotation.
This way it isn't a hard BC break but users in dev environment will receive a deprecation that the class is not supposed to be extended from. But still they can extend the class until the next major version. This way we allow the users (our we internally) some time to migrate extended classes or re-open the the class to be extended (just remove the annotation and deprecation notice).

Users will see this kind of deprecation:

```
User Deprecated: The "FQCN" class is considered final since version 5.0. It may change without further notice as of its next major version. You should not extend it from "FQCN".
```

- By closing the command we can do already some work for the future
  - Register commands as services (will be the default way in SF4)
  - Tag the commands as "console.command" because the auto-registration was deprecated in 3.4

**Next up**

In version 6 we should replace the `extend ContainerAwareCommand` by just `extend Command`, remove the `$this->getContainer()` usages and remove the BC layer from the constructor of the commands. I've added `NEXT_MAJOR` docblocks to easily search things we should change/cleanup in version 6
