### PR TITLE
[Leadgenerationbundle]: abstract functions should be public

### DIFF
--- a/src/Kunstmaan/LeadGenerationBundle/Entity/Popup/AbstractPopup.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Entity/Popup/AbstractPopup.php
@@ -195,10 +195,10 @@ abstract class AbstractPopup implements EntityInterface
      *
      * @return string
      */
-    abstract protected function getControllerAction();
+    abstract public function getControllerAction();
 
     /**
      * @return string
      */
-    abstract protected function getAdminType();
+    abstract public function getAdminType();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Abstract function should be public because it's being called outside the entity.
