### PR TITLE
[GeneratorBundle] Fix missing browser sync option for generate commands

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -47,6 +47,7 @@ EOT
             ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace to generate the default website in')
             ->addOption('prefix', '', InputOption::VALUE_OPTIONAL, 'The prefix to be used in the table names of the generated entities')
             ->addOption('demosite', '', InputOption::VALUE_NONE, 'Whether to generate a website with demo contents or a basic website')
+            ->addOption('browsersync', '', InputOption::VALUE_OPTIONAL, 'The URI that will be used for browsersync to connect')
             ->setName('kuma:generate:default-site');
     }
 
@@ -82,12 +83,15 @@ EOT
          */
         $this->demosite = $this->assistant->getOption('demosite');
 
+        $browserSyncUrl = $this->assistant->getOptionOrDefault('browsersync', null);
+
         // First we generate the layout if it is not yet generated
         $command = $this->getApplication()->find('kuma:generate:layout');
         $arguments = array(
             'command'      => 'kuma:generate:layout',
             '--namespace'  => str_replace('\\', '/', $this->bundle->getNamespace()),
             '--demosite'   => $this->demosite,
+            '--browsersync' => $browserSyncUrl,
             '--subcommand' => true
         );
         $input = new ArrayInput($arguments);

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
@@ -36,6 +36,7 @@ EOT
             ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace of the bundle where we need to create the layout in')
             ->addOption('subcommand', '', InputOption::VALUE_OPTIONAL, 'Whether the command is called from an other command or not')
             ->addOption('demosite', '', InputOption::VALUE_NONE, 'Pass this parameter when the demosite styles/javascipt should be generated')
+            ->addOption('browsersync', '', InputOption::VALUE_OPTIONAL, 'The URI that will be used for browsersync to connect')
             ->setName('kuma:generate:layout');
     }
 
@@ -60,6 +61,7 @@ EOT
             $this->assistant->writeSection('Layout generation');
         }
 
+        $this->browserSyncUrl = $this->assistant->getOptionOrDefault('browsersync', null);
         $rootDir = $this->getApplication()->getKernel()->getRootDir().'/../';
         $this->createGenerator()->generate($this->bundle, $rootDir, $this->assistant->getOption('demosite'), $this->browserSyncUrl);
 
@@ -83,7 +85,9 @@ EOT
         $bundleNamespace = $this->assistant->getOptionOrDefault('namespace', null);
         $this->bundle = $this->askForBundleName('layout', $bundleNamespace);
 
-        $this->browserSyncUrl = $this->assistant->ask('Which URL would you like to configure for browserSync?', 'http://myproject.dev');
+        if (null === $this->browserSyncUrl) {
+            $this->browserSyncUrl = $this->assistant->ask('Which URL would you like to configure for browserSync?', 'http://myproject.dev');
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1774 

This allows to add the browserSync url from the command line.
