### PR TITLE
[KunstmaanNodeSearchBundle] add keyword as data type

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
         $properties = $rootNode->children()->arrayNode('mapping')->useAttributeAsKey('name')->prototype('array');
 
         $properties->children()->scalarNode('type')->beforeNormalization()->ifNotInArray($types = [
-            'string', 'token_count', 'text',
+            'string', 'token_count', 'text', 'keyword',
             'float', 'double', 'byte', 'short', 'integer', 'long',
             'date',
             'boolean',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

As of elasticsearch 5.x, the string data type is deprecated and replaced by "keyword" and "text". 

https://www.elastic.co/guide/en/elasticsearch/reference/5.5/string.html

When having old indexes with the string datatype, it will stil work because elasticsearch is able to auto upgrade those fields. But when you have special types, the auto upgrade does not work and we need to be able to use the "keyword" datatype. 
