### PR TITLE
[WIP][AllBundles]: Deprecate NodePagesConfiguration

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -1,0 +1,8 @@
+# UPGRADE FROM 5.0 to 5.1
+
+## Deprecate use of old service id's
+
+PR https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/1814 introduces the use of FQCN as service id's instead of the old id's.
+Therefore we added child definitions for the old service id's to still work.
+When you are still using the old service id's in your project, you will get deprecation messages.
+In KunstmaanBundlesCMS 6.0 the old service id's will be removed, so be sure to update your custom bundles.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
     "name": "kunstmaan/bundles-cms",
     "type": "library",
     "description": "The Kunstmaan Bundles CMS is an advanced yet user-friendly content management system, based on the full stack Symfony framework combined with a whole host of community bundles. It provides a full featured, multi-language CMS system with an innovative page and form assembling process, versioning, workflow, translation and media managers and much more.",
-    "keywords": ["cms"],
+    "keywords": [
+        "cms"
+    ],
     "homepage": "http://bundles.kunstmaan.be",
     "license": "MIT",
     "authors": [
@@ -29,7 +31,6 @@
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
-
         "friendsofsymfony/user-bundle": "~2.0",
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzlehttp/guzzle": "~6.1",
@@ -90,8 +91,13 @@
         "kunstmaan/languagechooser-bundle": "self.version",
         "kunstmaan/tagging-bundle": "self.version"
     },
+    "conflict": {
+        "friendsofsymfony/user-bundle": "<2.0.2"
+    },
     "autoload": {
-        "psr-4": {"Kunstmaan\\": "src/Kunstmaan/"}
+        "psr-4": {
+            "Kunstmaan\\": "src/Kunstmaan/"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/docs/05-09-using-the-multi-domain-bundle.md
+++ b/docs/05-09-using-the-multi-domain-bundle.md
@@ -96,10 +96,10 @@ current browser session.
     firewalls:
         main:
             pattern: ^/([^/]*)/admin
+            provider: fos_userbundle
             form_login:
                 login_path: fos_user_security_login
                 check_path: fos_user_security_check
-                provider: fos_userbundle
             logout:
                 path:   fos_user_security_logout
                 target: KunstmaanAdminBundle_homepage

--- a/docs/05-14-enabling-google-auth-login.md
+++ b/docs/05-14-enabling-google-auth-login.md
@@ -32,6 +32,7 @@ security:
         main:
             pattern: .*
             guard:
+                provider: fos_userbundle
                 authenticators:
                     - kunstmaan_admin.oauth_authenticator
             form_login:

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/AdminPanelCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/AdminPanelCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\AdminBundle\Helper\AdminPanel\AdminPanel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -16,11 +17,11 @@ class AdminPanelCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_admin.admin_panel')) {
+        if (!$container->hasDefinition(AdminPanel::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_admin.admin_panel');
+        $definition = $container->getDefinition(AdminPanel::class);
 
         foreach ($container->findTaggedServiceIds('kunstmaan_admin.admin_panel.adaptor') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DataCollectorPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\AdminBundle\Helper\Toolbar\DataCollector;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -16,11 +17,11 @@ class DataCollectorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_admin.toolbar.datacollector')) {
+        if (!$container->hasDefinition(DataCollector::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_admin.toolbar.datacollector');
+        $definition = $container->getDefinition(DataCollector::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_admin.toolbar_collector');
 
         // Check if debug enabled

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\AdminBundle\EventListener\AdminLocaleListener;
+use Kunstmaan\AdminBundle\EventListener\CloneListener;
+use Kunstmaan\AdminBundle\EventListener\ExceptionSubscriber;
+use Kunstmaan\AdminBundle\EventListener\LoginListener;
+use Kunstmaan\AdminBundle\EventListener\MappingListener;
+use Kunstmaan\AdminBundle\EventListener\PasswordCheckListener;
+use Kunstmaan\AdminBundle\EventListener\PasswordResettingListener;
+use Kunstmaan\AdminBundle\EventListener\SessionSecurityListener;
+use Kunstmaan\AdminBundle\EventListener\ToolbarListener;
+use Kunstmaan\AdminBundle\Form\ColorType;
+use Kunstmaan\AdminBundle\Form\RangeType;
+use Kunstmaan\AdminBundle\Form\WysiwygType;
+use Kunstmaan\AdminBundle\Helper\AdminPanel\AdminPanel;
+use Kunstmaan\AdminBundle\Helper\AdminPanel\DefaultAdminPanelAdaptor;
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
+use Kunstmaan\AdminBundle\Helper\CloneHelper;
+use Kunstmaan\AdminBundle\Helper\Creators\ACLPermissionCreator;
+use Kunstmaan\AdminBundle\Helper\DomainConfiguration;
+use Kunstmaan\AdminBundle\Helper\FormHelper;
+use Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder;
+use Kunstmaan\AdminBundle\Helper\Menu\ModulesMenuAdaptor;
+use Kunstmaan\AdminBundle\Helper\Menu\SettingsMenuAdaptor;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\AclNativeHelper;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Voter\AclVoter;
+use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreator;
+use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserFinder;
+use Kunstmaan\AdminBundle\Helper\Toolbar\DataCollector;
+use Kunstmaan\AdminBundle\Helper\UserProcessor;
+use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
+use Kunstmaan\AdminBundle\Security\OAuthAuthenticator;
+use Kunstmaan\AdminBundle\Toolbar\BundleVersionDataCollector;
+use Kunstmaan\AdminBundle\Toolbar\ExceptionDataCollector;
+use Kunstmaan\AdminBundle\Twig\AdminPermissionsTwigExtension;
+use Kunstmaan\AdminBundle\Twig\AdminRouteHelperTwigExtension;
+use Kunstmaan\AdminBundle\Twig\DateByLocaleExtension;
+use Kunstmaan\AdminBundle\Twig\FormToolsExtension;
+use Kunstmaan\AdminBundle\Twig\GoogleSignInTwigExtension;
+use Kunstmaan\AdminBundle\Twig\LocaleSwitcherTwigExtension;
+use Kunstmaan\AdminBundle\Twig\MenuTwigExtension;
+use Kunstmaan\AdminBundle\Twig\MultiDomainAdminTwigExtension;
+use Kunstmaan\AdminBundle\Twig\SidebarTwigExtension;
+use Kunstmaan\AdminBundle\Twig\TabsTwigExtension;
+use Kunstmaan\AdminBundle\Twig\ToolbarTwigExtension;
+use Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictionsValidator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\AdminBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_admin.menubuilder', MenuBuilder::class],
+                ['kunstmaan_admin.admin_panel', AdminPanel::class],
+                ['kunstmaan_admin.menu.adaptor.modules', ModulesMenuAdaptor::class],
+                ['kunstmaan_admin.menu.adaptor.settings', SettingsMenuAdaptor::class],
+                ['kunstmaan_admin.login.listener', LoginListener::class],
+                ['kunstmaan_admin.admin_locale.listener', AdminLocaleListener::class],
+                ['kunstmaan_admin.menu.twig.extension', MenuTwigExtension::class],
+                ['kunstmaan_admin.localeswitcher.twig.extension', LocaleSwitcherTwigExtension::class],
+                ['kunstmaan_admin.multidomain.twig.extension', MultiDomainAdminTwigExtension::class],
+                ['kunstmaan_admin.locale.twig.extension', DateByLocaleExtension::class],
+                ['kunstmaan_admin.formtools.twig.extension', FormToolsExtension::class],
+                ['kunstmaan_admin.permissions.twig.extension', AdminPermissionsTwigExtension::class],
+                ['kunstmaan_admin.acl.helper', AclHelper::class],
+                ['kunstmaan_admin.acl.native.helper', AclNativeHelper::class],
+                ['kunstmaan_admin.security.acl.permission.map', PermissionMap::class],
+                ['kunstmaan_admin.security.acl.voter', AclVoter::class, false],
+                ['kunstmaan_admin.permissionadmin', PermissionAdmin::class],
+                ['kunstmaan_admin.clone.helper', CloneHelper::class],
+                ['kunstmaan_admin.adminroute.helper', AdminRouteHelper::class],
+                ['kunstmaan_admin.adminroute.twig.extension', AdminRouteHelperTwigExtension::class],
+                ['kunstmaan_admin.clone.listener', CloneListener::class],
+                ['kunstmaan_admin.logger.processor.user', UserProcessor::class],
+                ['kunstmaan_admin.form.helper', FormHelper::class],
+                ['kunstmaan_admin.tabs.twig.extension', TabsTwigExtension::class],
+                ['kunstmaan_admin.permission_creator', ACLPermissionCreator::class],
+                ['kunstmaan_admin.versionchecker', VersionChecker::class],
+                ['kunstmaan_admin.form.type.color', ColorType::class],
+                ['kunstmaan_admin.doctrine_mapping.listener', MappingListener::class],
+                ['kunstmaan_admin.form.type.range', RangeType::class],
+                ['kunstmaan_admin.session_security', RangeType::class],
+                ['kunstmaan_form.type.wysiwyg', WysiwygType::class],
+                ['kunstmaan_admin.password_resetting.listener', WysiwygType::class],
+                ['kunstmaan_admin.password_check.listener', WysiwygType::class],
+                ['kunstmaan_admin.admin_panel.adaptor', DefaultAdminPanelAdaptor::class],
+                ['kunstmaan_admin.domain_configuration', DomainConfiguration::class],
+                ['kunstmaan_admin.oauth_authenticator', OAuthAuthenticator::class],
+                ['kunstmaan_admin.oauth_user_creator', OAuthUserCreator::class],
+                ['kunstmaan_admin.oauth_user_finder', OAuthUserFinder::class],
+                ['kunstmaan_admin.google_signin.twig.extension', GoogleSignInTwigExtension::class],
+                ['kunstmaan_admin.sidebar.twig.extension', SidebarTwigExtension::class],
+                ['kunstmaan_admin.validator.password_restrictions', PasswordRestrictionsValidator::class],
+                ['kunstmaan_admin.exception.listener', ExceptionSubscriber::class],
+                ['kunstmaan_admin.toolbar.twig.extension', ToolbarTwigExtension::class],
+                ['kunstmaan_admin.toolbar.datacollector', DataCollector::class],
+                ['kunstmaan_admin.toolbar.listener', ToolbarListener::class],
+                ['kunstmaan_admin.datacollector.bundleversion', BundleVersionDataCollector::class],
+                ['kunstmaan_admin.datacollector.exception', ExceptionDataCollector::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_admin.security.acl.permission.map.class', PermissionMap::class],
+                ['kunstmaan_admin.menubuilder.class', MenuBuilder::class],
+                ['kunstmaan_admin.admin_panel.class', AdminPanel::class],
+                ['kunstmaan_admin.login.listener.class', LoginListener::class],
+                ['kunstmaan_admin.admin_locale.listener.class', AdminLocaleListener::class],
+                ['kunstmaan_admin.acl.helper.class', AclHelper::class],
+                ['kunstmaan_admin.acl.native.helper.class', AclNativeHelper::class],
+                ['kunstmaan_admin.clone.listener.class', CloneListener::class],
+                ['kunstmaan_admin.session_security.class', SessionSecurityListener::class],
+                ['kunstmaan_admin.password_resetting.listener.class', PasswordResettingListener::class],
+                ['kunstmaan_admin.password_check.listener.class', PasswordCheckListener::class],
+                ['kunstmaan_admin.domain_configuration.class', DomainConfiguration::class],
+                ['kunstmaan_admin.validator.password_restrictions.class', PasswordRestrictionsValidator::class],
+                ['kunstmaan_admin.adminroute.helper.class', AdminRouteHelper::class],
+                ['kunstmaan_admin.adminroute.twig.class', AdminRouteHelperTwigExtension::class],
+                ['kunstmaan_admin.exception.listener.class', ExceptionSubscriber::class],
+                ['kunstmaan_admin.toolbar.listener.class', ToolbarListener::class],
+                ['kunstmaan_admin.toolbar.collector.bundle.class', BundleVersionDataCollector::class],
+                ['kunstmaan_admin.toolbar.collector.exception.class', ExceptionDataCollector::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanAdminBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanAdminBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/MenuCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/MenuCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -16,11 +17,11 @@ class MenuCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_admin.menubuilder')) {
+        if (!$container->hasDefinition(MenuBuilder::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_admin.menubuilder');
+        $definition = $container->getDefinition(MenuBuilder::class);
 
         foreach ($container->findTaggedServiceIds('kunstmaan_admin.menu.adaptor') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -4,8 +4,12 @@ namespace Kunstmaan\AdminBundle\DependencyInjection;
 
 use FOS\UserBundle\Form\Type\ResettingFormType;
 use InvalidArgumentException;
-
+use Kunstmaan\AdminBundle\Entity\Group;
+use Kunstmaan\AdminBundle\Entity\User;
+use Kunstmaan\AdminBundle\Helper\DomainConfiguration;
+use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -32,7 +36,7 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
     public function load(array $configs, ContainerBuilder $container)
     {
         $container->setParameter('version_checker.url', 'https://bundles.kunstmaan.be/version-check');
-        $container->setParameter('version_checker.timeframe', 60*60*24);
+        $container->setParameter('version_checker.timeframe', 60 * 60 * 24);
         $container->setParameter('version_checker.enabled', true);
 
         $configuration = new Configuration();
@@ -59,11 +63,14 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_admin.google_signin.client_secret', $config['google_signin']['client_secret']);
         $container->setParameter('kunstmaan_admin.google_signin.hosted_domains', $config['google_signin']['hosted_domains']);
 
-        $container->setParameter('kunstmaan_admin.password_restrictions.min_digits' , $config['password_restrictions']['min_digits']);
-        $container->setParameter('kunstmaan_admin.password_restrictions.min_uppercase' , $config['password_restrictions']['min_uppercase']);
-        $container->setParameter('kunstmaan_admin.password_restrictions.min_special_characters' , $config['password_restrictions']['min_special_characters']);
-        $container->setParameter('kunstmaan_admin.password_restrictions.min_length' , $config['password_restrictions']['min_length']);
-        $container->setParameter('kunstmaan_admin.password_restrictions.max_length' , $config['password_restrictions']['max_length']);
+        $container->setParameter('kunstmaan_admin.password_restrictions.min_digits', $config['password_restrictions']['min_digits']);
+        $container->setParameter('kunstmaan_admin.password_restrictions.min_uppercase', $config['password_restrictions']['min_uppercase']);
+        $container->setParameter(
+            'kunstmaan_admin.password_restrictions.min_special_characters',
+            $config['password_restrictions']['min_special_characters']
+        );
+        $container->setParameter('kunstmaan_admin.password_restrictions.min_length', $config['password_restrictions']['min_length']);
+        $container->setParameter('kunstmaan_admin.password_restrictions.max_length', $config['password_restrictions']['max_length']);
         $container->setParameter('kunstmaan_admin.enable_toolbar_helper', $config['enable_toolbar_helper']);
         $container->setParameter('kunstmaan_admin.provider_keys', $config['provider_keys']);
 
@@ -74,34 +81,45 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
             $loader->load('console_listener.yml');
         }
 
-        if (0 !== count($config['menu_items'])) {
+        if (0 !== \count($config['menu_items'])) {
             $this->addSimpleMenuAdaptor($container, $config['menu_items']);
         }
+
+        $container->setAlias(DomainConfigurationInterface::class, new Alias(DomainConfiguration::class));
     }
 
+    /**
+     * @param ContainerBuilder $container
+     */
     public function prepend(ContainerBuilder $container)
     {
-        $knpMenuConfig['twig']              = true; // set to false to disable the Twig extension and the TwigRenderer
-        $knpMenuConfig['templating']        = false; // if true, enables the helper for PHP templates
-        $knpMenuConfig['default_renderer']  = 'twig'; // The renderer to use, list is also available by default
+        $knpMenuConfig['twig'] = true; // set to false to disable the Twig extension and the TwigRenderer
+        $knpMenuConfig['templating'] = false; // if true, enables the helper for PHP templates
+        $knpMenuConfig['default_renderer'] = 'twig'; // The renderer to use, list is also available by default
         $container->prependExtensionConfig('knp_menu', $knpMenuConfig);
 
-        $fosUserConfig['db_driver']                     = 'orm'; // other valid values are 'mongodb', 'couchdb'
-        $fosUserConfig['firewall_name']                 = 'main';
-        $fosUserConfig['user_class']                    = 'Kunstmaan\AdminBundle\Entity\User';
-        $fosUserConfig['group']['group_class']          = 'Kunstmaan\AdminBundle\Entity\Group';
-        $fosUserConfig['resetting']['token_ttl']        = 86400;
+        $fosUserConfig['db_driver'] = 'orm'; // other valid values are 'mongodb', 'couchdb'
+        $fosUserConfig['from_email']['address'] = 'admin@kunstmaan.be';
+        $fosUserConfig['from_email']['sender_name'] = 'admin';
+        $fosUserConfig['firewall_name'] = 'main';
+        $fosUserConfig['user_class'] = User::class;
+        $fosUserConfig['group']['group_class'] = Group::class;
+        $fosUserConfig['resetting']['token_ttl'] = 86400;
         // Use this node only if you don't want the global email address for the resetting email
-        $fosUserConfig['resetting']['email']['from_email']['address']        = 'admin@kunstmaan.be';
-        $fosUserConfig['resetting']['email']['from_email']['sender_name']    = 'admin';
-        $fosUserConfig['resetting']['email']['template']    = 'FOSUserBundle:Resetting:email.txt.twig';
-        $fosUserConfig['resetting']['form']['type']                 = ResettingFormType::class;
-        $fosUserConfig['resetting']['form']['name']                 = 'fos_user_resetting_form';
-        $fosUserConfig['resetting']['form']['validation_groups']    = ['ResetPassword'];
+        $fosUserConfig['resetting']['email']['from_email']['address'] = 'admin@kunstmaan.be';
+        $fosUserConfig['resetting']['email']['from_email']['sender_name'] = 'admin';
+        $fosUserConfig['resetting']['email']['template'] = 'FOSUserBundle:Resetting:email.txt.twig';
+        $fosUserConfig['resetting']['form']['type'] = ResettingFormType::class;
+        $fosUserConfig['resetting']['form']['name'] = 'fos_user_resetting_form';
+        $fosUserConfig['resetting']['form']['validation_groups'] = ['ResetPassword'];
         $container->prependExtensionConfig('fos_user', $fosUserConfig);
 
-        $monologConfig['handlers']['main']['type']  = 'rotating_file';
-        $monologConfig['handlers']['main']['path']  = sprintf('%s/%s', $container->getParameter('kernel.logs_dir'), $container->getParameter('kernel.environment'));
+        $monologConfig['handlers']['main']['type'] = 'rotating_file';
+        $monologConfig['handlers']['main']['path'] = sprintf(
+            '%s/%s',
+            $container->getParameter('kernel.logs_dir'),
+            $container->getParameter('kernel.environment')
+        );
         $monologConfig['handlers']['main']['level'] = 'debug';
         $container->prependExtensionConfig('monolog', $monologConfig);
 
@@ -125,12 +143,18 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         return __DIR__.'/../Resources/config/schema';
     }
 
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $menuItems
+     */
     private function addSimpleMenuAdaptor(ContainerBuilder $container, array $menuItems)
     {
-        $definition = new Definition('Kunstmaan\AdminBundle\Helper\Menu\SimpleMenuAdaptor', [
-            new Reference('security.authorization_checker'),
-            $menuItems
-        ]);
+        $definition = new Definition(
+            'Kunstmaan\AdminBundle\Helper\Menu\SimpleMenuAdaptor', [
+                new Reference('security.authorization_checker'),
+                $menuItems,
+            ]
+        );
         $definition->addTag('kunstmaan_admin.menu.adaptor');
 
         $container->setDefinition('kunstmaan_admin.menu.adaptor.simple', $definition);

--- a/src/Kunstmaan/AdminBundle/EventListener/ExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ExceptionSubscriber.php
@@ -9,6 +9,11 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+/**
+ * Class ExceptionSubscriber
+ *
+ * @package Kunstmaan\AdminBundle\EventListener
+ */
 class ExceptionSubscriber implements EventSubscriberInterface
 {
     /**
@@ -27,14 +32,15 @@ class ExceptionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::EXCEPTION => 'onKernelException'
+            KernelEvents::EXCEPTION => 'onKernelException',
         ];
     }
 
     /**
      * ExceptionSubscriber constructor.
+     *
      * @param EntityManagerInterface $em
-     * @param array $excludes
+     * @param array                  $excludes
      */
     public function __construct(EntityManagerInterface $em, array $excludes = [])
     {
@@ -53,13 +59,16 @@ class ExceptionSubscriber implements EventSubscriberInterface
         if ($exception instanceof HttpExceptionInterface) {
             $uri = $request->getUri();
 
-            if(count($this->excludes) > 0) {
-                $excludes = array_filter($this->excludes, function($pattern) use($uri) {
-                   return preg_match($pattern, $uri);
-                });
+            if (count($this->excludes) > 0) {
+                $excludes = array_filter(
+                    $this->excludes,
+                    function ($pattern) use ($uri) {
+                        return preg_match($pattern, $uri);
+                    }
+                );
 
-                if(count($excludes) > 0) {
-                    return ;
+                if (count($excludes) > 0) {
+                    return;
                 }
             }
 

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -3,14 +3,14 @@
 namespace Kunstmaan\AdminBundle\EventListener;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Routing\RouterInterface as Router;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 
 /**
  * PasswordCheckListener to check if the user has to change his password
@@ -33,7 +33,7 @@ class PasswordCheckListener
     private $router;
 
     /**
-     * @var Session
+     * @var SessionInterface
      */
     private $session;
 
@@ -49,14 +49,20 @@ class PasswordCheckListener
 
     /**
      * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param TokenStorageInterface $tokenStorage
-     * @param Router $router
-     * @param Session $session
-     * @param TranslatorInterface $translator
-     * @param AdminRouteHelper $adminRouteHelper
+     * @param TokenStorageInterface         $tokenStorage
+     * @param Router                        $router
+     * @param SessionInterface              $session
+     * @param TranslatorInterface           $translator
+     * @param AdminRouteHelper              $adminRouteHelper
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, TokenStorageInterface $tokenStorage, Router $router, Session $session, TranslatorInterface $translator, AdminRouteHelper $adminRouteHelper)
-    {
+    public function __construct(
+        AuthorizationCheckerInterface $authorizationChecker,
+        TokenStorageInterface $tokenStorage,
+        Router $router,
+        SessionInterface $session,
+        TranslatorInterface $translator,
+        AdminRouteHelper $adminRouteHelper
+    ) {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
         $this->router = $router;
@@ -73,7 +79,7 @@ class PasswordCheckListener
         $url = $event->getRequest()->getRequestUri();
         if ($this->tokenStorage->getToken() && $this->adminRouteHelper->isAdminRoute($url)) {
             $route = $event->getRequest()->get('_route');
-            if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') && $route != 'fos_user_change_password') {
+            if ($route !== 'fos_user_change_password' && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
                 $user = $this->tokenStorage->getToken()->getUser();
                 if ($user->isPasswordChanged() === false) {
                     $response = new RedirectResponse($this->router->generate('fos_user_change_password'));

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordResettingListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordResettingListener.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\AdminBundle\EventListener;
 
 use FOS\UserBundle\Event\FilterUserResponseEvent;
-use FOS\UserBundle\Model\UserManager;
+use FOS\UserBundle\Model\UserManagerInterface;
 
 /**
  * Set password_changed property to 1 after changing the password
@@ -11,14 +11,14 @@ use FOS\UserBundle\Model\UserManager;
 class PasswordResettingListener
 {
     /**
-     * @var UserManager
+     * @var UserManagerInterface
      */
     private $userManager;
 
     /**
-     * @param UserManager $userManager
+     * @param UserManagerInterface $userManager
      */
-    public function __construct(UserManager $userManager)
+    public function __construct(UserManagerInterface $userManager)
     {
         $this->userManager = $userManager;
     }

--- a/src/Kunstmaan/AdminBundle/EventListener/ToolbarListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ToolbarListener.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class ToolbarListener implements EventSubscriberInterface
 {
@@ -36,7 +36,7 @@ class ToolbarListener implements EventSubscriberInterface
     protected $dataCollector;
 
     /**
-     * @var AuthorizationChecker
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -68,21 +68,21 @@ class ToolbarListener implements EventSubscriberInterface
     /**
      * ToolbarListener constructor.
      *
-     * @param \Twig_Environment     $twig
-     * @param UrlGeneratorInterface $urlGenerator
-     * @param DataCollector         $dataCollector
-     * @param AuthorizationChecker  $authorizationChecker
-     * @param TokenStorageInterface $tokenStorage
-     * @param bool                  $enabled
-     * @param ContainerInterface    $container
-     * @param AdminRouteHelper      $adminRouteHelper
-     * @param array                 $providerKeys
+     * @param \Twig_Environment             $twig
+     * @param UrlGeneratorInterface         $urlGenerator
+     * @param DataCollector                 $dataCollector
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param TokenStorageInterface         $tokenStorage
+     * @param bool                          $enabled
+     * @param ContainerInterface            $container
+     * @param AdminRouteHelper              $adminRouteHelper
+     * @param array                         $providerKeys
      */
     public function __construct(
         \Twig_Environment $twig,
         UrlGeneratorInterface $urlGenerator,
         DataCollector $dataCollector,
-        AuthorizationChecker $authorizationChecker,
+        AuthorizationCheckerInterface $authorizationChecker,
         TokenStorageInterface $tokenStorage,
         $enabled,
         ContainerInterface $container,

--- a/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
 use Kunstmaan\AdminBundle\Event\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -12,9 +12,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class CloneHelper
 {
-
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -24,10 +23,10 @@ class CloneHelper
     private $eventDispatcher;
 
     /**
-     * @param EntityManager            $em              The EntityManager
+     * @param EntityManagerInterface   $em              The EntityManager
      * @param EventDispatcherInterface $eventDispatcher The EventDispatchInterface
      */
-    public function __construct(EntityManager $em, EventDispatcherInterface $eventDispatcher)
+    public function __construct(EntityManagerInterface $em, EventDispatcherInterface $eventDispatcher)
     {
         $this->em = $em;
         $this->eventDispatcher = $eventDispatcher;
@@ -41,14 +40,13 @@ class CloneHelper
     public function deepCloneAndSave($entity)
     {
         $clonedEntity = clone $entity;
-        $this->eventDispatcher->dispatch(Events::DEEP_CLONE_AND_SAVE, new DeepCloneAndSaveEvent($entity, $clonedEntity, $this->em));
+        $this->eventDispatcher->dispatch(Events::DEEP_CLONE_AND_SAVE, new DeepCloneAndSaveEvent($entity, $clonedEntity));
 
         $this->em->persist($clonedEntity);
         $this->em->flush();
 
-        $this->eventDispatcher->dispatch(Events::POST_DEEP_CLONE_AND_SAVE, new DeepCloneAndSaveEvent($entity, $clonedEntity, $this->em));
+        $this->eventDispatcher->dispatch(Events::POST_DEEP_CLONE_AND_SAVE, new DeepCloneAndSaveEvent($entity, $clonedEntity));
 
         return $clonedEntity;
     }
-
 }

--- a/src/Kunstmaan/AdminBundle/Helper/Creators/ACLPermissionCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Creators/ACLPermissionCreator.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle\Helper\Creators;
 
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Acl\Model\EntryInterface;
 use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterfac
 class ACLPermissionCreator
 {
     /**
-     * @var MutableAclProviderInterface
+     * @var AclProviderInterface
      */
     private $aclProvider;
 

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\AdminBundle\Helper\Security\Acl;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\MaskBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionDefinition;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Role\RoleInterface;
 class AclNativeHelper
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em = null;
 
@@ -36,15 +36,15 @@ class AclNativeHelper
     /**
      * Constructor.
      *
-     * @param EntityManager            $em The entity manager
-     * @param TokenStorageInterface    $tokenStorage The security context
-     * @param RoleHierarchyInterface   $rh The role hierarchies
+     * @param EntityManagerInterface $em           The entity manager
+     * @param TokenStorageInterface  $tokenStorage The security context
+     * @param RoleHierarchyInterface $rh           The role hierarchies
      */
-    public function __construct(EntityManager $em, TokenStorageInterface $tokenStorage, RoleHierarchyInterface $rh)
+    public function __construct(EntityManagerInterface $em, TokenStorageInterface $tokenStorage, RoleHierarchyInterface $rh)
     {
-        $this->em              = $em;
-        $this->tokenStorage    = $tokenStorage;
-        $this->roleHierarchy   = $rh;
+        $this->em = $em;
+        $this->tokenStorage = $tokenStorage;
+        $this->roleHierarchy = $rh;
     }
 
     /**
@@ -60,48 +60,48 @@ class AclNativeHelper
         $aclConnection = $this->em->getConnection();
 
         $databasePrefix = is_file($aclConnection->getDatabase()) ? '' : $aclConnection->getDatabase().'.';
-        $rootEntity     = $permissionDef->getEntity();
-        $linkAlias      = $permissionDef->getAlias();
+        $rootEntity = $permissionDef->getEntity();
+        $linkAlias = $permissionDef->getAlias();
         // Only tables with a single ID PK are currently supported
-        $linkField      = $this->em->getClassMetadata($rootEntity)->getSingleIdentifierColumnName();
+        $linkField = $this->em->getClassMetadata($rootEntity)->getSingleIdentifierColumnName();
 
-        $rootEntity = '"' . str_replace('\\', '\\\\', $rootEntity) . '"';
-        $query      = $queryBuilder;
+        $rootEntity = '"'.str_replace('\\', '\\\\', $rootEntity).'"';
+        $query = $queryBuilder;
 
         $builder = new MaskBuilder();
         foreach ($permissionDef->getPermissions() as $permission) {
-            $mask = constant(get_class($builder) . '::MASK_' . strtoupper($permission));
+            $mask = constant(get_class($builder).'::MASK_'.strtoupper($permission));
             $builder->add($mask);
         }
         $mask = $builder->get();
 
         /* @var $token TokenInterface */
-        $token     = $this->tokenStorage->getToken();
-        $userRoles = array();
+        $token = $this->tokenStorage->getToken();
+        $userRoles = [];
         if (!is_null($token)) {
-            $user      = $token->getUser();
+            $user = $token->getUser();
             $userRoles = $this->roleHierarchy->getReachableRoles($token->getRoles());
         }
 
         // Security context does not provide anonymous role automatically.
-        $uR = array('"IS_AUTHENTICATED_ANONYMOUSLY"');
+        $uR = ['"IS_AUTHENTICATED_ANONYMOUSLY"'];
 
         /* @var $role RoleInterface */
         foreach ($userRoles as $role) {
             // The reason we ignore this is because by default FOSUserBundle adds ROLE_USER for every user
             if ($role->getRole() !== 'ROLE_USER') {
-                $uR[] = '"' . $role->getRole() . '"';
+                $uR[] = '"'.$role->getRole().'"';
             }
         }
-        $uR       = array_unique($uR);
+        $uR = array_unique($uR);
         $inString = implode(' OR s.identifier = ', (array) $uR);
 
         if (is_object($user)) {
-            $inString .= ' OR s.identifier = "' . str_replace(
+            $inString .= ' OR s.identifier = "'.str_replace(
                     '\\',
                     '\\\\',
                     get_class($user)
-                ) . '-' . $user->getUserName() . '"';
+                ).'-'.$user->getUserName().'"';
         }
 
         $joinTableQuery = <<<SELECTQUERY
@@ -119,7 +119,7 @@ AND (s.identifier = {$inString})
 AND e.mask & {$mask} > 0
 SELECTQUERY;
 
-        $query->join($linkAlias, '(' . $joinTableQuery . ')', 'perms_', 'perms_.id = ' . $linkAlias . '.' . $linkField);
+        $query->join($linkAlias, '('.$joinTableQuery.')', 'perms_', 'perms_.id = '.$linkAlias.'.'.$linkField);
 
         return $query;
     }

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Helper\Security\Acl\Permission;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
 use Kunstmaan\AdminBundle\Entity\AclChangeset;
 use Kunstmaan\AdminBundle\Entity\Role;
@@ -27,7 +27,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class PermissionAdmin
 {
-    const ADD    = 'ADD';
+    const ADD = 'ADD';
+
     const DELETE = 'DEL';
 
     /**
@@ -36,7 +37,7 @@ class PermissionAdmin
     protected $resource = null;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em = null;
 
@@ -83,7 +84,7 @@ class PermissionAdmin
     /**
      * Constructor
      *
-     * @param EntityManager                            $em                   The EntityManager
+     * @param EntityManagerInterface                   $em                   The EntityManager
      * @param TokenStorageInterface                    $tokenStorage         The token storage
      * @param AclProviderInterface                     $aclProvider          The ACL provider
      * @param ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy The object retrieval strategy
@@ -92,22 +93,21 @@ class PermissionAdmin
      * @param KernelInterface                          $kernel               The kernel
      */
     public function __construct(
-        EntityManager $em,
+        EntityManagerInterface $em,
         TokenStorageInterface $tokenStorage,
         AclProviderInterface $aclProvider,
         ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy,
         EventDispatcherInterface $eventDispatcher,
         Shell $shellHelper,
         KernelInterface $kernel
-    )
-    {
-        $this->em                   = $em;
-        $this->tokenStorage         = $tokenStorage;
-        $this->aclProvider          = $aclProvider;
+    ) {
+        $this->em = $em;
+        $this->tokenStorage = $tokenStorage;
+        $this->aclProvider = $aclProvider;
         $this->oidRetrievalStrategy = $oidRetrievalStrategy;
-        $this->eventDispatcher      = $eventDispatcher;
-        $this->shellHelper          = $shellHelper;
-        $this->kernel               = $kernel;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->shellHelper = $shellHelper;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -118,16 +118,16 @@ class PermissionAdmin
      */
     public function initialize(AbstractEntity $resource, PermissionMapInterface $permissionMap)
     {
-        $this->resource      = $resource;
+        $this->resource = $resource;
         $this->permissionMap = $permissionMap;
-        $this->permissions   = array();
+        $this->permissions = [];
 
         // Init permissions
         try {
             $objectIdentity = $this->oidRetrievalStrategy->getObjectIdentity($this->resource);
             /* @var $acl AclInterface */
-            $acl            = $this->aclProvider->findAcl($objectIdentity);
-            $objectAces     = $acl->getObjectAces();
+            $acl = $this->aclProvider->findAcl($objectIdentity);
+            $objectAces = $acl->getObjectAces();
             /* @var $ace AuditableEntryInterface */
             foreach ($objectAces as $ace) {
                 $securityIdentity = $ace->getSecurityIdentity();
@@ -234,7 +234,7 @@ class PermissionAdmin
             $this->createAclChangeSet($this->resource, $changes, $user);
 
             $cmd = 'php bin/console kuma:acl:apply';
-            $cmd .= ' --env=' . $this->kernel->getEnvironment();
+            $cmd .= ' --env='.$this->kernel->getEnvironment();
 
             $this->shellHelper->runInBackground($cmd);
         }
@@ -298,7 +298,7 @@ class PermissionAdmin
         // Process permissions in changeset
         foreach ($changeset as $role => $roleChanges) {
             $index = $this->getObjectAceIndex($acl, $role);
-            $mask  = 0;
+            $mask = 0;
             if (false !== $index) {
                 $mask = $this->getMaskAtIndex($acl, $index);
             }
@@ -360,9 +360,9 @@ class PermissionAdmin
      */
     private function getMaskAtIndex(AclInterface $acl, $index)
     {
-        $objectAces       = $acl->getObjectAces();
+        $objectAces = $acl->getObjectAces();
         /* @var $ace AuditableEntryInterface */
-        $ace              = $objectAces[$index];
+        $ace = $objectAces[$index];
         $securityIdentity = $ace->getSecurityIdentity();
         if ($securityIdentity instanceof RoleSecurityIdentity) {
             return $ace->getMask();

--- a/src/Kunstmaan/AdminBundle/Helper/Toolbar/AbstractDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Toolbar/AbstractDataCollector.php
@@ -79,4 +79,12 @@ abstract class AbstractDataCollector extends BaseDataCollector implements DataCo
 
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
 }

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -6,6 +6,7 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AddLogProcessorsCompilerP
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AdminPanelCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorAfterPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -29,6 +30,7 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new AdminPanelCompilerPass());
         $container->addCompilerPass(new AddLogProcessorsCompilerPass());
         $container->addCompilerPass(new DataCollectorPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
 
         $container->registerExtension(new KunstmaanAdminExtension());
     }

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -21,123 +21,140 @@ parameters:
     kunstmaan_admin.toolbar.collector.exception.class: 'Kunstmaan\AdminBundle\Toolbar\ExceptionDataCollector'
 
 services:
-    kunstmaan_admin.menubuilder:
-        class: '%kunstmaan_admin.menubuilder.class%'
-        arguments: ['@service_container']
+    Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
 
-    kunstmaan_admin.admin_panel:
-        class: '%kunstmaan_admin.admin_panel.class%'
+    Kunstmaan\AdminBundle\Helper\AdminPanel\AdminPanel: ~
 
-    kunstmaan_admin.menu.adaptor.modules:
-        class: Kunstmaan\AdminBundle\Helper\Menu\ModulesMenuAdaptor
+    Kunstmaan\AdminBundle\Helper\Menu\ModulesMenuAdaptor:
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_admin.menu.adaptor.settings:
-        class: Kunstmaan\AdminBundle\Helper\Menu\SettingsMenuAdaptor
-        arguments: ['@security.authorization_checker', "%version_checker.enabled%"]
+    Kunstmaan\AdminBundle\Helper\Menu\SettingsMenuAdaptor:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - "%version_checker.enabled%"
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_admin.login.listener:
-        class: '%kunstmaan_admin.login.listener.class%'
-        arguments: ['@kunstmaan_admin.logger', '@kunstmaan_admin.versionchecker', '@kunstmaan_admin.adminroute.helper']
+    Kunstmaan\AdminBundle\EventListener\LoginListener:
+        arguments:
+            - '@kunstmaan_admin.logger'
+            - '@Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker'
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
         tags:
             - { name: 'kernel.event_listener', event: 'security.interactive_login' }
 
-    kunstmaan_admin.admin_locale.listener:
-        class: '%kunstmaan_admin.admin_locale.listener.class%'
-        arguments: ['@security.token_storage', '@translator', '@kunstmaan_admin.adminroute.helper', '%kunstmaan_admin.default_admin_locale%', '%kunstmaan_admin.firewall.provider_key%']
+    Kunstmaan\AdminBundle\EventListener\AdminLocaleListener:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@Symfony\Component\Translation\TranslatorInterface'
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
+            - '%kunstmaan_admin.default_admin_locale%'
+            - '%kunstmaan_admin.firewall.provider_key%'
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.request', method: 'onKernelRequest' }
 
-    kunstmaan_admin.menu.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\MenuTwigExtension
-        arguments: ['@kunstmaan_admin.menubuilder', '@kunstmaan_admin.admin_panel']
+    Kunstmaan\AdminBundle\Twig\MenuTwigExtension:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder'
+            - '@Kunstmaan\AdminBundle\Helper\AdminPanel\AdminPanel'
         tags:
             -  { name: 'twig.extension' }
 
-    kunstmaan_admin.localeswitcher.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\LocaleSwitcherTwigExtension
+    Kunstmaan\AdminBundle\Twig\LocaleSwitcherTwigExtension:
         arguments: ['@kunstmaan_admin.domain_configuration']
         tags:
             -  { name: 'twig.extension' }
 
-    kunstmaan_admin.multidomain.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\MultiDomainAdminTwigExtension
-        arguments: ['@kunstmaan_admin.domain_configuration']
+    Kunstmaan\AdminBundle\Twig\MultiDomainAdminTwigExtension:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
               -  { name: 'twig.extension' }
 
-    kunstmaan_admin.locale.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\DateByLocaleExtension
+    Kunstmaan\AdminBundle\Twig\DateByLocaleExtension:
         tags:
             - { name: 'twig.extension' }
 
-    kunstmaan_admin.formtools.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\FormToolsExtension
+    Kunstmaan\AdminBundle\Twig\FormToolsExtension:
         arguments: ['@kunstmaan_admin.form.helper']
         tags:
             - { name: 'twig.extension' }
 
-    kunstmaan_admin.permissions.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\AdminPermissionsTwigExtension
+    Kunstmaan\AdminBundle\Twig\AdminPermissionsTwigExtension:
         tags:
             -  { name: 'twig.extension' }
 
-    kunstmaan_admin.acl.helper:
-        class: '%kunstmaan_admin.acl.helper.class%'
-        arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.role_hierarchy']
+    Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@security.role_hierarchy'
 
-    kunstmaan_admin.acl.native.helper:
-        class: '%kunstmaan_admin.acl.native.helper.class%'
-        arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.role_hierarchy']
+    Kunstmaan\AdminBundle\Helper\Security\Acl\AclNativeHelper:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@security.role_hierarchy'
 
-    kunstmaan_admin.security.acl.permission.map:
-        class: '%kunstmaan_admin.security.acl.permission.map.class%'
+    Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap: ~
 
-    kunstmaan_admin.security.acl.voter:
-        class: Kunstmaan\AdminBundle\Helper\Security\Acl\Voter\AclVoter
-        arguments: ['@security.acl.provider', '@security.acl.object_identity_retrieval_strategy', '@security.acl.security_identity_retrieval_strategy', '@kunstmaan_admin.security.acl.permission.map']
+    Kunstmaan\AdminBundle\Helper\Security\Acl\Voter\AclVoter:
+        arguments:
+            - '@Symfony\Component\Security\Acl\Model\AclProviderInterface'
+            - '@security.acl.object_identity_retrieval_strategy'
+            - '@security.acl.security_identity_retrieval_strategy'
+            - '@kunstmaan_admin.security.acl.permission.map'
         tags:
             - { name: security.voter, priority: 255 }
             - { name: monolog.logger, channel: security }
         # small performance boost
         public: false
 
-    kunstmaan_admin.permissionadmin:
-        class: Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin
-        arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.acl.provider', '@security.acl.object_identity_retrieval_strategy', '@event_dispatcher', '@kunstmaan_utilities.shell', '@kernel']
+    Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@Symfony\Component\Security\Acl\Model\AclProviderInterface'
+            - '@security.acl.object_identity_retrieval_strategy'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
+            - '@kunstmaan_utilities.shell'
+            - '@kernel'
 
-    kunstmaan_admin.clone.helper:
-        class: Kunstmaan\AdminBundle\Helper\CloneHelper
-        arguments: ['@doctrine.orm.entity_manager', '@event_dispatcher']
+    Kunstmaan\AdminBundle\Helper\CloneHelper:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
 
-    kunstmaan_admin.adminroute.helper:
-        class: '%kunstmaan_admin.adminroute.helper.class%'
-        arguments: ['%kunstmaan_admin.admin_prefix%', '@request_stack']
+    Kunstmaan\AdminBundle\Helper\AdminRouteHelper:
+        arguments:
+            - '%kunstmaan_admin.admin_prefix%'
+            - '@Symfony\Component\HttpFoundation\RequestStack'
 
-    kunstmaan_admin.adminroute.twig.extension:
-        class: '%kunstmaan_admin.adminroute.twig.class%'
-        arguments: ['@kunstmaan_admin.adminroute.helper']
+    Kunstmaan\AdminBundle\Twig\AdminRouteHelperTwigExtension:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
         tags:
             -  { name: 'twig.extension' }
 
-    kunstmaan_admin.clone.listener:
-        class: '%kunstmaan_admin.clone.listener.class%'
+    Kunstmaan\AdminBundle\EventListener\CloneListener:
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.onDeepCloneAndSave, method: onDeepCloneAndSave }
 
-    kunstmaan_admin.logger.processor.user:
-        class: Kunstmaan\AdminBundle\Helper\UserProcessor
-        arguments: [ '@service_container' ]
+    Kunstmaan\AdminBundle\Helper\UserProcessor:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
         tags:
             - { name: monolog.processor, method: processRecord }
             - { name: kunstmaan_admin.logger.processor, method: processRecord }
 
     kunstmaan_admin.logger.handler:
         class: Monolog\Handler\RotatingFileHandler
-        arguments: ['%kernel.logs_dir%/kunstmaan_%kernel.environment%.log', 10]
+        arguments:
+            - '%kernel.logs_dir%/kunstmaan_%kernel.environment%.log'
+            - 10
 
     kunstmaan_admin.logger:
         class: Symfony\Bridge\Monolog\Logger
@@ -145,115 +162,113 @@ services:
         calls:
             - [pushHandler, ['@kunstmaan_admin.logger.handler']]
 
-    kunstmaan_admin.form.helper:
-        class: Kunstmaan\AdminBundle\Helper\FormHelper
+    Kunstmaan\AdminBundle\Helper\FormHelper: ~
 
-    kunstmaan_admin.tabs.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\TabsTwigExtension
+    Kunstmaan\AdminBundle\Twig\TabsTwigExtension:
         tags:
             - { name: twig.extension }
 
-    kunstmaan_admin.permission_creator:
-        class: Kunstmaan\AdminBundle\Helper\Creators\ACLPermissionCreator
-        arguments: ['@security.acl.provider', '@security.acl.object_identity_retrieval_strategy']
+    Kunstmaan\AdminBundle\Helper\Creators\ACLPermissionCreator:
+        arguments:
+            - '@security.acl.provider'
+            - '@security.acl.object_identity_retrieval_strategy'
 
-    kunstmaan_admin.versionchecker:
-        class: Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker
-        arguments: ['@service_container', '@kunstmaan_admin.cache']
+    Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
+            - '@kunstmaan_admin.cache'
 
     kunstmaan_admin.cache:
         class: Doctrine\Common\Cache\FilesystemCache
-        arguments: ['%kernel.cache_dir%/fcache']
+        arguments:
+            - '%kernel.cache_dir%/fcache'
 
-    kunstmaan_admin.form.type.color:
-        class: Kunstmaan\AdminBundle\Form\ColorType
+    Kunstmaan\AdminBundle\Form\ColorType:
         tags:
             - { name: form.type }
 
-    kunstmaan_admin.doctrine_mapping.listener:
-        class: Kunstmaan\AdminBundle\EventListener\MappingListener
-        arguments: ['%fos_user.model.user.class%']
+    Kunstmaan\AdminBundle\EventListener\MappingListener:
+        arguments:
+            - '%fos_user.model.user.class%'
         tags:
             - { name: doctrine.event_listener, event: loadClassMetadata }
 
-    kunstmaan_admin.form.type.range:
-        class: Kunstmaan\AdminBundle\Form\RangeType
+    Kunstmaan\AdminBundle\Form\RangeType:
         tags:
             - { name: form.type }
 
-    kunstmaan_admin.session_security:
-        class: '%kunstmaan_admin.session_security.class%'
-        arguments: ['%kunstmaan_admin.session_security.ip_check%', '%kunstmaan_admin.session_security.user_agent_check%', '@logger']
+    Kunstmaan\AdminBundle\EventListener\SessionSecurityListener:
+        arguments:
+            - '%kunstmaan_admin.session_security.ip_check%'
+            - '%kunstmaan_admin.session_security.user_agent_check%'
+            - '@Psr\Log\LoggerInterface'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -1000 }
 
-    kunstmaan_form.type.wysiwyg:
-        class: Kunstmaan\AdminBundle\Form\WysiwygType
+    Kunstmaan\AdminBundle\Form\WysiwygType:
         tags:
             - { name: form.type }
 
-    kunstmaan_admin.password_resetting.listener:
-        class: '%kunstmaan_admin.password_resetting.listener.class%'
-        arguments: ['@fos_user.user_manager']
+    Kunstmaan\AdminBundle\EventListener\PasswordResettingListener:
+        arguments:
+            - '@FOS\UserBundle\Model\UserManagerInterface'
         tags:
             - { name: kernel.event_listener, event: fos_user.change_password.edit.completed, method: onPasswordResettingSuccess }
 
-    kunstmaan_admin.password_check.listener:
-        class: '%kunstmaan_admin.password_check.listener.class%'
-        arguments: ['@security.authorization_checker', '@security.token_storage', '@router.default', '@session', '@translator', '@kunstmaan_admin.adminroute.helper']
+    Kunstmaan\AdminBundle\EventListener\PasswordCheckListener:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Symfony\Component\HttpFoundation\Session\SessionInterface'
+            - '@Symfony\Component\Translation\TranslatorInterface'
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 1 }
 
-    kunstmaan_admin.admin_panel.adaptor:
-        class: Kunstmaan\AdminBundle\Helper\AdminPanel\DefaultAdminPanelAdaptor
-        arguments: ['@security.token_storage']
+    Kunstmaan\AdminBundle\Helper\AdminPanel\DefaultAdminPanelAdaptor:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
         tags:
             -  { name: 'kunstmaan_admin.admin_panel.adaptor' }
 
-    kunstmaan_admin.domain_configuration:
-        class: '%kunstmaan_admin.domain_configuration.class%'
+    Kunstmaan\AdminBundle\Helper\DomainConfiguration:
         arguments: ['@service_container']
 
-    kunstmaan_admin.oauth_authenticator:
-        class: Kunstmaan\AdminBundle\Security\OAuthAuthenticator
+    Kunstmaan\AdminBundle\Security\OAuthAuthenticator:
         arguments:
-            - '@router'
-            - '@session'
-            - '@translator'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Symfony\Component\HttpFoundation\Session\SessionInterface'
+            - '@Symfony\Component\Translation\TranslatorInterface'
             - '@kunstmaan_admin.oauth_user_creator'
             - '%kunstmaan_admin.google_signin.client_id%'
             - '%kunstmaan_admin.google_signin.client_secret%'
 
-    kunstmaan_admin.oauth_user_creator:
-        class: Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreator
+    Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreator:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '%kunstmaan_admin.google_signin.hosted_domains%'
             - '%fos_user.model.user.class%'
             - '@kunstmaan_admin.oauth_user_finder'
 
-    kunstmaan_admin.oauth_user_finder:
-        class: Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserFinder
+    Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserFinder:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '%fos_user.model.user.class%'
 
-    kunstmaan_admin.google_signin.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\GoogleSignInTwigExtension
+    Kunstmaan\AdminBundle\Twig\GoogleSignInTwigExtension:
         arguments:
             - '%kunstmaan_admin.google_signin.enabled%'
             - '%kunstmaan_admin.google_signin.client_id%'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_admin.sidebar.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\SidebarTwigExtension
+    Kunstmaan\AdminBundle\Twig\SidebarTwigExtension:
         tags:
             - { name: twig.extension }
 
-    kunstmaan_admin.validator.password_restrictions:
-        class: '%kunstmaan_admin.validator.password_restrictions.class%'
+    Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictionsValidator:
         arguments:
             - '%kunstmaan_admin.password_restrictions.min_digits%'
             - '%kunstmaan_admin.password_restrictions.min_uppercase%'
@@ -263,23 +278,20 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: password_restrictions }
 
-    kunstmaan_admin.exception.listener:
-        class: "%kunstmaan_admin.exception.listener.class%"
+    Kunstmaan\AdminBundle\EventListener\ExceptionSubscriber:
         arguments:
-            - "@doctrine.orm.entity_manager"
+            - '@Doctrine\ORM\EntityManagerInterface'
             - "%kunstmaan_admin.admin_exception_excludes%"
         tags:
             - { name: kernel.event_subscriber }
 
     ### TOOLBAR DATA COLLECTOR ###
 
-    kunstmaan_admin.toolbar.twig.extension:
-        class: Kunstmaan\AdminBundle\Twig\ToolbarTwigExtension
+    Kunstmaan\AdminBundle\Twig\ToolbarTwigExtension:
         tags:
             - { name: twig.extension }
 
-    kunstmaan_admin.toolbar.datacollector:
-        class: Kunstmaan\AdminBundle\Helper\Toolbar\DataCollector
+    Kunstmaan\AdminBundle\Helper\Toolbar\DataCollector:
         arguments:
              - '@router'
 
@@ -288,30 +300,29 @@ services:
         calls:
             - [setAdminRouteHelper, ['@kunstmaan_admin.adminroute.helper']]
 
-    kunstmaan_admin.toolbar.listener:
-        class: '%kunstmaan_admin.toolbar.listener.class%'
+    Kunstmaan\AdminBundle\EventListener\ToolbarListener:
         tags:
             - { name: kernel.event_subscriber }
         arguments:
-            - '@twig'
-            - '@router'
-            - '@kunstmaan_admin.toolbar.datacollector'
-            - '@security.authorization_checker'
-            - '@security.token_storage'
+            - '@Twig_Environment'
+            - '@Symfony\Component\Routing\Generator\UrlGeneratorInterface'
+            - '@Kunstmaan\AdminBundle\Helper\Toolbar\DataCollector'
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
             - '%kunstmaan_admin.enable_toolbar_helper%'
-            - '@service_container'
-            - '@kunstmaan_admin.adminroute.helper'
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
             - '%kunstmaan_admin.provider_keys%'
 
-    kunstmaan_admin.datacollector.bundleversion:
-        class: '%kunstmaan_admin.toolbar.collector.bundle.class%'
+    Kunstmaan\AdminBundle\Toolbar\BundleVersionDataCollector:
         arguments:
-            - '@kunstmaan_admin.versionchecker'
+            - '@Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker'
             - '@kunstmaan_admin.cache'
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: 'KunstmaanAdminBundle:Toolbar:bundles_version.html.twig', id: kuma_bundle_versions }
-    kunstmaan_admin.datacollector.exception:
-        class: '%kunstmaan_admin.toolbar.collector.exception.class%'
-        arguments: ["@doctrine.orm.entity_manager"]
+
+    Kunstmaan\AdminBundle\Toolbar\ExceptionDataCollector:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: 'KunstmaanAdminBundle:Toolbar:exception.html.twig', id: kuma_exception }

--- a/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
+++ b/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
@@ -8,7 +8,7 @@ use Kunstmaan\AdminBundle\Helper\Security\OAuth\OAuthUserCreatorInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -22,7 +22,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
     /** @var RouterInterface */
     private $router;
 
-    /** @var Session */
+    /** @var SessionInterface */
     private $session;
 
     /** @var TranslatorInterface */
@@ -39,15 +39,22 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
 
     /**
      * OAuthAuthenticator constructor.
-     * @param RouterInterface $router
-     * @param Session $session
-     * @param TranslatorInterface $translator
+     *
+     * @param RouterInterface           $router
+     * @param SessionInterface          $session
+     * @param TranslatorInterface       $translator
      * @param OAuthUserCreatorInterface $oAuthUserCreator
-     * @param $clientId
-     * @param $clientSecret
+     * @param                           $clientId
+     * @param                           $clientSecret
      */
-    public function __construct(RouterInterface $router, Session $session, TranslatorInterface $translator, OAuthUserCreatorInterface $oAuthUserCreator, $clientId, $clientSecret)
-    {
+    public function __construct(
+        RouterInterface $router,
+        SessionInterface $session,
+        TranslatorInterface $translator,
+        OAuthUserCreatorInterface $oAuthUserCreator,
+        $clientId,
+        $clientSecret
+    ) {
         $this->router = $router;
         $this->session = $session;
         $this->translator = $translator;
@@ -69,7 +76,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      *  B) For an API token authentication system, you return a 401 response
      *      return new Response('Auth header required', 401);
      *
-     * @param Request $request The request that resulted in an AuthenticationException
+     * @param Request                 $request       The request that resulted in an AuthenticationException
      * @param AuthenticationException $authException The exception that started the authentication process
      *
      * @return Response
@@ -99,18 +106,15 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      *
      * @param Request $request
      *
-     * @return mixed|null
+     * @return array
      */
     public function getCredentials(Request $request)
     {
-        if ($request->attributes->get('_route') != 'KunstmaanAdminBundle_oauth_signin' || !$request->request->has('_google_id_token')) {
-            return null;
-        }
-
         $token = $request->request->get('_google_id_token');
-        return array(
+
+        return [
             'token' => $token,
-        );
+        ];
     }
 
     /**
@@ -121,7 +125,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      * You may throw an AuthenticationException if you wish. If you return
      * null, then a UsernameNotFoundException is thrown for you.
      *
-     * @param mixed $credentials
+     * @param mixed                 $credentials
      * @param UserProviderInterface $userProvider
      *
      * @throws AuthenticationException
@@ -156,7 +160,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      *
      * The *credentials* are the return value from getCredentials()
      *
-     * @param mixed $credentials
+     * @param mixed         $credentials
      * @param UserInterface $user
      *
      * @return bool
@@ -177,7 +181,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      * If you return null, the request will continue, but the user will
      * not be authenticated. This is probably not what you want to do.
      *
-     * @param Request $request
+     * @param Request                 $request
      * @param AuthenticationException $exception
      *
      * @return Response|null
@@ -185,6 +189,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
         $this->session->getFlashBag()->add(FlashTypes::ERROR, $this->translator->trans('errors.oauth.invalid'));
+
         return new RedirectResponse($this->router->generate('fos_user_security_login'));
     }
 
@@ -197,15 +202,29 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      * If you return null, the current request will continue, and the user
      * will be authenticated. This makes sense, for example, with an API.
      *
-     * @param Request $request
+     * @param Request        $request
      * @param TokenInterface $token
-     * @param string $providerKey The provider (i.e. firewall) key
+     * @param string         $providerKey The provider (i.e. firewall) key
      *
      * @return Response|null
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
         return new RedirectResponse($this->router->generate('KunstmaanAdminBundle_homepage'));
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function supports(Request $request)
+    {
+        if ($request->attributes->get('_route') !== 'KunstmaanAdminBundle_oauth_signin' || !$request->request->has('_google_id_token')) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
@@ -5,10 +5,14 @@ namespace Kunstmaan\AdminBundle\Toolbar;
 use Doctrine\Common\Cache\Cache;
 use Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
-use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Class BundleVersionDataCollector
+ *
+ * @package Kunstmaan\AdminBundle\Toolbar
+ */
 class BundleVersionDataCollector extends AbstractDataCollector
 {
     /** @var VersionChecker */
@@ -41,7 +45,7 @@ class BundleVersionDataCollector extends AbstractDataCollector
         $data = $this->cache->fetch('version_check');
 
         return [
-            'data' => $data
+            'data' => $data,
         ];
     }
 

--- a/src/Kunstmaan/AdminBundle/Toolbar/ExceptionDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Toolbar/ExceptionDataCollector.php
@@ -8,6 +8,11 @@ use Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Class ExceptionDataCollector
+ *
+ * @package Kunstmaan\AdminBundle\Toolbar
+ */
 class ExceptionDataCollector extends AbstractDataCollector
 {
     /**
@@ -15,6 +20,11 @@ class ExceptionDataCollector extends AbstractDataCollector
      */
     private $em;
 
+    /**
+     * ExceptionDataCollector constructor.
+     *
+     * @param EntityManagerInterface $em
+     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
@@ -34,9 +44,9 @@ class ExceptionDataCollector extends AbstractDataCollector
     public function collectData()
     {
         $model = $this->em->getRepository(Exception::class)->findExceptionStatistics();
-        if ( isset($model['cp_all'], $model['cp_sum']) ) {
+        if (isset($model['cp_all'], $model['cp_sum'])) {
             return [
-                'data' => $model
+                'data' => $model,
             ];
         } else {
             return [];
@@ -50,7 +60,7 @@ class ExceptionDataCollector extends AbstractDataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        if ( false === $this->isEnabled() ) {
+        if (false === $this->isEnabled()) {
             $this->data = false;
         } else {
             $this->data = $this->collectData();

--- a/src/Kunstmaan/AdminListBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/AdminListBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\AdminListBundle\AdminList\AdminListFactory;
+use Kunstmaan\AdminListBundle\EventSubscriber\AdminListSubscriber;
+use Kunstmaan\AdminListBundle\Service\EntityVersionLockService;
+use Kunstmaan\AdminListBundle\Service\ExportService;
+use Kunstmaan\AdminListBundle\Twig\AdminListTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\AdminListBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_adminlist.factory', AdminListFactory::class],
+                ['kunstmaan_adminlist.service.export', ExportService::class],
+                ['kunstmaan_adminlist.twig.extension', AdminListTwigExtension::class],
+                ['kunstmaan_entity.admin_entity.entity_version_lock_service', EntityVersionLockService::class],
+                ['kunstmaan_adminlist.subscriber.adminlist', AdminListSubscriber::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_adminlist.service.export.class', ExportService::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanAdminListBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanAdminListBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/DependencyInjection/KunstmaanAdminListExtension.php
+++ b/src/Kunstmaan/AdminListBundle/DependencyInjection/KunstmaanAdminListExtension.php
@@ -32,20 +32,23 @@ class KunstmaanAdminListExtension extends Extension implements PrependExtensionI
         $loader->load('services.yml');
     }
 
+    /**
+     * @param ContainerBuilder $container
+     */
     public function prepend(ContainerBuilder $container)
     {
 
         $parameterName = 'datePicker_startDate';
 
-        $config = array();
+        $config = [];
         $config['globals'][$parameterName] = '01/01/1970';
 
-        if($container->hasParameter($parameterName)) {
+        if ($container->hasParameter($parameterName)) {
             $config['globals'][$parameterName] = $container->getParameter($parameterName);
         }
 
         $container->prependExtensionConfig('twig', $config);
         $configs = $container->getExtensionConfig($this->getAlias());
-        $config = $this->processConfiguration(new Configuration(), $configs);
+        $this->processConfiguration(new Configuration(), $configs);
     }
 }

--- a/src/Kunstmaan/AdminListBundle/KunstmaanAdminListBundle.php
+++ b/src/Kunstmaan/AdminListBundle/KunstmaanAdminListBundle.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\AdminListBundle;
 
+use Kunstmaan\AdminListBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,4 +11,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanAdminListBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -2,30 +2,25 @@ parameters:
     kunstmaan_adminlist.service.export.class: Kunstmaan\AdminListBundle\Service\ExportService
 
 services:
-    kunstmaan_adminlist.factory:
-        class: Kunstmaan\AdminListBundle\AdminList\AdminListFactory
+    Kunstmaan\AdminListBundle\AdminList\AdminListFactory: ~
 
-    kunstmaan_adminlist.service.export:
-        class:  '%kunstmaan_adminlist.service.export.class%'
+    Kunstmaan\AdminListBundle\Service\ExportService:
         calls:
             -  [ setRenderer, [ '@templating' ] ]
             -  [ setTranslator, [ '@translator' ] ]
 
-    kunstmaan_adminlist.twig.extension:
-        class: Kunstmaan\AdminListBundle\Twig\AdminListTwigExtension
+    Kunstmaan\AdminListBundle\Twig\AdminListTwigExtension:
         tags:
             -  { name: twig.extension }
 
-    kunstmaan_entity.admin_entity.entity_version_lock_service:
-        class: Kunstmaan\AdminListBundle\Service\EntityVersionLockService
+    Kunstmaan\AdminListBundle\Service\EntityVersionLockService:
         arguments:
-            -  '@doctrine.orm.entity_manager'
+            -  '@Doctrine\ORM\EntityManagerInterface'
             -  '%kunstmaan_entity.lock_threshold%'
             -  '%kunstmaan_entity.lock_enabled%'
 
-    kunstmaan_adminlist.subscriber.adminlist:
-        class: Kunstmaan\AdminListBundle\EventSubscriber\AdminListSubscriber
+    Kunstmaan\AdminListBundle\EventSubscriber\AdminListSubscriber:
         arguments:
-            - "@router"
+            - '@Symfony\Component\Routing\RouterInterface'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticleAuthorAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticleAuthorAdminListConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\ArticleBundle\AdminList;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
@@ -23,11 +23,11 @@ class AbstractArticleAuthorAdminListConfigurator extends AbstractDoctrineORMAdmi
     protected $permission;
 
     /**
-     * @param EntityManager $em         The entity manager
-     * @param AclHelper     $aclHelper  The ACL helper
-     * @param string        $locale     The current locale
+     * @param EntityManagerInterface $em        The entity manager
+     * @param AclHelper              $aclHelper The ACL helper
+     * @param string                 $locale    The current locale
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper, $locale)
+    public function __construct(EntityManagerInterface $em, AclHelper $aclHelper, $locale)
     {
         parent::__construct($em, $aclHelper);
         $this->locale = $locale;

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\ArticleBundle\AdminList;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionDefinition;
@@ -29,17 +29,17 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
     protected $permission;
 
     /**
-     * @param EntityManager $em         The entity manager
-     * @param AclHelper     $aclHelper  The ACL helper
-     * @param string        $locale     The current locale
-     * @param string        $permission The permission
+     * @param EntityManagerInterface $em         The entity manager
+     * @param AclHelper              $aclHelper  The ACL helper
+     * @param string                 $locale     The current locale
+     * @param string                 $permission The permission
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper, $locale, $permission)
+    public function __construct(EntityManagerInterface $em, AclHelper $aclHelper, $locale, $permission)
     {
         parent::__construct($em, $aclHelper);
         $this->locale = $locale;
         $this->setPermissionDefinition(
-            new PermissionDefinition(array($permission), 'Kunstmaan\NodeBundle\Entity\Node', 'n')
+            new PermissionDefinition([$permission], 'Kunstmaan\NodeBundle\Entity\Node', 'n')
         );
     }
 
@@ -123,10 +123,10 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
         /* @var Node $node */
         $node = $item->getNode();
 
-        return array(
-            'path'   => 'KunstmaanNodeBundle_nodes_edit',
-            'params' => array('id' => $node->getId())
-        );
+        return [
+            'path' => 'KunstmaanNodeBundle_nodes_edit',
+            'params' => ['id' => $node->getId()],
+        ];
     }
 
     /**
@@ -141,10 +141,10 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
         /* @var Node $node */
         $node = $item->getNode();
 
-        return array(
-            'path'   => 'KunstmaanNodeBundle_nodes_delete',
-            'params' => array('id' => $node->getId())
-        );
+        return [
+            'path' => 'KunstmaanNodeBundle_nodes_delete',
+            'params' => ['id' => $node->getId()],
+        ];
     }
 
     /**
@@ -166,6 +166,7 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
 
     /**
      * Returns all overview pages
+     *
      * @return mixed
      */
     public function getOverviewPages()
@@ -183,6 +184,7 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
 
     /**
      * Returns the full entity class name
+     *
      * @return string
      */
     public function getEntityClassName()

--- a/src/Kunstmaan/ArticleBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/ArticleBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kunstmaan\ArticleBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\ArticleBundle\Twig\ArticleTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\ArticleBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_articlebundle.twig.extension', ArticleTwigExtension::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanArticleBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/ArticleBundle/DependencyInjection/KunstmaanArticleExtension.php
+++ b/src/Kunstmaan/ArticleBundle/DependencyInjection/KunstmaanArticleExtension.php
@@ -2,10 +2,10 @@
 
 namespace Kunstmaan\ArticleBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/src/Kunstmaan/ArticleBundle/KunstmaanArticleBundle.php
+++ b/src/Kunstmaan/ArticleBundle/KunstmaanArticleBundle.php
@@ -2,9 +2,19 @@
 
 namespace Kunstmaan\ArticleBundle;
 
+use Kunstmaan\ArticleBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class KunstmaanArticleBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/ArticleBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/ArticleBundle/Resources/config/services.yml
@@ -1,8 +1,5 @@
-parameters:
-
 services:
-    kunstmaan_articlebundle.twig.extension:
-        class: 'Kunstmaan\ArticleBundle\Twig\ArticleTwigExtension'
+    Kunstmaan\ArticleBundle\Twig\ArticleTwigExtension:
         arguments: ['@doctrine.orm.entity_manager', '@router']
         tags:
             -  { name: twig.extension }

--- a/src/Kunstmaan/CacheBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/CacheBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\CacheBundle\EventListener\VarnishListener;
+use Kunstmaan\CacheBundle\Helper\Menu\VarnishMenuAdaptor;
+use Kunstmaan\CacheBundle\Helper\VarnishHelper;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\CacheBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_cache.menu_adaptor.varnish', VarnishMenuAdaptor::class],
+                ['kunstmaan_cache.helper.varnish', VarnishHelper::class],
+                ['kunstmaan_cache.listener.varnish', VarnishListener::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_cache.menu_adaptor.varnish.class', VarnishMenuAdaptor::class],
+                ['kunstmaan_cache.helper.varnish.class', VarnishHelper::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanCacheBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanCacheBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
+++ b/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
@@ -2,8 +2,24 @@
 
 namespace Kunstmaan\CacheBundle;
 
+use Kunstmaan\CacheBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanCacheBundle
+ *
+ * @package Kunstmaan\CacheBundle
+ */
 class KunstmaanCacheBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/CacheBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/CacheBundle/Resources/config/services.yml
@@ -3,21 +3,18 @@ parameters:
     kunstmaan_cache.helper.varnish.class: Kunstmaan\CacheBundle\Helper\VarnishHelper
 
 services:
-  kunstmaan_cache.menu_adaptor.varnish:
-    class: "%kunstmaan_cache.menu_adaptor.varnish.class%"
+  Kunstmaan\CacheBundle\Helper\Menu\VarnishMenuAdaptor:
     tags:
       -  { name: "kunstmaan_admin.menu.adaptor" }
 
-  kunstmaan_cache.helper.varnish:
-    class: "%kunstmaan_cache.helper.varnish.class%"
+  Kunstmaan\CacheBundle\Helper\VarnishHelper:
     arguments:
       - "@fos_http_cache.cache_manager"
-      - "@kunstmaan_admin.domain_configuration"
+      - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
 
-  kunstmaan_cache.listener.varnish:
-    class: Kunstmaan\CacheBundle\EventListener\VarnishListener
+  Kunstmaan\CacheBundle\EventListener\VarnishListener:
     arguments:
-        - "@security.authorization_checker"
-        - "@router"
+        - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+        - '@Symfony\Component\Routing\RouterInterface'
     tags:
         - { name: 'kernel.event_listener', event: 'kunstmaan_node.configureActionMenu', method: 'onActionMenuConfigure' }

--- a/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Kunstmaan\ConfigBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\ConfigBundle\Controller\ConfigController;
+use Kunstmaan\ConfigBundle\Helper\Menu\ConfigMenuAdaptor;
+use Kunstmaan\ConfigBundle\Twig\ConfigTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\ConfigBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_config.menu.adaptor', ConfigMenuAdaptor::class],
+                ['kunstmaan_config.config.twig.extension', ConfigTwigExtension::class],
+                ['kunstmaan_config.controller.config', ConfigController::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_config.menu.adaptor.class', ConfigMenuAdaptor::class],
+                ['kunstmaan_config.twig.extension.class', ConfigTwigExtension::class],
+                ['kunstmaan_config.controller.config.class', ConfigController::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanConfigBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanConfigBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/KunstmaanConfigConfigurationPass.php
+++ b/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/KunstmaanConfigConfigurationPass.php
@@ -28,7 +28,7 @@ class KunstmaanConfigConfigurationPass implements CompilerPassInterface
             }
 
             // Check if entity implements the ConfigurationInterface.
-            if (!in_array(ConfigurationInterface::class, class_implements($class))) {
+            if (!\in_array(ConfigurationInterface::class, class_implements($class), false)) {
                 throw new \RuntimeException(sprintf('The entity class "%s" needs to implement the ConfigurationInterface', $class));
             }
         }

--- a/src/Kunstmaan/ConfigBundle/KunstmaanConfigBundle.php
+++ b/src/Kunstmaan/ConfigBundle/KunstmaanConfigBundle.php
@@ -2,15 +2,27 @@
 
 namespace Kunstmaan\ConfigBundle;
 
+use Kunstmaan\ConfigBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\ConfigBundle\DependencyInjection\Compiler\KunstmaanConfigConfigurationPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanConfigBundle
+ *
+ * @package Kunstmaan\ConfigBundle
+ */
 class KunstmaanConfigBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
     public function build(ContainerBuilder $container)
     {
+        parent::build($container);
+
         $container->addCompilerPass(new KunstmaanConfigConfigurationPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/ConfigBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/ConfigBundle/Resources/config/services.yml
@@ -4,25 +4,25 @@ parameters:
     kunstmaan_config.controller.config.class: 'Kunstmaan\ConfigBundle\Controller\ConfigController'
 
 services:
-  kunstmaan_config.menu.adaptor:
-    class: "%kunstmaan_config.menu.adaptor.class%"
-    arguments: ["%kunstmaan_config%", "@security.authorization_checker"]
+  Kunstmaan\ConfigBundle\Helper\Menu\ConfigMenuAdaptor:
+    arguments:
+      - '%kunstmaan_config%'
+      - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
     tags:
-      -  { name: "kunstmaan_admin.menu.adaptor" }
+      -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-
-  kunstmaan_config.config.twig.extension:
-    class: "%kunstmaan_config.twig.extension.class%"
-    arguments: ["@doctrine.orm.entity_manager", "%kunstmaan_config%"]
+  Kunstmaan\ConfigBundle\Twig\ConfigTwigExtension:
+    arguments:
+      - '@Doctrine\ORM\EntityManagerInterface'
+      - '%kunstmaan_config%'
     tags:
       - { name: twig.extension }
 
-  kunstmaan_config.controller.config:
-    class: "%kunstmaan_config.controller.config.class%"
+  Kunstmaan\ConfigBundle\Controller\ConfigController:
     arguments:
-      - "@router"
-      - "@templating"
-      - "@security.authorization_checker"
-      - "@doctrine.orm.entity_manager"
-      - "%kunstmaan_config%"
-      - "@form.factory"
+      - '@Symfony\Component\Routing\RouterInterface'
+      - '@Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'
+      - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+      - '@Doctrine\ORM\EntityManagerInterface'
+      - '%kunstmaan_config%'
+      - '@Symfony\Component\Form\FormFactoryInterface'

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Kunstmaan\DashboardBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand;
+use Kunstmaan\DashboardBundle\Controller\GoogleAnalyticsController;
+use Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper;
+use Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper;
+use Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper;
+use Kunstmaan\DashboardBundle\Helper\Google\ClientHelper;
+use Kunstmaan\DashboardBundle\Manager\WidgetManager;
+use Kunstmaan\DashboardBundle\Widget\DashboardWidget;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\DashboardBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_dashboard.manager.widgets', WidgetManager::class],
+                ['kunstmaan_dashboard.widget.googleanalytics', DashboardWidget::class],
+                ['kunstmaan_dashboard.helper.google.client', ClientHelper::class],
+                ['kunstmaan_dashboard.helper.google.analytics.service', ServiceHelper::class],
+                ['kunstmaan_dashboard.helper.google.analytics.config', ConfigHelper::class],
+                ['kunstmaan_dashboard.helper.google.analytics.query', QueryHelper::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_dashboard.widget.googleanalytics.command', GoogleAnalyticsDataCollectCommand::class],
+                ['kunstmaan_dashboard.widget.googleanalytics.controller', GoogleAnalyticsController::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanDashboardBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanDashboardBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/WidgetCompilerPass.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/WidgetCompilerPass.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace Kunstmaan\DashboardBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\DashboardBundle\Manager\WidgetManager;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -17,20 +19,20 @@ class WidgetCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_dashboard.manager.widgets')) {
+        if (!$container->hasDefinition(WidgetManager::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_dashboard.manager.widgets');
+        $definition = $container->getDefinition(WidgetManager::class);
 
         foreach ($container->findTaggedServiceIds('kunstmaan_dashboard.widget') as $id => $tags) {
             foreach ($tags as $tag) {
                 if (!empty($tag['method'])) {
-                    $widget = array(new Reference($id), $tag['method']);
+                    $widget = [new Reference($id), $tag['method']];
                 } else {
                     $widget = new Reference($id);
                 }
-                $definition->addMethodCall('addWidget', array($widget));
+                $definition->addMethodCall('addWidget', [$widget]);
             }
         }
     }

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
@@ -22,7 +22,7 @@ class KunstmaanDashboardExtension extends Extension
         $configuration = new Configuration();
         $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
+++ b/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
@@ -1,9 +1,14 @@
 <?php
 
 namespace Kunstmaan\DashboardBundle\Helper\Google\Analytics;
-use Doctrine\ORM\EntityManager;
-use Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper;
 
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Class ConfigHelper
+ *
+ * @package Kunstmaan\DashboardBundle\Helper\Google\Analytics
+ */
 class ConfigHelper
 {
 
@@ -22,16 +27,17 @@ class ConfigHelper
     /** @var string $profileId */
     private $profileId = false;
 
-    /** @var EntityManager $em */
+    /** @var EntityManagerInterface $em */
     private $em;
 
     /**
      * constructor
      *
-     * @param ServiceHelper $serviceHelper
-     * @param EntityManager $em
+     * @param ServiceHelper          $serviceHelper
+     * @param EntityManagerInterface $em
      */
-    public function __construct(ServiceHelper $serviceHelper, EntityManager $em) {
+    public function __construct(ServiceHelper $serviceHelper, EntityManagerInterface $em)
+    {
         $this->serviceHelper = $serviceHelper;
         $this->em = $em;
         $this->init();
@@ -42,7 +48,7 @@ class ConfigHelper
      *
      * @param int $configId
      */
-    public function init($configId=false)
+    public function init($configId = false)
     {
         // if token is already saved in the database
         if ($this->getToken($configId) && '' !== $this->getToken($configId)) {
@@ -62,336 +68,340 @@ class ConfigHelper
 
     /* =============================== TOKEN =============================== */
 
-        /**
-         * Get the token from the database
-         *
-         * @return string $token
-         */
-        private function getToken($configId=false)
-        {
-            if (!$this->token || $configId) {
-                /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-                $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-                if ($configId) {
-                    $this->token = $analyticsConfigRepository->find($configId)->getToken();
-                } else {
-                    $this->token = $analyticsConfigRepository->findFirst()->getToken();
-                }
+    /**
+     * Get the token from the database
+     *
+     * @return string $token
+     */
+    private function getToken($configId = false)
+    {
+        if (!$this->token || $configId) {
+            /** @var AnalyticsConfigRepository $analyticsConfigRepository */
+            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            if ($configId) {
+                $this->token = $analyticsConfigRepository->find($configId)->getToken();
+            } else {
+                $this->token = $analyticsConfigRepository->findFirst()->getToken();
             }
-
-            return $this->token;
         }
 
-        /**
-         * Save the token to the database
-         */
-        public function saveToken($token, $configId=false)
-        {
-            $this->token = $token;
-            $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveToken($token, $configId);
-        }
+        return $this->token;
+    }
 
-        /**
-         * Check if token is set
-         *
-         * @return boolean $result
-         */
-        public function tokenIsSet()
-        {
-            return $this->getToken() && '' !== $this->getToken();
-        }
+    /**
+     * Save the token to the database
+     */
+    public function saveToken($token, $configId = false)
+    {
+        $this->token = $token;
+        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveToken($token, $configId);
+    }
+
+    /**
+     * Check if token is set
+     *
+     * @return boolean $result
+     */
+    public function tokenIsSet()
+    {
+        return $this->getToken() && '' !== $this->getToken();
+    }
 
     /* =============================== ACCOUNT =============================== */
 
-        /**
-         * Get a list of all available accounts
-         *
-         * @return array $data A list of all properties
-         */
-        public function getAccounts()
-        {
-            $accounts = $this->serviceHelper->getService()->management_accounts->listManagementAccounts()->getItems();
-            $data = array();
+    /**
+     * Get a list of all available accounts
+     *
+     * @return array $data A list of all properties
+     */
+    public function getAccounts()
+    {
+        $accounts = $this->serviceHelper->getService()->management_accounts->listManagementAccounts()->getItems();
+        $data = [];
 
-            foreach ($accounts as $account) {
-                $data[$account->getName()] = array(
-                    'accountId' => $account->getId(),
-                    'accountName' => $account->getName()
-                );
+        foreach ($accounts as $account) {
+            $data[$account->getName()] = [
+                'accountId' => $account->getId(),
+                'accountName' => $account->getName(),
+            ];
+        }
+        ksort($data);
+
+        return $data;
+    }
+
+    /**
+     * Get the accountId from the database
+     *
+     * @return string $accountId
+     */
+    public function getAccountId($configId = false)
+    {
+        if (!$this->accountId || $configId) {
+            /** @var AnalyticsConfigRepository $analyticsConfigRepository */
+            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            if ($configId) {
+                $this->accountId = $analyticsConfigRepository->find($configId)->getAccountId();
+            } else {
+                $this->accountId = $analyticsConfigRepository->findFirst()->getAccountId();
             }
-            ksort($data);
-            return $data;
         }
 
-        /**
-         * Get the accountId from the database
-         *
-         * @return string $accountId
-         */
-        public function getAccountId($configId=false)
-        {
-            if (!$this->accountId || $configId) {
-                /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-                $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-                if ($configId) {
-                    $this->accountId = $analyticsConfigRepository->find($configId)->getAccountId();
-                } else {
-                    $this->accountId = $analyticsConfigRepository->findFirst()->getAccountId();
-                }
-            }
+        return $this->accountId;
+    }
 
-            return $this->accountId;
-        }
+    /**
+     * Save the accountId to the database
+     */
+    public function saveAccountId($accountId, $configId = false)
+    {
+        $this->accountId = $accountId;
+        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveAccountId($accountId, $configId);
+    }
 
-        /**
-         * Save the accountId to the database
-         */
-        public function saveAccountId($accountId, $configId=false)
-        {
-            $this->accountId = $accountId;
-            $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveAccountId($accountId, $configId);
-        }
-
-        /**
-         * Check if token is set
-         *
-         * @return boolean $result
-         */
-        public function accountIsSet()
-        {
-            return $this->getAccountId() && '' !== $this->getAccountId();
-        }
+    /**
+     * Check if token is set
+     *
+     * @return boolean $result
+     */
+    public function accountIsSet()
+    {
+        return $this->getAccountId() && '' !== $this->getAccountId();
+    }
 
     /* =============================== PROPERTY =============================== */
 
-        /**
-         * Get a list of all available properties
-         *
-         * @return array $data A list of all properties
-         */
-        public function getProperties($accountId=false)
-        {
-            if (!$this->getAccountId() && !$accountId) {
-                return false;
-            }
+    /**
+     * Get a list of all available properties
+     *
+     * @return array $data A list of all properties
+     */
+    public function getProperties($accountId = false)
+    {
+        if (!$this->getAccountId() && !$accountId) {
+            return false;
+        }
 
-            if ($accountId) {
-                $webproperties = $this->serviceHelper->getService()->management_webproperties->listManagementWebproperties($accountId);
+        if ($accountId) {
+            $webproperties = $this->serviceHelper->getService()->management_webproperties->listManagementWebproperties($accountId);
+        } else {
+            $webproperties = $this->serviceHelper->getService()->management_webproperties->listManagementWebproperties($this->getAccountId());
+        }
+        $data = [];
+
+        foreach ($webproperties->getItems() as $property) {
+            $profiles = $this->getProfiles($accountId, $property->getId());
+            if (count($profiles) > 0) {
+                $data[$property->getName()] = [
+                    'propertyId' => $property->getId(),
+                    'propertyName' => $property->getName().' ('.$property->getWebsiteUrl().')',
+                ];
+            }
+        }
+        ksort($data);
+
+        return $data;
+    }
+
+    /**
+     * Get the propertyId from the database
+     *
+     * @return string $propertyId
+     */
+    public function getPropertyId($configId = false)
+    {
+        if (!$this->propertyId || $configId) {
+            /** @var AnalyticsConfigRepository $analyticsConfigRepository */
+            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            if ($configId) {
+                $this->propertyId = $analyticsConfigRepository->find($configId)->getPropertyId();
             } else {
-                $webproperties = $this->serviceHelper->getService()->management_webproperties->listManagementWebproperties($this->getAccountId());
+                $this->propertyId = $analyticsConfigRepository->findFirst()->getPropertyId();
             }
-            $data = array();
-
-            foreach ($webproperties->getItems() as $property) {
-                $profiles = $this->getProfiles($accountId, $property->getId());
-                if (count($profiles) > 0) {
-                    $data[$property->getName()] = array(
-                        'propertyId' => $property->getId(),
-                        'propertyName' => $property->getName() . ' (' . $property->getWebsiteUrl() . ')',
-                    );
-                }
-            }
-            ksort($data);
-            return $data;
         }
 
-        /**
-         * Get the propertyId from the database
-         *
-         * @return string $propertyId
-         */
-        public function getPropertyId($configId=false)
-        {
-            if (!$this->propertyId || $configId) {
-                /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-                $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-                if ($configId) {
-                    $this->propertyId = $analyticsConfigRepository->find($configId)->getPropertyId();
-                } else {
-                    $this->propertyId = $analyticsConfigRepository->findFirst()->getPropertyId();
-                }
-            }
+        return $this->propertyId;
+    }
 
-            return $this->propertyId;
-        }
+    /**
+     * Save the propertyId to the database
+     */
+    public function savePropertyId($propertyId, $configId = false)
+    {
+        $this->propertyId = $propertyId;
+        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->savePropertyId($propertyId, $configId);
+    }
 
-        /**
-         * Save the propertyId to the database
-         */
-        public function savePropertyId($propertyId, $configId=false)
-        {
-            $this->propertyId = $propertyId;
-            $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->savePropertyId($propertyId, $configId);
-        }
-
-        /**
-         * Check if propertyId is set
-         *
-         * @return boolean $result
-         */
-        public function propertyIsSet()
-        {
-            return null !== $this->getPropertyId() && '' !== $this->getPropertyId();
-        }
+    /**
+     * Check if propertyId is set
+     *
+     * @return boolean $result
+     */
+    public function propertyIsSet()
+    {
+        return null !== $this->getPropertyId() && '' !== $this->getPropertyId();
+    }
 
     /* =============================== PROFILE =============================== */
 
-        /**
-         * Get a list of all available profiles
-         *
-         * @return array $data A list of all properties
-         */
-        public function getProfiles($accountId=false, $propertyId=false)
-        {
-            if (!$this->getAccountId() && !$accountId || !$this->getPropertyId() && !$propertyId) {
-                return false;
-            }
+    /**
+     * Get a list of all available profiles
+     *
+     * @return array $data A list of all properties
+     */
+    public function getProfiles($accountId = false, $propertyId = false)
+    {
+        if (!$this->getAccountId() && !$accountId || !$this->getPropertyId() && !$propertyId) {
+            return false;
+        }
 
-            // get views
-            if ($accountId && $propertyId) {
-                $profiles = $this->serviceHelper->getService()->management_profiles->listManagementProfiles(
-                    $accountId,
-                    $propertyId
-                );
+        // get views
+        if ($accountId && $propertyId) {
+            $profiles = $this->serviceHelper->getService()->management_profiles->listManagementProfiles(
+                $accountId,
+                $propertyId
+            );
+        } else {
+            $profiles = $this->serviceHelper->getService()->management_profiles->listManagementProfiles(
+                $this->getAccountId(),
+                $this->getPropertyId()
+            );
+        }
+
+        $data = [];
+        if (is_array($profiles->getItems())) {
+            foreach ($profiles->getItems() as $profile) {
+                $data[$profile->name] = [
+                    'profileId' => $profile->id,
+                    'profileName' => $profile->name,
+                    'created' => $profile->created,
+                ];
+            }
+        }
+        ksort($data);
+
+        return $data;
+    }
+
+    /**
+     * Get the propertyId from the database
+     *
+     * @return string $propertyId
+     */
+    public function getProfileId($configId = false)
+    {
+        if (!$this->profileId || $configId) {
+            /** @var AnalyticsConfigRepository $analyticsConfigRepository */
+            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            if ($configId) {
+                $this->profileId = $analyticsConfigRepository->find($configId)->getProfileId();
             } else {
-                $profiles = $this->serviceHelper->getService()->management_profiles->listManagementProfiles(
-                    $this->getAccountId(),
-                    $this->getPropertyId()
-                );
-            }
-
-            $data = array();
-            if (is_array($profiles->getItems())) {
-                foreach ($profiles->getItems() as $profile) {
-                    $data[$profile->name] = array(
-                            'profileId' => $profile->id,
-                            'profileName' => $profile->name,
-                            'created' => $profile->created
-                        );
-                }
-            }
-            ksort($data);
-            return $data;
-        }
-
-        /**
-         * Get the propertyId from the database
-         *
-         * @return string $propertyId
-         */
-        public function getProfileId($configId=false)
-        {
-            if (!$this->profileId || $configId) {
-                /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-                $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-                if ($configId) {
-                    $this->profileId = $analyticsConfigRepository->find($configId)->getProfileId();
-                } else {
-                    $this->profileId = $analyticsConfigRepository->findFirst()->getProfileId();
-                }
-            }
-
-            return $this->profileId;
-        }
-
-        /**
-         * Save the profileId to the database
-         */
-        public function saveProfileId($profileId, $configId=false)
-        {
-            $this->profileId = $profileId;
-            $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveProfileId($profileId, $configId);
-        }
-
-        /**
-         * Check if token is set
-         *
-         * @return boolean $result
-         */
-        public function profileIsSet()
-        {
-            return null !== $this->getProfileId() && '' !== $this->getProfileId();
-        }
-
-        /**
-         * Get the active profile
-         *
-         * @return the profile
-         */
-        public function getActiveProfile() {
-            $profiles = $this->getProfiles();
-            $profileId = $this->getProfileId();
-
-            if (!is_array($profiles)) {
-                throw new \Exception('<fg=red>The config is invalid</fg=red>');
-            }
-
-            foreach ($profiles as $profile) {
-                if ($profile['profileId'] == $profileId) {
-                    return $profile;
-                }
+                $this->profileId = $analyticsConfigRepository->findFirst()->getProfileId();
             }
         }
+
+        return $this->profileId;
+    }
+
+    /**
+     * Save the profileId to the database
+     */
+    public function saveProfileId($profileId, $configId = false)
+    {
+        $this->profileId = $profileId;
+        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveProfileId($profileId, $configId);
+    }
+
+    /**
+     * Check if token is set
+     *
+     * @return boolean $result
+     */
+    public function profileIsSet()
+    {
+        return null !== $this->getProfileId() && '' !== $this->getProfileId();
+    }
+
+    /**
+     * Get the active profile
+     *
+     * @return the profile
+     */
+    public function getActiveProfile()
+    {
+        $profiles = $this->getProfiles();
+        $profileId = $this->getProfileId();
+
+        if (!is_array($profiles)) {
+            throw new \Exception('<fg=red>The config is invalid</fg=red>');
+        }
+
+        foreach ($profiles as $profile) {
+            if ($profile['profileId'] == $profileId) {
+                return $profile;
+            }
+        }
+    }
 
     /* =============================== PROFILE SEGMENTS =============================== */
-        /**
-         * get all segments for the saved profile
-         *
-         * @return array
-         */
-        public function getProfileSegments()
-        {
-            $profileSegments = $this
-                    ->serviceHelper
-                    ->getService()
-                    ->management_segments
-                    ->listManagementSegments()
-                    ->items;
+    /**
+     * get all segments for the saved profile
+     *
+     * @return array
+     */
+    public function getProfileSegments()
+    {
+        $profileSegments = $this
+            ->serviceHelper
+            ->getService()
+            ->management_segments
+            ->listManagementSegments()
+            ->items;
 
-            $builtin = array();
-            $own = array();
-            foreach ($profileSegments as $segment) {
-                if ($segment->type == 'BUILT_IN') {
-                    $builtin[] = array(
-                        'name' => $segment->name,
-                        'query' => $segment->segmentId
-                    );
-                } else {
-                    $own[] = array(
-                        'name' => $segment->name,
-                        'query' => $segment->segmentId
-                    );
-                }
+        $builtin = [];
+        $own = [];
+        foreach ($profileSegments as $segment) {
+            if ($segment->type == 'BUILT_IN') {
+                $builtin[] = [
+                    'name' => $segment->name,
+                    'query' => $segment->segmentId,
+                ];
+            } else {
+                $own[] = [
+                    'name' => $segment->name,
+                    'query' => $segment->segmentId,
+                ];
             }
-
-            return array('builtin' => $builtin, 'own' => $own);
         }
+
+        return ['builtin' => $builtin, 'own' => $own];
+    }
 
     /* =============================== CONFIG =============================== */
 
-        /**
-         * Save the config to the database
-         */
-        public function saveConfigName($configName, $configId=false)
-        {
-            $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveConfigName($configName, $configId);
-        }
+    /**
+     * Save the config to the database
+     */
+    public function saveConfigName($configName, $configId = false)
+    {
+        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveConfigName($configName, $configId);
+    }
 
     /* =============================== AUTH URL =============================== */
 
-        /**
-         * get the authUrl
-         *
-         * @return string $authUrl
-         */
-        public function getAuthUrl()
-        {
-            return $this
-                ->serviceHelper
-                ->getClientHelper()
-                ->getClient()
-                ->createAuthUrl();
-        }
+    /**
+     * get the authUrl
+     *
+     * @return string $authUrl
+     */
+    public function getAuthUrl()
+    {
+        return $this
+            ->serviceHelper
+            ->getClientHelper()
+            ->getClient()
+            ->createAuthUrl();
+    }
 
 
 }

--- a/src/Kunstmaan/DashboardBundle/KunstmaanDashboardBundle.php
+++ b/src/Kunstmaan/DashboardBundle/KunstmaanDashboardBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\DashboardBundle;
 
+use Kunstmaan\DashboardBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\DashboardBundle\DependencyInjection\Compiler\WidgetCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -12,6 +13,8 @@ class KunstmaanDashboardBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
         $container->addCompilerPass(new WidgetCompilerPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -2,20 +2,19 @@ parameters:
     kunstmaan_dashboard.widget.googleanalytics.command: Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand
     kunstmaan_dashboard.widget.googleanalytics.controller: Kunstmaan\DashboardBundle\Controller\GoogleAnalyticsController
     kunstmaan_dashboard.googleclient.class: 'Google_Client'
-    kunstmaan_dashboard.googleclienthelper.class: 'Kunstmaan\DashboardBundle\Helper\GoogleClientHelper'
     google.api.app_name: 'Kuma Analytics Dashboard'
 
 services:
-    kunstmaan_dashboard.manager.widgets:
-        class: Kunstmaan\DashboardBundle\Manager\WidgetManager
+    Kunstmaan\DashboardBundle\Manager\WidgetManager: ~
 
-    kunstmaan_dashboard.widget.googleanalytics:
-        class: Kunstmaan\DashboardBundle\Widget\DashboardWidget
-        arguments: ['%kunstmaan_dashboard.widget.googleanalytics.command%', '%kunstmaan_dashboard.widget.googleanalytics.controller%', '@service_container']
+    Kunstmaan\DashboardBundle\Widget\DashboardWidget:
+        arguments:
+            - '%kunstmaan_dashboard.widget.googleanalytics.command%'
+            - '%kunstmaan_dashboard.widget.googleanalytics.controller%'
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
         tags:
             - { name: kunstmaan_dashboard.widget, priority: 1 }
 
-    # google client
     kunstmaan_dashboard.googleclient:
         class: '%kunstmaan_dashboard.googleclient.class%'
         calls:
@@ -26,22 +25,22 @@ services:
           - [ 'setScopes', [ 'https://www.googleapis.com/auth/analytics.readonly' ] ]
           - [ 'setUseObjects', [ true ] ]
 
-    # client helper
-    kunstmaan_dashboard.helper.google.client:
-        class: 'Kunstmaan\DashboardBundle\Helper\Google\ClientHelper'
-        arguments: ['@kunstmaan_dashboard.googleclient', '@router', 'KunstmaanDashboardBundle_setToken']
+    Kunstmaan\DashboardBundle\Helper\Google\ClientHelper:
+        arguments:
+          - '@kunstmaan_dashboard.googleclient'
+          - '@Symfony\Component\Routing\RouterInterface'
+          - 'KunstmaanDashboardBundle_setToken'
 
-    # service helper
-    kunstmaan_dashboard.helper.google.analytics.service:
-        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper'
-        arguments: ['@kunstmaan_dashboard.helper.google.client']
+    Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper:
+        arguments:
+          - '@Kunstmaan\DashboardBundle\Helper\Google\ClientHelper'
 
-    # config helper
-    kunstmaan_dashboard.helper.google.analytics.config:
-        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper'
-        arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@doctrine.orm.entity_manager']
+    Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper:
+        arguments:
+          - '@Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper'
+          - '@Doctrine\ORM\EntityManagerInterface'
 
-    # query helper
-    kunstmaan_dashboard.helper.google.analytics.query:
-        class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper'
-        arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@kunstmaan_dashboard.helper.google.analytics.config']
+    Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper:
+        arguments:
+          - '@Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper'
+          - '@Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper'

--- a/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\FixturesBundle\Builder;
 
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\FixturesBundle\Loader\Fixture;
 use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Entity\Media;
@@ -14,7 +14,10 @@ use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
 
 class MediaBuilder implements BuilderInterface
 {
+    /** @var EntityManagerInterface */
     private $em;
+
+    /** @var FileHandler */
     private $fileHandler;
 
     /**
@@ -24,7 +27,14 @@ class MediaBuilder implements BuilderInterface
 
     private $folder;
 
-    public function __construct(EntityManager $em, FileHandler $fileHandler, MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory)
+    /**
+     * MediaBuilder constructor.
+     *
+     * @param EntityManagerInterface          $em
+     * @param FileHandler                     $fileHandler
+     * @param MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory
+     */
+    public function __construct(EntityManagerInterface $em, FileHandler $fileHandler, MimeTypeGuesserFactoryInterface $mimeTypeGuesserFactory)
     {
         $this->em = $em;
         $this->fileHandler = $fileHandler;
@@ -44,17 +54,17 @@ class MediaBuilder implements BuilderInterface
     {
         $properties = $fixture->getProperties();
         if (!isset($properties['folder'])) {
-            throw new \Exception('There is no folder specified for media fixture ' . $fixture->getName());
+            throw new \Exception('There is no folder specified for media fixture '.$fixture->getName());
         }
 
-        $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('rel' => $properties['folder']));
+        $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(['rel' => $properties['folder']]);
 
         if (!$this->folder instanceof Folder) {
-            $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('internalName' => $properties['folder']));
+            $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(['internalName' => $properties['folder']]);
         }
 
         if (!$this->folder instanceof Folder) {
-            throw new \Exception('Could not find the specified folder for media fixture ' . $fixture->getName());
+            throw new \Exception('Could not find the specified folder for media fixture '.$fixture->getName());
         }
 
 

--- a/src/Kunstmaan/FixturesBundle/Builder/PagePartBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/PagePartBuilder.php
@@ -2,14 +2,19 @@
 
 namespace Kunstmaan\FixturesBundle\Builder;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\FixturesBundle\Loader\Fixture;
 use Kunstmaan\FixturesBundle\Populator\Populator;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 
+/**
+ * Class PagePartBuilder
+ *
+ * @package Kunstmaan\FixturesBundle\Builder
+ */
 class PagePartBuilder implements BuilderInterface
 {
-    /** @var \Doctrine\ORM\EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var \Kunstmaan\PagePartBundle\Repository\PagePartRefRepository */
@@ -18,11 +23,17 @@ class PagePartBuilder implements BuilderInterface
     /** @var \Kunstmaan\FixturesBundle\Populator\Populator */
     private $populator;
 
-    public function __construct(EntityManager $em, Populator $populator)
+    /**
+     * PagePartBuilder constructor.
+     *
+     * @param EntityManagerInterface $em
+     * @param Populator              $populator
+     */
+    public function __construct(EntityManagerInterface $em, Populator $populator)
     {
-        $this->em           = $em;
+        $this->em = $em;
         $this->pagePartRepo = $em->getRepository('KunstmaanPagePartBundle:PagePartRef');
-        $this->populator    = $populator;
+        $this->populator = $populator;
     }
 
     public function canBuild(Fixture $fixture)
@@ -46,28 +57,28 @@ class PagePartBuilder implements BuilderInterface
 
     public function postFlushBuild(Fixture $fixture)
     {
-        $params       = $fixture->getParameters();
+        $params = $fixture->getParameters();
         $translations = $fixture->getTranslations();
-        $original     = $fixture->getEntity();
+        $original = $fixture->getEntity();
 
         if (!isset($params['page']) || empty($translations)) {
             throw new \Exception(
-                'No page reference and/or translations detected for pagepart fixture ' . $fixture->getName() . ' (' . $fixture->getClass() . ')'
+                'No page reference and/or translations detected for pagepart fixture '.$fixture->getName().' ('.$fixture->getClass().')'
             );
         }
 
         $pageFixture = $params['page'];
         if (!$pageFixture instanceof Fixture) {
             throw new \Exception(
-                'Could not find a reference "' . $params['page'] . '"" for fixture ' . $fixture->getName() . ' (' . $fixture->getClass() . ')'
+                'Could not find a reference "'.$params['page'].'"" for fixture '.$fixture->getName().' ('.$fixture->getClass().')'
             );
         }
 
         $additionalEntities = $pageFixture->getAdditionalEntities();
-        $pp                 = $original;
-        $first              = null;
+        $pp = $original;
+        $first = null;
         foreach ($translations as $language => $data) {
-            $key = $pageFixture->getName() . '_' . $language;
+            $key = $pageFixture->getName().'_'.$language;
             if (!isset($additionalEntities[$key])) {
                 continue;
             }
@@ -83,10 +94,10 @@ class PagePartBuilder implements BuilderInterface
 
             // Find latest position.
             $position = array_key_exists('position', $params) ? $params['position'] : null;
-            $context  = isset($params['context']) ? $params['context'] : 'main';
+            $context = isset($params['context']) ? $params['context'] : 'main';
             if (is_null($position)) {
                 $pageParts = $this->pagePartRepo->getPagePartRefs($page, $context);
-                $position  = count($pageParts) + 1;
+                $position = count($pageParts) + 1;
             }
 
             $this->pagePartRepo->addPagePart($page, $pp, $position, $context);

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/BuilderCompilerPass.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/BuilderCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\FixturesBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\FixturesBundle\Builder\BuildingSupervisor;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -13,11 +14,11 @@ class BuilderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_fixtures.builder.builder')) {
+        if (!$container->hasDefinition(BuildingSupervisor::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_fixtures.builder.builder');
+        $definition = $container->getDefinition(BuildingSupervisor::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_fixtures.builder');
 
         foreach ($taggedServices as $id => $tagAttributes) {

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Kunstmaan\FixturesBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\FixturesBundle\Builder\BuildingSupervisor;
+use Kunstmaan\FixturesBundle\Builder\MediaBuilder;
+use Kunstmaan\FixturesBundle\Builder\MenuItemBuilder;
+use Kunstmaan\FixturesBundle\Builder\PageBuilder;
+use Kunstmaan\FixturesBundle\Builder\PagePartBuilder;
+use Kunstmaan\FixturesBundle\Parser\Parser;
+use Kunstmaan\FixturesBundle\Parser\Property\Method;
+use Kunstmaan\FixturesBundle\Parser\Property\Reference;
+use Kunstmaan\FixturesBundle\Parser\Spec\Listed;
+use Kunstmaan\FixturesBundle\Parser\Spec\Range;
+use Kunstmaan\FixturesBundle\Populator\Methods\ArrayAdd;
+use Kunstmaan\FixturesBundle\Populator\Methods\Property;
+use Kunstmaan\FixturesBundle\Populator\Methods\Setter;
+use Kunstmaan\FixturesBundle\Populator\Populator;
+use Kunstmaan\FixturesBundle\Provider\Node;
+use Kunstmaan\FixturesBundle\Provider\NodeTranslation;
+use Kunstmaan\FixturesBundle\Provider\Spec;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\FixturesBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_fixtures.builder.builder', BuildingSupervisor::class],
+                ['kunstmaan_fixtures.builder.page', PageBuilder::class],
+                ['kunstmaan_fixtures.builder.pagepart', PagePartBuilder::class],
+                ['kunstmaan_fixtures.builder.media', MediaBuilder::class],
+                ['kunstmaan_fixtures.builder.menuitem', MenuItemBuilder::class],
+                ['kunstmaan_fixtures.parser.parser', Parser::class],
+                ['kunstmaan_fixtures.parser.property.method', Method::class],
+                ['kunstmaan_fixtures.parser.property.reference', Reference::class],
+                ['kunstmaan_fixtures.parser.spec.range', Range::class],
+                ['kunstmaan_fixtures.parser.spec.listed', Listed::class],
+                ['kunstmaan_fixtures.populator.populator', Populator::class],
+                ['kunstmaan_fixtures.populator.method.property', Property::class],
+                ['kunstmaan_fixtures.populator.method.setter', Setter::class],
+                ['kunstmaan_fixtures.populator.method.array', ArrayAdd::class],
+                ['kunstmaan_fixtures.provider.spec', Spec::class],
+                ['kunstmaan_fixtures.provider.nodetranslation', NodeTranslation::class],
+                ['kunstmaan_fixtures.provider.node', Node::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanFixturesBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/ParserCompilerPass.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/ParserCompilerPass.php
@@ -2,10 +2,16 @@
 
 namespace Kunstmaan\FixturesBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\FixturesBundle\Parser\Parser;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * Class ParserCompilerPass
+ *
+ * @package Kunstmaan\FixturesBundle\DependencyInjection\Compiler
+ */
 class ParserCompilerPass implements CompilerPassInterface
 {
     /**
@@ -13,18 +19,18 @@ class ParserCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_fixtures.parser.parser')) {
+        if (!$container->hasDefinition(Parser::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_fixtures.parser.parser');
+        $definition = $container->getDefinition(Parser::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_fixtures.parser.property');
 
         foreach ($taggedServices as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
                 $definition->addMethodCall(
                     'addParser',
-                    array(new Reference($id), $attributes['alias'])
+                    [new Reference($id), $attributes['alias']]
                 );
             }
         }
@@ -35,7 +41,7 @@ class ParserCompilerPass implements CompilerPassInterface
             foreach ($tagAttributes as $attributes) {
                 $definition->addMethodCall(
                     'addSpecParser',
-                    array(new Reference($id), $attributes['alias'])
+                    [new Reference($id), $attributes['alias']]
                 );
             }
         }

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/PopulatorCompilerPass.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/PopulatorCompilerPass.php
@@ -2,10 +2,16 @@
 
 namespace Kunstmaan\FixturesBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\FixturesBundle\Populator\Populator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * Class PopulatorCompilerPass
+ *
+ * @package Kunstmaan\FixturesBundle\DependencyInjection\Compiler
+ */
 class PopulatorCompilerPass implements CompilerPassInterface
 {
     /**
@@ -13,18 +19,18 @@ class PopulatorCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_fixtures.builder.builder')) {
+        if (!$container->hasDefinition(Populator::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_fixtures.populator.populator');
+        $definition = $container->getDefinition(Populator::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_fixtures.populator');
 
         foreach ($taggedServices as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
                 $definition->addMethodCall(
                     'addPopulator',
-                    array(new Reference($id), $attributes['alias'])
+                    [new Reference($id), $attributes['alias']]
                 );
             }
         }

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -2,10 +2,16 @@
 
 namespace Kunstmaan\FixturesBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\FixturesBundle\Builder\BuildingSupervisor;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * Class ProviderCompilerPass
+ *
+ * @package Kunstmaan\FixturesBundle\DependencyInjection\Compiler
+ */
 class ProviderCompilerPass implements CompilerPassInterface
 {
     /**
@@ -13,18 +19,18 @@ class ProviderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_fixtures.builder.builder')) {
+        if (!$container->hasDefinition(BuildingSupervisor::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_fixtures.builder.builder');
+        $definition = $container->getDefinition(BuildingSupervisor::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_fixtures.provider');
 
         foreach ($taggedServices as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
                 $definition->addMethodCall(
                     'addProvider',
-                    array(new Reference($id), $attributes['alias'])
+                    [new Reference($id), $attributes['alias']]
                 );
             }
         }

--- a/src/Kunstmaan/FixturesBundle/KunstmaanFixturesBundle.php
+++ b/src/Kunstmaan/FixturesBundle/KunstmaanFixturesBundle.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\FixturesBundle;
 
 use Kunstmaan\FixturesBundle\DependencyInjection\Compiler\BuilderCompilerPass;
+use Kunstmaan\FixturesBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\FixturesBundle\DependencyInjection\Compiler\ParserCompilerPass;
 use Kunstmaan\FixturesBundle\DependencyInjection\Compiler\PopulatorCompilerPass;
 use Kunstmaan\FixturesBundle\DependencyInjection\Compiler\ProviderCompilerPass;
@@ -19,5 +20,6 @@ class KunstmaanFixturesBundle extends Bundle
         $container->addCompilerPass(new PopulatorCompilerPass());
         $container->addCompilerPass(new ParserCompilerPass());
         $container->addCompilerPass(new ProviderCompilerPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/FixturesBundle/Provider/NodeTranslation.php
+++ b/src/Kunstmaan/FixturesBundle/Provider/NodeTranslation.php
@@ -2,20 +2,29 @@
 
 namespace Kunstmaan\FixturesBundle\Provider;
 
+use Doctrine\ORM\EntityManagerInterface;
 
-use Doctrine\ORM\EntityManager;
-
+/**
+ * Class NodeTranslation
+ *
+ * @package Kunstmaan\FixturesBundle\Provider
+ */
 class NodeTranslation
 {
     private $nodeTransRepo;
 
-    public function __construct(EntityManager $em)
+    /**
+     * NodeTranslation constructor.
+     *
+     * @param EntityManagerInterface $em
+     */
+    public function __construct(EntityManagerInterface $em)
     {
         $this->nodeTransRepo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
     }
 
     public function getTranslationByTitle($title, $lang)
     {
-        return $this->nodeTransRepo->findOneBy(array('title' => $title, 'lang' => $lang));
+        return $this->nodeTransRepo->findOneBy(['title' => $title, 'lang' => $lang]);
     }
 }

--- a/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FixturesBundle/Resources/config/services.yml
@@ -1,97 +1,80 @@
 services:
-    kunstmaan_fixtures.builder.builder:
-        class: Kunstmaan\FixturesBundle\Builder\BuildingSupervisor
+    Kunstmaan\FixturesBundle\Builder\BuildingSupervisor:
         arguments:
-            - '@kunstmaan_fixtures.parser.parser'
-            - '@kunstmaan_fixtures.populator.populator'
+            - '@Kunstmaan\FixturesBundle\Parser\Parser'
+            - '@Kunstmaan\FixturesBundle\Populator\Populator'
 
-    kunstmaan_fixtures.builder.page:
-        class: Kunstmaan\FixturesBundle\Builder\PageBuilder
+    Kunstmaan\FixturesBundle\Builder\PageBuilder:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '@kunstmaan_node.acl_permission_creator_service'
-            - '@kunstmaan_fixtures.populator.populator'
+            - '@Kunstmaan\FixturesBundle\Populator\Populator'
             - '@kunstmaan_utilities.slugifier'
             - '@kunstmaan_node.pages_configuration'
         tags:
             - { name: kunstmaan_fixtures.builder, alias: PageBuilder }
 
-    kunstmaan_fixtures.builder.pagepart:
-        class: Kunstmaan\FixturesBundle\Builder\PagePartBuilder
+    Kunstmaan\FixturesBundle\Builder\PagePartBuilder:
         arguments:
-            - '@doctrine.orm.entity_manager'
-            - '@kunstmaan_fixtures.populator.populator'
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Kunstmaan\FixturesBundle\Populator\Populator'
         tags:
             - { name: kunstmaan_fixtures.builder, alias: PagePartBuilder }
 
-    kunstmaan_fixtures.builder.media:
-        class: Kunstmaan\FixturesBundle\Builder\MediaBuilder
+    Kunstmaan\FixturesBundle\Builder\MediaBuilder:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '@kunstmaan_media.media_handlers.file'
             - '@kunstmaan_media.mimetype_guesser.factory'
         tags:
             - { name: kunstmaan_fixtures.builder, alias: MediaBuilder }
 
-    kunstmaan_fixtures.builder.menuitem:
-        class: Kunstmaan\FixturesBundle\Builder\MenuItemBuilder
+    Kunstmaan\FixturesBundle\Builder\MenuItemBuilder:
         tags:
             - { name: kunstmaan_fixtures.builder, alias: MenuItemBuilder }
 
-    kunstmaan_fixtures.parser.parser:
-        class: Kunstmaan\FixturesBundle\Parser\Parser
+    Kunstmaan\FixturesBundle\Parser\Parser: ~
 
-    kunstmaan_fixtures.parser.property.method:
-        class: Kunstmaan\FixturesBundle\Parser\Property\Method
+    Kunstmaan\FixturesBundle\Parser\Property\Method:
         tags:
             - { name: kunstmaan_fixtures.parser.property, alias: PropertyMethod }
 
-    kunstmaan_fixtures.parser.property.reference:
-        class: Kunstmaan\FixturesBundle\Parser\Property\Reference
+    Kunstmaan\FixturesBundle\Parser\Property\Reference:
         tags:
             - { name: kunstmaan_fixtures.parser.property, alias: PropertyReference }
 
-    kunstmaan_fixtures.parser.spec.range:
-        class: Kunstmaan\FixturesBundle\Parser\Spec\Range
+    Kunstmaan\FixturesBundle\Parser\Spec\Range:
         tags:
             - { name: kunstmaan_fixtures.parser.spec, alias: SpecRange }
 
-    kunstmaan_fixtures.parser.spec.listed:
-        class: Kunstmaan\FixturesBundle\Parser\Spec\Listed
+    Kunstmaan\FixturesBundle\Parser\Spec\Listed:
         tags:
             - { name: kunstmaan_fixtures.parser.spec, alias: SpecListed }
 
-    kunstmaan_fixtures.populator.populator:
-        class: Kunstmaan\FixturesBundle\Populator\Populator
+    Kunstmaan\FixturesBundle\Populator\Populator: ~
 
-    kunstmaan_fixtures.populator.method.property:
-        class: Kunstmaan\FixturesBundle\Populator\Methods\Property
+    Kunstmaan\FixturesBundle\Populator\Methods\Property:
         tags:
             - { name: kunstmaan_fixtures.populator, alias: Property }
 
-    kunstmaan_fixtures.populator.method.setter:
-        class: Kunstmaan\FixturesBundle\Populator\Methods\Setter
+    Kunstmaan\FixturesBundle\Populator\Methods\Setter:
         tags:
             - { name: kunstmaan_fixtures.populator, alias: Setter }
 
-    kunstmaan_fixtures.populator.method.array:
-        class: Kunstmaan\FixturesBundle\Populator\Methods\ArrayAdd
+    Kunstmaan\FixturesBundle\Populator\Methods\ArrayAdd:
         tags:
             - { name: kunstmaan_fixtures.populator, alias: Array }
 
-    kunstmaan_fixtures.provider.spec:
-        class: Kunstmaan\FixturesBundle\Provider\Spec
+    Kunstmaan\FixturesBundle\Provider\Spec:
         tags:
             - { name: kunstmaan_fixtures.provider, alias: Spec }
 
-    kunstmaan_fixtures.provider.nodetranslation:
-        class: Kunstmaan\FixturesBundle\Provider\NodeTranslation
+    Kunstmaan\FixturesBundle\Provider\NodeTranslation:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: kunstmaan_fixtures.provider, alias: NodeTranslation }
 
-    kunstmaan_fixtures.provider.node:
-        class: Kunstmaan\FixturesBundle\Provider\Node
+    Kunstmaan\FixturesBundle\Provider\Node:
         tags:
             - { name: kunstmaan_fixtures.provider, alias: Node }

--- a/src/Kunstmaan/FormBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/FormBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Kunstmaan\FormBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\FormBundle\EventListener\ConfigureActionsMenuListener;
+use Kunstmaan\FormBundle\Helper\FormHandler;
+use Kunstmaan\FormBundle\Helper\FormMailer;
+use Kunstmaan\FormBundle\Helper\Menu\FormSubmissionsMenuAdaptor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\FormBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_form.menu.adaptor.forms', FormSubmissionsMenuAdaptor::class],
+                ['kunstmaan_form.form_mailer', FormMailer::class],
+                ['kunstmaan_form.form_handler', FormHandler::class],
+                ['kunstmaan_form.configure_sub_actions_menu_listener', ConfigureActionsMenuListener::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_form.form_mailer.class', FormMailer::class],
+                ['kunstmaan_form.form_handler.class', FormHandler::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanFormBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanFormBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/FormBundle/DependencyInjection/KunstmaanFormExtension.php
+++ b/src/Kunstmaan/FormBundle/DependencyInjection/KunstmaanFormExtension.php
@@ -2,7 +2,10 @@
 
 namespace Kunstmaan\FormBundle\DependencyInjection;
 
+use Kunstmaan\FormBundle\Helper\FormHandler;
+use Kunstmaan\FormBundle\Helper\FormHandlerInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
@@ -20,22 +23,28 @@ class KunstmaanFormExtension extends Extension implements PrependExtensionInterf
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-
         $configuration = new Configuration();
         $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $container->setAlias(FormHandlerInterface::class, new Alias(FormHandler::class));
     }
 
+    /**
+     * @param ContainerBuilder $container
+     */
     public function prepend(ContainerBuilder $container)
     {
-        if(!$container->hasParameter('form_submission_rootdir')) {
-            $container->setParameter('form_submission_rootdir',
-                sprintf('%s/../web/uploads/formsubmissions', $container->getParameter('kernel.root_dir')));
+        if (!$container->hasParameter('form_submission_rootdir')) {
+            $container->setParameter(
+                'form_submission_rootdir',
+                sprintf('%s/../web/uploads/formsubmissions', $container->getParameter('kernel.root_dir'))
+            );
         }
 
-        if(!$container->hasParameter('form_submission_webdir')) {
+        if (!$container->hasParameter('form_submission_webdir')) {
             $container->setParameter('form_submission_webdir', '/uploads/formsubmissions/');
         }
 

--- a/src/Kunstmaan/FormBundle/EventListener/ConfigureActionsMenuListener.php
+++ b/src/Kunstmaan/FormBundle/EventListener/ConfigureActionsMenuListener.php
@@ -2,11 +2,9 @@
 
 namespace Kunstmaan\FormBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
-
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\FormBundle\Entity\AbstractFormPage;
 use Kunstmaan\NodeBundle\Event\ConfigureActionMenuEvent;
-
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -15,21 +13,17 @@ use Symfony\Component\Routing\RouterInterface;
 class ConfigureActionsMenuListener
 {
 
-    /**
-     * @var EntityManager
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var Router
-     */
+    /** @var RouterInterface */
     private $router;
 
     /**
-     * @param EntityManager $em     The entity manager
-     * @param RouterInterface       $router The router
+     * @param EntityManagerInterface $em     The entity manager
+     * @param RouterInterface        $router The router
      */
-    public function __construct(EntityManager $em, RouterInterface $router)
+    public function __construct(EntityManagerInterface $em, RouterInterface $router)
     {
         $this->router = $router;
         $this->em = $em;
@@ -49,7 +43,15 @@ class ConfigureActionsMenuListener
             $page = $activeNodeVersion->getRef($this->em);
             if ($page instanceof AbstractFormPage) {
                 $activeNodeTranslation = $activeNodeVersion->getNodeTranslation();
-                $menu->addChild('subaction.formsubmissions', array('uri' => $this->router->generate('KunstmaanFormBundle_formsubmissions_list', array('nodeTranslationId' => $activeNodeTranslation->getId()))));
+                $menu->addChild(
+                    'subaction.formsubmissions',
+                    [
+                        'uri' => $this->router->generate(
+                            'KunstmaanFormBundle_formsubmissions_list',
+                            ['nodeTranslationId' => $activeNodeTranslation->getId()]
+                        ),
+                    ]
+                );
             }
         }
     }

--- a/src/Kunstmaan/FormBundle/Helper/FormMailer.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormMailer.php
@@ -6,18 +6,20 @@ use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Swift_Mailer;
 use Swift_Message;
 use Swift_Mime_Message;
-use Symfony\Bundle\TwigBundle\TwigEngine;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * The form mailer
+ * Class FormMailer
+ *
+ * @package Kunstmaan\FormBundle\Helper
  */
 class FormMailer implements FormMailerInterface
 {
     /** @var \Swift_Mailer */
     private $mailer;
 
-    /** @var \Symfony\Bundle\TwigBundle\TwigEngine */
+    /** @var EngineInterface * */
     private $templating;
 
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
@@ -25,14 +27,14 @@ class FormMailer implements FormMailerInterface
 
     /**
      * @param Swift_Mailer       $mailer     The mailer service
-     * @param TwigEngine         $templating The templating service
+     * @param EngineInterface    $templating The templating service
      * @param ContainerInterface $container  The container
      */
-    public function __construct(Swift_Mailer $mailer, TwigEngine $templating, ContainerInterface $container)
+    public function __construct(Swift_Mailer $mailer, EngineInterface $templating, ContainerInterface $container)
     {
-        $this->mailer     = $mailer;
+        $this->mailer = $mailer;
         $this->templating = $templating;
-        $this->container  = $container;
+        $this->container = $container;
     }
 
     /**
@@ -51,10 +53,10 @@ class FormMailer implements FormMailerInterface
         $message->setBody(
             $this->templating->render(
                 'KunstmaanFormBundle:Mailer:mail.html.twig',
-                array(
+                [
                     'submission' => $submission,
-                    'host'       => $request->getScheme() . '://' . $request->getHttpHost()
-                )
+                    'host' => $request->getScheme().'://'.$request->getHttpHost(),
+                ]
             ),
             'text/html'
         );

--- a/src/Kunstmaan/FormBundle/KunstmaanFormBundle.php
+++ b/src/Kunstmaan/FormBundle/KunstmaanFormBundle.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\FormBundle;
 
+use Kunstmaan\FormBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,4 +11,10 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanFormBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/FormBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/services.yml
@@ -3,21 +3,23 @@ parameters:
   kunstmaan_form.form_handler.class: 'Kunstmaan\FormBundle\Helper\FormHandler'
 
 services:
-    kunstmaan_form.menu.adaptor.forms:
-        class: Kunstmaan\FormBundle\Helper\Menu\FormSubmissionsMenuAdaptor
+    Kunstmaan\FormBundle\Helper\Menu\FormSubmissionsMenuAdaptor:
         tags:
             -  { name: kunstmaan_admin.menu.adaptor }
 
-    kunstmaan_form.form_mailer:
-        class: '%kunstmaan_form.form_mailer.class%'
-        arguments: ['@mailer', '@templating', '@service_container']
+    Kunstmaan\FormBundle\Helper\FormMailer:
+        arguments:
+            - '@Swift_Mailer'
+            - '@Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
 
-    kunstmaan_form.form_handler:
-        class: "%kunstmaan_form.form_handler.class%"
-        arguments: ['@service_container']
+    Kunstmaan\FormBundle\Helper\FormHandler:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
 
-    kunstmaan_form.configure_sub_actions_menu_listener:
-        class: Kunstmaan\FormBundle\EventListener\ConfigureActionsMenuListener
-        arguments: ['@doctrine.orm.entity_manager', '@router']
+    Kunstmaan\FormBundle\EventListener\ConfigureActionsMenuListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Routing\RouterInterface'
         tags:
             - { name: 'kernel.event_listener', event: 'kunstmaan_node.configureSubActionMenu', method: 'onSubActionMenuConfigure' }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_partial.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_partial.yml
@@ -4,4 +4,4 @@
     type:     annotation
     prefix:   /{_locale}/admin/{{ entity_class|lower }}{{ type|lower }}/
     requirements:
-         _locale: %requiredlocales%
+         _locale: "%requiredlocales%"

--- a/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleBlackListAdminType;
+use Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleWhiteListAdminType;
+use Kunstmaan\LeadGenerationBundle\Service\MenuAdaptor;
+use Kunstmaan\LeadGenerationBundle\Service\PopupManager;
+use Kunstmaan\LeadGenerationBundle\Service\Rule\LocaleRuleService;
+use Kunstmaan\LeadGenerationBundle\Twig\PopupTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_lead_generation.popup.manager', PopupManager::class],
+                ['kunstmaan_lead_generation.popup.twig.extension', PopupTwigExtension::class],
+                ['kunstmaan_lead_generation.menu.adaptor', MenuAdaptor::class],
+                ['kunstmaan_lead_generation.rule.form.localewhitelistrule', LocaleWhiteListAdminType::class],
+                ['kunstmaan_lead_generation.rule.form.localeblacklistrule', LocaleBlackListAdminType::class],
+                ['kunstmaan_lead_generation.rule.service.localeruleservice', LocaleRuleService::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_lead_generation.popup.twig.extension.class', PopupTwigExtension::class, true],
+                ['kunstmaan_lead_generation.popup.manager.class', PopupManager::class, true],
+                ['kunstmaan_lead_generation.menu.adaptor.class', MenuAdaptor::class, true],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanLeadGenerationBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanLeadGenerationBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/LeadGenerationBundle/KunstmaanLeadGenerationBundle.php
+++ b/src/Kunstmaan/LeadGenerationBundle/KunstmaanLeadGenerationBundle.php
@@ -2,9 +2,19 @@
 
 namespace Kunstmaan\LeadGenerationBundle;
 
+use Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class KunstmaanLeadGenerationBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/LeadGenerationBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/LeadGenerationBundle/Resources/config/services.yml
@@ -1,40 +1,38 @@
 parameters:
-    kunstmaan_lead_generation.popup.twig.extension.class: Kunstmaan\LeadGenerationBundle\Twig\PopupTwigExtension
     kunstmaan_lead_generation.popup.manager.class: Kunstmaan\LeadGenerationBundle\Service\PopupManager
+    kunstmaan_lead_generation.popup.twig.extension.class: Kunstmaan\LeadGenerationBundle\Twig\PopupTwigExtension
     kunstmaan_lead_generation.menu.adaptor.class: Kunstmaan\LeadGenerationBundle\Service\MenuAdaptor
 
 services:
-    kunstmaan_lead_generation.popup.manager:
-        class: '%kunstmaan_lead_generation.popup.manager.class%'
-        arguments: ['@doctrine.orm.entity_manager']
-
-    kunstmaan_lead_generation.popup.twig.extension:
-        class: '%kunstmaan_lead_generation.popup.twig.extension.class%'
+    Kunstmaan\LeadGenerationBundle\Service\PopupManager:
         arguments:
-            - '@kunstmaan_lead_generation.popup.manager'
-            - '@service_container'
+            - '@Doctrine\ORM\EntityManagerInterface'
+
+    Kunstmaan\LeadGenerationBundle\Twig\PopupTwigExtension:
+        arguments:
+            - '@Kunstmaan\LeadGenerationBundle\Service\PopupManager'
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
             - '%kunstmaan_lead_generation.popup_types%'
             - '%kunstmaan_lead_generation.debug%'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_lead_generation.menu.adaptor:
-        class: '%kunstmaan_lead_generation.menu.adaptor.class%'
+    Kunstmaan\LeadGenerationBundle\Service\MenuAdaptor:
         tags:
             - { name: kunstmaan_admin.menu.adaptor }
 
-    kunstmaan_lead_generation.rule.form.localewhitelistrule:
-        class: Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleWhiteListAdminType
-        arguments: ['@kunstmaan_admin.domain_configuration']
+    Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleWhiteListAdminType:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
             - { name: form.type }
 
-    kunstmaan_lead_generation.rule.form.localeblacklistrule:
-        class: Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleBlackListAdminType
-        arguments: ['@kunstmaan_admin.domain_configuration']
+    Kunstmaan\LeadGenerationBundle\Form\Rule\LocaleBlackListAdminType:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
             - { name: form.type }
 
-    kunstmaan_lead_generation.rule.service.localeruleservice:
-        class: Kunstmaan\LeadGenerationBundle\Service\Rule\LocaleRuleService
-        arguments: ['@request_stack']
+    Kunstmaan\LeadGenerationBundle\Service\Rule\LocaleRuleService:
+        arguments:
+            - '@Symfony\Component\HttpFoundation\RequestStack'

--- a/src/Kunstmaan/LeadGenerationBundle/Service/PopupManager.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Service/PopupManager.php
@@ -2,9 +2,14 @@
 
 namespace Kunstmaan\LeadGenerationBundle\Service;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup;
 
+/**
+ * Class PopupManager
+ *
+ * @package Kunstmaan\LeadGenerationBundle\Service
+ */
 class PopupManager
 {
     /**
@@ -13,14 +18,14 @@ class PopupManager
     private $popups = null;
 
     /**
-     * @var EntityManager $em
+     * @var EntityManagerInterface $em
      */
     private $em;
 
     /**
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }
@@ -32,7 +37,7 @@ class PopupManager
      */
     public function getPopups()
     {
-        if (is_null($this->popups)) {
+        if (null === $this->popups) {
             $this->popups = $this->em->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->findAll();
         }
 
@@ -46,7 +51,7 @@ class PopupManager
      */
     public function getUniqueJsIncludes()
     {
-        $includes = array();
+        $includes = [];
         foreach ($this->getPopups() as $popup) {
             foreach ($popup->getRules() as $rule) {
                 $includes[] = $rule->getJsFilePath();
@@ -58,22 +63,23 @@ class PopupManager
 
     /**
      * @param AbstractPopup $popup
+     *
      * @return array
      */
     public function getAvailableRules(AbstractPopup $popup)
     {
-        if (!is_null($popup->getAvailableRules())) {
+        if (null !== $popup->getAvailableRules()) {
             return $popup->getAvailableRules();
-        } else {
-            return array(
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\AfterXSecondsRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\AfterXScrollPercentRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\MaxXTimesRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\RecurringEveryXTimeRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\UrlBlacklistRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\UrlWhitelistRule',
-                'Kunstmaan\LeadGenerationBundle\Entity\Rule\OnExitIntentRule'
-            );
         }
+
+        return [
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\AfterXSecondsRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\AfterXScrollPercentRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\MaxXTimesRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\RecurringEveryXTimeRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\UrlBlacklistRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\UrlWhitelistRule',
+            'Kunstmaan\LeadGenerationBundle\Entity\Rule\OnExitIntentRule',
+        ];
     }
 }

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\MediaBundle\Command\CleanDeletedMediaCommand;
+use Kunstmaan\MediaBundle\Command\RebuildFolderTreeCommand;
+use Kunstmaan\MediaBundle\EventListener\DoctrineMediaListener;
+use Kunstmaan\MediaBundle\Form\Type\IconFontType;
+use Kunstmaan\MediaBundle\Form\Type\MediaType;
+use Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactory;
+use Kunstmaan\MediaBundle\Helper\FolderManager;
+use Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader;
+use Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager;
+use Kunstmaan\MediaBundle\Helper\MediaManager;
+use Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor;
+use Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory;
+use Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService;
+use Kunstmaan\MediaBundle\Repository\FolderRepository;
+use Kunstmaan\MediaBundle\Validator\Constraints\HasGuessableExtensionValidator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\MediaBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_media.media_manager', MediaManager::class],
+                ['kunstmaan_media.listener.doctrine', DoctrineMediaListener::class],
+                ['form.type.media', MediaType::class],
+                ['form.type.iconfont', IconFontType::class],
+                ['kunstmaan_media.icon_font_manager', IconFontManager::class],
+                ['kunstmaan_media.icon_font.default_loader', DefaultIconFontLoader::class],
+                ['kunstmaan_media.media_creator_service', MediaCreatorService::class],
+                ['kunstmaan_media.repository.folder', FolderRepository::class],
+                ['kunstmaan_media.menu.adaptor', MediaMenuAdaptor::class],
+                ['kunstmaan_media.folder_manager', FolderManager::class],
+                ['kunstmaan_media.mimetype_guesser.factory', MimeTypeGuesserFactory::class],
+                ['kunstmaan_media.extension_guesser.factory', ExtensionGuesserFactory::class],
+                ['kunstmaan_media.command.rebuildfoldertree', RebuildFolderTreeCommand::class],
+                ['kunstmaan_media.command.cleandeletedmedia', CleanDeletedMediaCommand::class],
+                ['kunstmaan_media.validator.has_guessable_extension', HasGuessableExtensionValidator::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_media.media_manager.class', MediaManager::class],
+                ['kunstmaan_media.folder_manager.class', FolderManager::class],
+                ['kunstmaan_media.menu.adaptor.class', MediaMenuAdaptor::class],
+                ['kunstmaan_media.listener.doctrine.class', DoctrineMediaListener::class],
+                ['kunstmaan_media.form.type.media.class', MediaType::class],
+                ['kunstmaan_media.form.type.iconfont.class', IconFontType::class],
+                ['kunstmaan_media.icon_font_manager.class', IconFontManager::class],
+                ['kunstmaan_media.icon_font.default_loader.class', DefaultIconFontLoader::class],
+                ['kunstmaan_media.media_creator_service.class', MediaCreatorService::class],
+                ['kunstmaan_media.mimetype_guesser.factory.class', MimeTypeGuesserFactory::class],
+                ['kunstmaan_media.extension_guesser.factory.class', ExtensionGuesserFactory::class],
+                ['kunstmaan_media.validator.has_guessable_extension.class', HasGuessableExtensionValidator::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanMediaBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanMediaBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\MediaBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager;
+use Kunstmaan\MediaBundle\Helper\MediaManager;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -18,16 +20,16 @@ class MediaHandlerCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('kunstmaan_media.media_manager')) {
-            $definition = $container->getDefinition('kunstmaan_media.media_manager');
+        if ($container->hasDefinition(MediaManager::class)) {
+            $definition = $container->getDefinition(MediaManager::class);
 
             foreach ($container->findTaggedServiceIds('kunstmaan_media.media_handler') as $id => $attributes) {
                 $definition->addMethodCall('addHandler', array(new Reference($id)));
             }
         }
 
-        if ($container->hasDefinition('kunstmaan_media.icon_font_manager')) {
-            $definition = $container->getDefinition('kunstmaan_media.icon_font_manager');
+        if ($container->hasDefinition(IconFontManager::class)) {
+            $definition = $container->getDefinition(IconFontManager::class);
 
             foreach ($container->findTaggedServiceIds('kunstmaan_media.icon_font.loader') as $id => $attributes) {
                 $definition->addMethodCall('addLoader', array(new Reference($id), $id));

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Kunstmaan\MediaBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -25,15 +26,15 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config        = $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $container->setParameter(
             'twig.form.resources',
             array_merge(
                 $container->getParameter('twig.form.resources'),
-                array('KunstmaanMediaBundle:Form:formWidgets.html.twig')
+                ['KunstmaanMediaBundle:Form:formWidgets.html.twig']
             )
         );
         $container->setParameter('kunstmaan_media.soundcloud_api_key', $config['soundcloud_api_key']);
@@ -57,6 +58,9 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $loader->load('imagine.xml');
     }
 
+    /**
+     * @param ContainerBuilder $container
+     */
     public function prepend(ContainerBuilder $container)
     {
 
@@ -64,13 +68,13 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
             $container->setParameter('kunstmaan_media.upload_dir', '/uploads/media/');
         }
 
-        $twigConfig = array();
-        $twigConfig['globals']['upload_dir']          = $container->getParameter('kunstmaan_media.upload_dir');
+        $twigConfig = [];
+        $twigConfig['globals']['upload_dir'] = $container->getParameter('kunstmaan_media.upload_dir');
         $twigConfig['globals']['mediabundleisactive'] = true;
-        $twigConfig['globals']['mediamanager']        = "@kunstmaan_media.media_manager";
+        $twigConfig['globals']['mediamanager'] = "@kunstmaan_media.media_manager";
         $container->prependExtensionConfig('twig', $twigConfig);
 
-        $liipConfig = Yaml::parse(file_get_contents(__DIR__ . '/../Resources/config/imagine_filters.yml'));
+        $liipConfig = Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/imagine_filters.yml'));
         $container->prependExtensionConfig('liip_imagine', $liipConfig['liip_imagine']);
 
         $configs = $container->getExtensionConfig($this->getAlias());

--- a/src/Kunstmaan/MediaBundle/KunstmaanMediaBundle.php
+++ b/src/Kunstmaan/MediaBundle/KunstmaanMediaBundle.php
@@ -2,14 +2,15 @@
 
 namespace Kunstmaan\MediaBundle;
 
+use Kunstmaan\MediaBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\MediaBundle\DependencyInjection\Compiler\MediaHandlerCompilerPass;
-
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanMediaBundle
+ * Class KunstmaanMediaBundle
+ *
+ * @package Kunstmaan\MediaBundle
  */
 class KunstmaanMediaBundle extends Bundle
 {
@@ -22,5 +23,6 @@ class KunstmaanMediaBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new MediaHandlerCompilerPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -1,10 +1,10 @@
 parameters:
     kunstmaan_media.media_manager.class: 'Kunstmaan\MediaBundle\Helper\MediaManager'
-    kunstmaan_media.folder_manager.class: 'Kunstmaan\MediaBundle\Helper\FolderManager'
-    kunstmaan_media.menu.adaptor.class: 'Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor'
     kunstmaan_media.listener.doctrine.class: 'Kunstmaan\MediaBundle\EventListener\DoctrineMediaListener'
     kunstmaan_media.form.type.media.class: 'Kunstmaan\MediaBundle\Form\Type\MediaType'
     kunstmaan_media.form.type.iconfont.class: 'Kunstmaan\MediaBundle\Form\Type\IconFontType'
+    kunstmaan_media.folder_manager.class: 'Kunstmaan\MediaBundle\Helper\FolderManager'
+    kunstmaan_media.menu.adaptor.class: 'Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor'
     kunstmaan_media.icon_font_manager.class: 'Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager'
     kunstmaan_media.icon_font.default_loader.class: 'Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader'
     kunstmaan_media.media_creator_service.class: 'Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService'
@@ -13,14 +13,13 @@ parameters:
     kunstmaan_media.validator.has_guessable_extension.class: 'Kunstmaan\MediaBundle\Validator\Constraints\HasGuessableExtensionValidator'
 
 services:
-    kunstmaan_media.media_manager:
-        class: '%kunstmaan_media.media_manager.class%'
+    Kunstmaan\MediaBundle\Helper\MediaManager:
         calls:
             - [ setDefaultHandler, [ '@kunstmaan_media.media_handlers.file' ] ]
 
-    kunstmaan_media.listener.doctrine:
-        class: '%kunstmaan_media.listener.doctrine.class%'
-        arguments: ['@kunstmaan_media.media_manager']
+    Kunstmaan\MediaBundle\EventListener\DoctrineMediaListener:
+        arguments:
+            - '@Kunstmaan\MediaBundle\Helper\MediaManager'
         tags:
             - { name: 'doctrine.event_listener', event: 'prePersist' }
             - { name: 'doctrine.event_listener', event: 'preUpdate' }
@@ -28,63 +27,57 @@ services:
             - { name: 'doctrine.event_listener', event: 'postUpdate' }
             - { name: 'doctrine.event_listener', event: 'preRemove' }
 
-    form.type.media:
-        class: '%kunstmaan_media.form.type.media.class%'
+    Kunstmaan\MediaBundle\Form\Type\MediaType:
         arguments:
-            - '@kunstmaan_media.media_manager'
-            - '@doctrine.orm.entity_manager'
+            - '@Kunstmaan\MediaBundle\Helper\MediaManager'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: form.type}
 
-    form.type.iconfont:
-        class: '%kunstmaan_media.form.type.iconfont.class%'
-        arguments: ['@kunstmaan_media.icon_font_manager']
+    Kunstmaan\MediaBundle\Form\Type\IconFontType:
+        arguments:
+            - '@Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager'
         tags:
             - { name: form.type }
 
-    kunstmaan_media.icon_font_manager:
-        class: '%kunstmaan_media.icon_font_manager.class%'
+    Kunstmaan\MediaBundle\Helper\IconFont\IconFontManager:
         calls:
             - [ setDefaultLoader, [ '@kunstmaan_media.icon_font.default_loader' ] ]
 
-    kunstmaan_media.icon_font.default_loader:
-        class: '%kunstmaan_media.icon_font.default_loader.class%'
-        arguments: ['@kernel']
+    Kunstmaan\MediaBundle\Helper\IconFont\DefaultIconFontLoader:
+        arguments:
+            - '@kernel'
         tags:
             -  { name: 'kunstmaan_media.icon_font.loader' }
 
-    kunstmaan_media.media_creator_service:
-        class: '%kunstmaan_media.media_creator_service.class%'
-        arguments: ['@service_container']
+    Kunstmaan\MediaBundle\Helper\Services\MediaCreatorService:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
 
-    kunstmaan_media.repository.folder:
-        class:            Kunstmaan\MediaBundle\Repository\FolderRepository
-        factory:          ['@doctrine.orm.entity_manager', getRepository]
-        arguments:        ['KunstmaanMediaBundle:Folder']
+    Kunstmaan\MediaBundle\Repository\FolderRepository:
+        factory: ['@Doctrine\ORM\EntityManagerInterface', getRepository]
+        arguments:
+            - 'KunstmaanMediaBundle:Folder'
 
-    kunstmaan_media.menu.adaptor:
-        class: '%kunstmaan_media.menu.adaptor.class%'
-        arguments: ['@kunstmaan_media.repository.folder']
+    Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor:
+        arguments:
+            - '@Kunstmaan\MediaBundle\Repository\FolderRepository'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_media.folder_manager:
-        class: '%kunstmaan_media.folder_manager.class%'
-        arguments: ['@kunstmaan_media.repository.folder']
+    Kunstmaan\MediaBundle\Helper\FolderManager:
+        arguments:
+            - '@Kunstmaan\MediaBundle\Repository\FolderRepository'
 
-    kunstmaan_media.mimetype_guesser.factory:
-        class: '%kunstmaan_media.mimetype_guesser.factory.class%'
+    Kunstmaan\MediaBundle\Helper\MimeTypeGuesserFactory: ~
 
-    kunstmaan_media.extension_guesser.factory:
-        class: '%kunstmaan_media.extension_guesser.factory.class%'
+    Kunstmaan\MediaBundle\Helper\ExtensionGuesserFactory: ~
 
-    kunstmaan_media.command.rebuildfoldertree:
-        class: Kunstmaan\MediaBundle\Command\RebuildFolderTreeCommand
+    Kunstmaan\MediaBundle\Command\RebuildFolderTreeCommand:
         calls:
             - [setContainer, ['@service_container'] ]
 
-    kunstmaan_media.command.cleandeletedmedia:
-        class: Kunstmaan\MediaBundle\Command\CleanDeletedMediaCommand
+    Kunstmaan\MediaBundle\Command\CleanDeletedMediaCommand:
         calls:
             - [setContainer, ['@service_container'] ]
 
@@ -99,8 +92,7 @@ services:
         arguments:
             - '@kunstmaan_media.filesystem_adapter'
 
-    kunstmaan_media.validator.has_guessable_extension:
-        class: '%kunstmaan_media.validator.has_guessable_extension.class%'
+    Kunstmaan\MediaBundle\Validator\Constraints\HasGuessableExtensionValidator:
         tags:
             - { name: validator.constraint_validator, alias: has_guessable_extension }
         calls:

--- a/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
+++ b/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\MenuBundle\AdminList;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
@@ -17,11 +17,11 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     private $menu;
 
     /**
-     * @param EntityManager $em        The entity manager
-     * @param AclHelper     $aclHelper The acl helper
-     * @param Menu          $menu
+     * @param EntityManagerInterface $em        The entity manager
+     * @param AclHelper              $aclHelper The acl helper
+     * @param Menu                   $menu
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper = null, Menu $menu)
+    public function __construct(EntityManagerInterface $em, AclHelper $aclHelper = null, Menu $menu)
     {
         parent::__construct($em, $aclHelper);
 
@@ -82,7 +82,7 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     public function getValue($item, $columnName)
     {
         if ($columnName == 'title') {
-           return $item->getDisplayTitle();
+            return $item->getDisplayTitle();
         } elseif ($columnName == 'online') {
             return $item;
         } elseif ($columnName == 'type') {
@@ -105,7 +105,7 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getExtraParameters()
     {
-        return array('menuid' => $this->menu->getId());
+        return ['menuid' => $this->menu->getId()];
     }
 
     /**

--- a/src/Kunstmaan/MenuBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/MenuBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kunstmaan\MenuBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\MenuBundle\Repository\MenuItemRepository;
+use Kunstmaan\MenuBundle\Service\MenuAdaptor;
+use Kunstmaan\MenuBundle\Service\MenuService;
+use Kunstmaan\MenuBundle\Service\RenderService;
+use Kunstmaan\MenuBundle\Twig\MenuTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\MenuBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_menu.menu.adaptor', MenuAdaptor::class],
+                ['kunstmaan_menu.menu.service', MenuService::class],
+                ['kunstmaan_menu.menu.render_service', RenderService::class],
+                ['kunstmaan_menu.menu.repository', MenuItemRepository::class],
+                ['kunstmaan_menu.menu.twig.extension', MenuTwigExtension::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_menu.menu.adaptor.class', MenuAdaptor::class],
+                ['kunstmaan_menu.menu.service.class', MenuService::class],
+                ['kunstmaan_menu.menu.twig.extension.class', MenuTwigExtension::class],
+                ['kunstmaan_menu.menu.repository.class', MenuItemRepository::class],
+                ['kunstmaan_menu.menu.render_service.class', RenderService::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanMenuBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanMenuBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/MenuBundle/DependencyInjection/KunstmaanMenuExtension.php
+++ b/src/Kunstmaan/MenuBundle/DependencyInjection/KunstmaanMenuExtension.php
@@ -23,14 +23,14 @@ class KunstmaanMenuExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('kunstmaan_menu.menus', $config['menus']);
-	$container->setParameter('kunstmaan_menu.entity.menu.class', $config['menu_entity']);
-	$container->setParameter('kunstmaan_menu.entity.menuitem.class', $config['menuitem_entity']);
-	$container->setParameter('kunstmaan_menu.adminlist.menu_configurator.class', $config['menu_adminlist']);
-	$container->setParameter('kunstmaan_menu.adminlist.menuitem_configurator.class', $config['menuitem_adminlist']);
-	$container->setParameter('kunstmaan_menu.form.menu_admintype.class', $config['menu_form']);
-	$container->setParameter('kunstmaan_menu.form.menuitem_admintype.class', $config['menuitem_form']);
+        $container->setParameter('kunstmaan_menu.entity.menu.class', $config['menu_entity']);
+        $container->setParameter('kunstmaan_menu.entity.menuitem.class', $config['menuitem_entity']);
+        $container->setParameter('kunstmaan_menu.adminlist.menu_configurator.class', $config['menu_adminlist']);
+        $container->setParameter('kunstmaan_menu.adminlist.menuitem_configurator.class', $config['menuitem_adminlist']);
+        $container->setParameter('kunstmaan_menu.form.menu_admintype.class', $config['menu_form']);
+        $container->setParameter('kunstmaan_menu.form.menuitem_admintype.class', $config['menuitem_form']);
 
-	$loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }
 }

--- a/src/Kunstmaan/MenuBundle/KunstmaanMenuBundle.php
+++ b/src/Kunstmaan/MenuBundle/KunstmaanMenuBundle.php
@@ -2,9 +2,24 @@
 
 namespace Kunstmaan\MenuBundle;
 
+use Kunstmaan\MenuBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanMenuBundle
+ *
+ * @package Kunstmaan\MenuBundle
+ */
 class KunstmaanMenuBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/MenuBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/services.yml
@@ -1,40 +1,36 @@
 parameters:
     kunstmaan_menu.menu.adaptor.class: Kunstmaan\MenuBundle\Service\MenuAdaptor
     kunstmaan_menu.menu.service.class: Kunstmaan\MenuBundle\Service\MenuService
-    kunstmaan_menu.menu.twig.extension.class: Kunstmaan\MenuBundle\Twig\MenuTwigExtension
-    kunstmaan_menu.menu.repository.class: Kunstmaan\MenuBundle\Repository\MenuItemRepository
     kunstmaan_menu.menu.render_service.class: Kunstmaan\MenuBundle\Service\RenderService
+    kunstmaan_menu.menu.repository.class: Kunstmaan\MenuBundle\Repository\MenuItemRepository
+    kunstmaan_menu.menu.twig.extension.class: Kunstmaan\MenuBundle\Twig\MenuTwigExtension
 
 services:
-    kunstmaan_menu.menu.adaptor:
-        class: '%kunstmaan_menu.menu.adaptor.class%'
-        arguments: ['%kunstmaan_menu.menus%']
+    Kunstmaan\MenuBundle\Service\MenuAdaptor:
+        arguments:
+            - '%kunstmaan_menu.menus%'
         tags:
             - { name: kunstmaan_admin.menu.adaptor }
 
-
-    kunstmaan_menu.menu.service:
-        class: '%kunstmaan_menu.menu.service.class%'
+    Kunstmaan\MenuBundle\Service\MenuService:
         arguments:
             - '%kunstmaan_menu.menus%'
-            - '@kunstmaan_admin.domain_configuration'
-            - '@doctrine.orm.entity_manager'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '%kunstmaan_menu.entity.menu.class%'
 
-    kunstmaan_menu.menu.render_service:
-        class: '%kunstmaan_menu.menu.render_service.class%'
+    Kunstmaan\MenuBundle\Service\RenderService:
         arguments:
-            - '@router'
+            - '@Symfony\Component\Routing\RouterInterface'
 
-    kunstmaan_menu.menu.repository:
-        class:            '%kunstmaan_menu.menu.repository.class%'
-        factory:          ['@doctrine.orm.entity_manager', getRepository]
-        arguments:        ['%kunstmaan_menu.entity.menuitem.class%']
-
-    kunstmaan_menu.menu.twig.extension:
-        class: '%kunstmaan_menu.menu.twig.extension.class%'
+    Kunstmaan\MenuBundle\Repository\MenuItemRepository:
+        factory: ['@Doctrine\ORM\EntityManagerInterface', getRepository]
         arguments:
-            - '@kunstmaan_menu.menu.repository'
-            - '@kunstmaan_menu.menu.render_service'
+            - '%kunstmaan_menu.entity.menuitem.class%'
+
+    Kunstmaan\MenuBundle\Twig\MenuTwigExtension:
+        arguments:
+            - '@Kunstmaan\MenuBundle\Repository\MenuItemRepository'
+            - '@Kunstmaan\MenuBundle\Service\RenderService'
         tags:
             - { name: twig.extension }

--- a/src/Kunstmaan/MenuBundle/Service/MenuService.php
+++ b/src/Kunstmaan/MenuBundle/Service/MenuService.php
@@ -2,10 +2,14 @@
 
 namespace Kunstmaan\MenuBundle\Service;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
-use Kunstmaan\MenuBundle\Entity\Menu;
 
+/**
+ * Class MenuService
+ *
+ * @package Kunstmaan\MenuBundle\Service
+ */
 class MenuService
 {
     /**
@@ -19,7 +23,7 @@ class MenuService
     private $domainConfiguration;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -29,11 +33,11 @@ class MenuService
     private $menuEntityClass;
 
     /**
-     * @param array $menuNames
+     * @param array                        $menuNames
      * @param DomainConfigurationInterface $domainConfiguration
-     * @param EntityManager $em
+     * @param EntityManagerInterface       $em
      */
-    public function __construct(array $menuNames, DomainConfigurationInterface $domainConfiguration, EntityManager $em, $menuEntityClass)
+    public function __construct(array $menuNames, DomainConfigurationInterface $domainConfiguration, EntityManagerInterface $em, $menuEntityClass)
     {
         $this->menuNames = $menuNames;
         $this->domainConfiguration = $domainConfiguration;
@@ -47,7 +51,7 @@ class MenuService
     public function makeSureMenusExist()
     {
         $locales = array_unique($this->getLocales());
-        $required = array();
+        $required = [];
 
         foreach ($this->menuNames as $name) {
             $required[$name] = $locales;

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Kunstmaan\MultiDomainBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener;
+use Kunstmaan\MultiDomainBundle\Helper\AdminPanel\SitesAdminPanelAdaptor;
+use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
+use Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler;
+use Kunstmaan\MultiDomainBundle\Router\DomainBasedLocaleRouter;
+use Kunstmaan\MultiDomainBundle\Twig\MultiDomainTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\MultiDomainBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_multi_domain.admin_panel.sites', SitesAdminPanelAdaptor::class],
+                ['kunstmaan_multi_domain.twig.extension', MultiDomainTwigExtension::class],
+                ['kunstmaan_multi_domain.host_override_listener', HostOverrideListener::class],
+                ['kunstmaan_multi_domain.host_override_cleanup', HostOverrideCleanupHandler::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_multi_domain.router.class', DomainBasedLocaleRouter::class],
+                ['kunstmaan_multi_domain.domain_configuration.class', DomainConfiguration::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanMultiDomainBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanMultiDomainBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/KunstmaanMultiDomainExtension.php
@@ -32,7 +32,7 @@ class KunstmaanMultiDomainExtension extends Extension
 
         $loader = new Loader\YamlFileLoader(
             $container,
-            new FileLocator(__DIR__ . '/../Resources/config')
+            new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.yml');
 
@@ -64,7 +64,7 @@ class KunstmaanMultiDomainExtension extends Extension
      */
     private function getHostConfigurations($hosts)
     {
-        $hostConfigurations = array();
+        $hostConfigurations = [];
         foreach ($hosts as $name => $settings) {
             $host = $settings['host'];
             // Set the key of the host as id.
@@ -92,7 +92,7 @@ class KunstmaanMultiDomainExtension extends Extension
      */
     private function getHostLocales($localeSettings)
     {
-        $hostLocales = array();
+        $hostLocales = [];
         foreach ($localeSettings as $key => $localeMapping) {
             $hostLocales[$localeMapping['uri_locale']] = $localeMapping['locale'];
         }
@@ -109,9 +109,9 @@ class KunstmaanMultiDomainExtension extends Extension
      */
     private function getLocalesExtra($localeSettings)
     {
-        $localesExtra = array();
+        $localesExtra = [];
         foreach ($localeSettings as $key => $localeMapping) {
-            $localesExtra[$localeMapping['uri_locale']] = array_key_exists('extra', $localeMapping) ? $localeMapping['extra'] : array();
+            $localesExtra[$localeMapping['uri_locale']] = array_key_exists('extra', $localeMapping) ? $localeMapping['extra'] : [];
         }
 
         return $localesExtra;

--- a/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
+++ b/src/Kunstmaan/MultiDomainBundle/EventListener/HostOverrideListener.php
@@ -6,15 +6,20 @@ use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * Class HostOverrideListener
+ *
+ * @package Kunstmaan\MultiDomainBundle\EventListener
+ */
 class HostOverrideListener
 {
     /**
-     * @var Session
+     * @var SessionInterface
      */
     protected $session;
 
@@ -34,21 +39,21 @@ class HostOverrideListener
     protected $adminRouteHelper;
 
     /**
-     * @param Session                      $session
+     * @param SessionInterface             $session
      * @param TranslatorInterface          $translator
      * @param DomainConfigurationInterface $domainConfiguration
-     * @param AdminRouteHelper $adminRouteHelper
+     * @param AdminRouteHelper             $adminRouteHelper
      */
     public function __construct(
-        Session $session,
+        SessionInterface $session,
         TranslatorInterface $translator,
         DomainConfigurationInterface $domainConfiguration,
         AdminRouteHelper $adminRouteHelper
     ) {
-        $this->session             = $session;
-        $this->translator          = $translator;
+        $this->session = $session;
+        $this->translator = $translator;
         $this->domainConfiguration = $domainConfiguration;
-        $this->adminRouteHelper    = $adminRouteHelper;
+        $this->adminRouteHelper = $adminRouteHelper;
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/KunstmaanMultiDomainBundle.php
+++ b/src/Kunstmaan/MultiDomainBundle/KunstmaanMultiDomainBundle.php
@@ -2,8 +2,24 @@
 
 namespace Kunstmaan\MultiDomainBundle;
 
+use Kunstmaan\MultiDomainBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanMultiDomainBundle
+ *
+ * @package Kunstmaan\MultiDomainBundle
+ */
 class KunstmaanMultiDomainBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -3,20 +3,22 @@ parameters:
     kunstmaan_multi_domain.domain_configuration.class: Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration
 
 services:
-    kunstmaan_multi_domain.admin_panel.sites:
-        class: Kunstmaan\MultiDomainBundle\Helper\AdminPanel\SitesAdminPanelAdaptor
+    Kunstmaan\MultiDomainBundle\Helper\AdminPanel\SitesAdminPanelAdaptor:
         tags:
             -  { name: 'kunstmaan_admin.admin_panel.adaptor', priority: 100 }
 
-    kunstmaan_multi_domain.twig.extension:
-        class: Kunstmaan\MultiDomainBundle\Twig\MultiDomainTwigExtension
-        arguments: ['@kunstmaan_admin.domain_configuration']
+    Kunstmaan\MultiDomainBundle\Twig\MultiDomainTwigExtension:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
-              -  { name: 'twig.extension' }
+            -  { name: 'twig.extension' }
 
-    kunstmaan_multi_domain.host_override_listener:
-        class: Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener
-        arguments: ['@session', '@translator', '@kunstmaan_admin.domain_configuration', '@kunstmaan_admin.adminroute.helper']
+    Kunstmaan\MultiDomainBundle\EventListener\HostOverrideListener:
+        arguments:
+            - '@Symfony\Component\HttpFoundation\Session\SessionInterface'
+            - '@Symfony\Component\Translation\TranslatorInterface'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
+            - '@Kunstmaan\AdminBundle\Helper\AdminRouteHelper'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 

--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -90,10 +90,7 @@ class SlugController extends Controller
         $eventDispatcher->dispatch(Events::PRE_SLUG_ACTION, $preEvent);
         $renderContext = $preEvent->getRenderContext();
 
-        /** @noinspection PhpUndefinedMethodInspection */
-        $response = $entity->service($this->container, $request, $renderContext);
-
-        $postEvent = new SlugEvent($response, $renderContext);
+        $postEvent = new SlugEvent(null, $renderContext);
         $eventDispatcher->dispatch(Events::POST_SLUG_ACTION, $postEvent);
 
         $response      = $postEvent->getResponse();

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\NodeBundle\Controller\UrlReplaceController;
+use Kunstmaan\NodeBundle\EventListener\FixDateListener;
+use Kunstmaan\NodeBundle\EventListener\LogPageEventsSubscriber;
+use Kunstmaan\NodeBundle\EventListener\MappingListener;
+use Kunstmaan\NodeBundle\EventListener\NodeListener;
+use Kunstmaan\NodeBundle\EventListener\NodeTranslationListener;
+use Kunstmaan\NodeBundle\EventListener\RenderContextListener;
+use Kunstmaan\NodeBundle\EventListener\SlugListener;
+use Kunstmaan\NodeBundle\EventListener\SlugSecurityListener;
+use Kunstmaan\NodeBundle\Form\NodeChoiceType;
+use Kunstmaan\NodeBundle\Form\Type\SlugType;
+use Kunstmaan\NodeBundle\Form\Type\URLChooserType;
+use Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder;
+use Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor;
+use Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher;
+use Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeVersionLockHelper;
+use Kunstmaan\NodeBundle\Helper\NodeMenu;
+use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
+use Kunstmaan\NodeBundle\Helper\Services\ACLPermissionCreatorService;
+use Kunstmaan\NodeBundle\Helper\Services\PageCreatorService;
+use Kunstmaan\NodeBundle\Helper\URLHelper;
+use Kunstmaan\NodeBundle\Router\SlugRouter;
+use Kunstmaan\NodeBundle\Toolbar\NodeDataCollector;
+use Kunstmaan\NodeBundle\Twig\NodeTwigExtension;
+use Kunstmaan\NodeBundle\Twig\PagesConfigurationTwigExtension;
+use Kunstmaan\NodeBundle\Twig\UrlReplaceTwigExtension;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\NodeBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_node.nodetranslation.listener', NodeTranslationListener::class],
+                ['kunstmaan_node.menu.adaptor.pages', PageMenuAdaptor::class],
+                ['kunstmaan_node.form.type.urlchooser', URLChooserType::class],
+                ['kunstmaan_node.form.type.slug', SlugType::class],
+                ['kunstmaan_node.form.type.nodechoice', NodeChoiceType::class],
+                ['kunstmaan_node.admin_node.publisher', NodeAdminPublisher::class],
+                ['kunstmaan_node.admin_node.node_version_lock_helper', NodeVersionLockHelper::class],
+                ['kunstmaan_node.actions_menu_builder', ActionsMenuBuilder::class],
+                ['kunstmaan_node.fix_date.listener', FixDateListener::class],
+                ['kunstmaan_node.edit_node.listener', NodeListener::class],
+                ['kunstmaan_node.log_page_events.subscriber', LogPageEventsSubscriber::class],
+                ['kunstmaan_node.slugrouter', SlugRouter::class],
+                ['kunstmaan_node.pages_configuration.twig_extension', PagesConfigurationTwigExtension::class, false],
+                ['kunstmaan_node.url_replace.twig.extension', UrlReplaceTwigExtension::class],
+                ['kunstmaan_node.page_creator_service', PageCreatorService::class],
+                ['kunstmaan_node.acl_permission_creator_service', ACLPermissionCreatorService::class],
+                ['kunstmaan_node.doctrine_mapping.listener', MappingListener::class],
+                ['kunstmaan_node.slug.listener', SlugListener::class],
+                ['kunstmaan_node.slug.security.listener', SlugSecurityListener::class],
+                ['kunstmaan_node.render.context.listener', RenderContextListener::class],
+                ['kunstmaan_node.node_menu', NodeMenu::class],
+                ['kunstmaan_node.node.twig.extension', NodeTwigExtension::class],
+                ['kunstmaan_node.helper.url', URLHelper::class],
+                ['kunstmaan_node.url_replace.controller', UrlReplaceController::class],
+                ['kunstmaan_node.datacollector.node', NodeDataCollector::class],
+                ['kunstmaan_node.pages_configuration', PagesConfiguration::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_node.slugrouter.class', SlugRouter::class],
+                ['kunstmaan_node.url_replace.twig.class', UrlReplaceTwigExtension::class],
+                ['kunstmaan_node.sluglistener.class', SlugListener::class],
+                ['kunstmaan_node.helper.url.class', URLHelper::class],
+                ['kunstmaan_multi_domain.url_replace.controller.class', UrlReplaceController::class],
+                ['kunstmaan_node.toolbar.collector.node.class', NodeDataCollector::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanNodeBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanNodeBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -2,9 +2,9 @@
 
 namespace Kunstmaan\NodeBundle\DependencyInjection;
 
+use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -26,14 +26,13 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        $container->setParameter('twig.form.resources', array_merge(
-            $container->getParameter('twig.form.resources'),
-            array('KunstmaanNodeBundle:Form:formWidgets.html.twig')
-        ));
-
-        $container->setDefinition('kunstmaan_node.pages_configuration', new Definition(
-            'Kunstmaan\NodeBundle\Helper\PagesConfiguration', [$config['pages']]
-        ));
+        $container->setParameter(
+            'twig.form.resources',
+            array_merge(
+                $container->getParameter('twig.form.resources'),
+                ['KunstmaanNodeBundle:Form:formWidgets.html.twig']
+            )
+        );
 
         $container->setParameter('kunstmaan_node.show_add_homepage', $config['show_add_homepage']);
         $container->setParameter('kunstmaan_node.lock_check_interval', $config['lock']['check_interval']);
@@ -41,6 +40,8 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
         $container->setParameter('kunstmaan_node.lock_enabled', $config['lock']['enabled']);
 
         $loader->load('services.yml');
+
+        $container->getDefinition(PagesConfiguration::class)->setArguments([$config['pages']]);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -2,20 +2,24 @@
 
 namespace Kunstmaan\NodeBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Controller\SlugActionInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Event\SlugSecurityEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
+/**
+ * Class SlugListener
+ *
+ * @package Kunstmaan\NodeBundle\EventListener
+ */
 class SlugListener
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
@@ -32,11 +36,11 @@ class SlugListener
     /**
      * SlugListener constructor.
      *
-     * @param EntityManager               $em
+     * @param EntityManagerInterface      $em
      * @param ControllerResolverInterface $resolver
      * @param EventDispatcherInterface    $eventDispatcher
      */
-    public function __construct(EntityManager $em, ControllerResolverInterface $resolver, EventDispatcherInterface $eventDispatcher)
+    public function __construct(EntityManagerInterface $em, ControllerResolverInterface $resolver, EventDispatcherInterface $eventDispatcher)
     {
         $this->em = $em;
         $this->resolver = $resolver;
@@ -45,6 +49,7 @@ class SlugListener
 
     /**
      * @param FilterControllerEvent $event
+     *
      * @throws \Exception
      */
     public function onKernelController(FilterControllerEvent $event)

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\NodeBundle\Helper\Menu;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Model\UserInterface;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
@@ -16,6 +16,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
+/**
+ * Class ActionsMenuBuilder
+ *
+ * @package Kunstmaan\NodeBundle\Helper\Menu
+ */
 class ActionsMenuBuilder
 {
     /**
@@ -29,7 +34,7 @@ class ActionsMenuBuilder
     private $activeNodeVersion;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -61,7 +66,7 @@ class ActionsMenuBuilder
 
     /**
      * @param FactoryInterface              $factory              The factory
-     * @param EntityManager                 $em                   The entity manager
+     * @param EntityManagerInterface        $em                   The entity manager
      * @param RouterInterface               $router               The router
      * @param EventDispatcherInterface      $dispatcher           The event dispatcher
      * @param AuthorizationCheckerInterface $authorizationChecker The security authorization checker
@@ -69,13 +74,12 @@ class ActionsMenuBuilder
      */
     public function __construct(
         FactoryInterface $factory,
-        EntityManager $em,
+        EntityManagerInterface $em,
         RouterInterface $router,
         EventDispatcherInterface $dispatcher,
         AuthorizationCheckerInterface $authorizationChecker,
         PagesConfiguration $pagesConfiguration
-    )
-    {
+    ) {
         $this->factory = $factory;
         $this->em = $em;
         $this->router = $router;
@@ -100,8 +104,8 @@ class ActionsMenuBuilder
                     'linkAttributes' => [
                         'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target' => '#versions'
-                    ]
+                        'data-target' => '#versions',
+                    ],
                 ]
             );
         }
@@ -176,9 +180,9 @@ class ActionsMenuBuilder
                             'type' => 'submit',
                             'class' => 'js-save-btn btn btn--raise-on-hover btn-primary',
                             'value' => 'save',
-                            'name' => 'save'
+                            'name' => 'save',
                         ],
-                        'extras' => ['renderType' => 'button']
+                        'extras' => ['renderType' => 'button'],
                     ]
                 );
                 if ($isSuperAdmin && is_subclass_of($node->getRefEntityName(), HasPageTemplateInterface::class)) {
@@ -189,7 +193,7 @@ class ActionsMenuBuilder
                                 'class' => 'btn btn-default btn--raise-on-hover',
                                 'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target' => '#exportPagetemplate'
+                                'data-target' => '#exportPagetemplate',
                             ],
                         ]
                     );
@@ -202,7 +206,7 @@ class ActionsMenuBuilder
                                 'class' => 'btn btn-default btn--raise-on-hover',
                                 'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target' => '#recopy'
+                                'data-target' => '#recopy',
                             ],
                         ]
                     );
@@ -217,13 +221,13 @@ class ActionsMenuBuilder
                         '_slug_preview',
                         [
                             'url' => $activeNodeTranslation->getUrl(),
-                            'version' => $activeNodeVersion->getId()
+                            'version' => $activeNodeVersion->getId(),
                         ]
                     ),
                     'linkAttributes' => [
                         'target' => '_blank',
-                        'class' => 'btn btn-default btn--raise-on-hover'
-                    ]
+                        'class' => 'btn btn-default btn--raise-on-hover',
+                    ],
                 ]
             );
 
@@ -234,8 +238,8 @@ class ActionsMenuBuilder
                         'linkAttributes' => [
                             'data-toggle' => 'modal',
                             'data-target' => '#pub',
-                            'class' => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default')
-                        ]
+                            'class' => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default'),
+                        ],
                     ]
                 );
             }
@@ -249,9 +253,9 @@ class ActionsMenuBuilder
                             'type' => 'submit',
                             'class' => 'js-save-btn btn btn--raise-on-hover btn-primary',
                             'value' => 'save',
-                            'name' => 'save'
+                            'name' => 'save',
                         ],
-                        'extras' => ['renderType' => 'button']
+                        'extras' => ['renderType' => 'button'],
                     ]
                 );
                 $isFirst = false;
@@ -267,8 +271,8 @@ class ActionsMenuBuilder
                         ),
                         'linkAttributes' => [
                             'target' => '_blank',
-                            'class' => 'btn btn-default btn--raise-on-hover'
-                        ]
+                            'class' => 'btn btn-default btn--raise-on-hover',
+                        ],
                     ]
                 );
 
@@ -286,8 +290,8 @@ class ActionsMenuBuilder
                                 'class' => 'btn btn-default btn--raise-on-hover',
                                 'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target' => '#unpub'
-                            ]
+                                'data-target' => '#unpub',
+                            ],
                         ]
                     );
                 } elseif (empty($queuedNodeTranslationAction)
@@ -301,8 +305,8 @@ class ActionsMenuBuilder
                                 'class' => 'btn btn-default btn--raise-on-hover',
                                 'data-toggle' => 'modal',
                                 'data-keyboard' => 'true',
-                                'data-target' => '#pub'
-                            ]
+                                'data-target' => '#pub',
+                            ],
                         ]
                     );
                 }
@@ -315,9 +319,9 @@ class ActionsMenuBuilder
                                 'type' => 'submit',
                                 'class' => 'btn btn--raise-on-hover'.($isFirst ? ' btn-primary btn-save' : ' btn-default'),
                                 'value' => 'saveasdraft',
-                                'name' => 'saveasdraft'
+                                'name' => 'saveasdraft',
                             ],
-                            'extras' => ['renderType' => 'button']
+                            'extras' => ['renderType' => 'button'],
                         ]
                     );
                     if ($isSuperAdmin && is_subclass_of($node->getRefEntityName(), HasPageTemplateInterface::class)) {
@@ -328,7 +332,7 @@ class ActionsMenuBuilder
                                     'class' => 'btn btn-default btn--raise-on-hover',
                                     'data-toggle' => 'modal',
                                     'data-keyboard' => 'true',
-                                    'data-target' => '#exportPagetemplate'
+                                    'data-target' => '#exportPagetemplate',
                                 ],
                             ]
                         );
@@ -341,7 +345,7 @@ class ActionsMenuBuilder
                                     'class' => 'btn btn-default btn--raise-on-hover',
                                     'data-toggle' => 'modal',
                                     'data-keyboard' => 'true',
-                                    'data-target' => '#recopy'
+                                    'data-target' => '#recopy',
                                 ],
                             ]
                         );
@@ -362,9 +366,9 @@ class ActionsMenuBuilder
                         'class' => 'btn btn-default btn--raise-on-hover',
                         'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target' => '#add-subpage-modal'
+                        'data-target' => '#add-subpage-modal',
                     ],
-                    'extras' => ['renderType' => 'button']
+                    'extras' => ['renderType' => 'button'],
                 ]
             );
         }
@@ -378,9 +382,9 @@ class ActionsMenuBuilder
                         'class' => 'btn btn-default btn--raise-on-hover',
                         'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target' => '#duplicate-page-modal'
+                        'data-target' => '#duplicate-page-modal',
                     ],
-                    'extras' => ['renderType' => 'button']
+                    'extras' => ['renderType' => 'button'],
                 ]
             );
         }
@@ -400,9 +404,9 @@ class ActionsMenuBuilder
                         'onClick' => 'oldEdited = isEdited; isEdited=false',
                         'data-toggle' => 'modal',
                         'data-keyboard' => 'true',
-                        'data-target' => '#delete-page-modal'
+                        'data-target' => '#delete-page-modal',
                     ],
-                    'extras' => ['renderType' => 'button']
+                    'extras' => ['renderType' => 'button'],
                 ]
             );
         }
@@ -452,9 +456,9 @@ class ActionsMenuBuilder
                     'class' => 'btn btn-default btn--raise-on-hover',
                     'data-toggle' => 'modal',
                     'data-keyboard' => 'true',
-                    'data-target' => '#add-homepage-modal'
+                    'data-target' => '#add-homepage-modal',
                 ],
-                'extras' => ['renderType' => 'button']
+                'extras' => ['renderType' => 'button'],
             ]
         );
 

--- a/src/Kunstmaan/NodeBundle/Helper/Services/PageCreatorService.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Services/PageCreatorService.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeBundle\Helper\Services;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Kunstmaan\AdminBundle\Repository\UserRepository;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
@@ -18,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PageCreatorService
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $entityManager;
 
@@ -31,7 +32,6 @@ class PageCreatorService
      * @var string
      */
     protected $userEntityClass;
-
 
     public function setEntityManager($entityManager)
     {

--- a/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
@@ -2,22 +2,23 @@
 
 namespace Kunstmaan\NodeBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\NodeBundle\Validation\URLValidator;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * A helper for replacing url's
+ * Class URLHelper
+ *
+ * @package Kunstmaan\NodeBundle\Helper
  */
 class URLHelper
 {
     use URLValidator;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -47,13 +48,17 @@ class URLHelper
     private $domainConfiguration;
 
     /**
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      * @param RouterInterface $router
      * @param LoggerInterface $logger
      * @param DomainConfigurationInterface $domainConfiguration
      */
-    public function __construct(EntityManager $em, RouterInterface $router, LoggerInterface $logger, DomainConfigurationInterface $domainConfiguration)
-    {
+    public function __construct(
+        EntityManagerInterface $em,
+        RouterInterface $router,
+        LoggerInterface $logger,
+        DomainConfigurationInterface $domainConfiguration
+    ) {
         $this->em = $em;
         $this->router = $router;
         $this->logger = $logger;
@@ -61,10 +66,10 @@ class URLHelper
     }
 
     /**
-     * Replace a given text, according to the node translation id and the multidomain site id.
-     *
      * @param $text
-     * @return mixed
+     *
+     * @return mixed|string
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function replaceUrl($text)
     {
@@ -102,12 +107,12 @@ class URLHelper
 
                             $url = $this->router->generate('_slug', $urlParams);
 
-                            $text = str_replace($fullTag, $hostId ? $hostBaseUrl . $url : $url, $text);
+                            $text = str_replace($fullTag, $hostId ? $hostBaseUrl.$url : $url, $text);
                         }
                     }
 
                     if (!$nodeTranslationFound) {
-                        $this->logger->error('No NodeTranslation found in the database when replacing url tag ' . $fullTag);
+                        $this->logger->error('No NodeTranslation found in the database when replacing url tag '.$fullTag);
                     }
                 }
             }
@@ -131,7 +136,7 @@ class URLHelper
                     }
 
                     if (!$mediaFound) {
-                        $this->logger->error('No Media found in the database when replacing url tag ' . $fullTag);
+                        $this->logger->error('No Media found in the database when replacing url tag '.$fullTag);
                     }
                 }
             }

--- a/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
+++ b/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
@@ -2,12 +2,25 @@
 
 namespace Kunstmaan\NodeBundle;
 
+use Kunstmaan\NodeBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanNodeBundle
+ * Class KunstmaanNodeBundle
+ *
+ * @package Kunstmaan\NodeBundle
  */
 class KunstmaanNodeBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 
 }

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -1,7 +1,7 @@
 parameters:
     kunstmaan_node.version_timeout: 3600
-    kunstmaan_node.slugrouter.class: 'Kunstmaan\NodeBundle\Router\SlugRouter'
-    kunstmaan_node.sluglistener.class: 'Kunstmaan\NodeBundle\EventListener\SlugListener'
+    kunstmaan_node.slugrouter.class: Kunstmaan\NodeBundle\Router\SlugRouter
+    kunstmaan_node.sluglistener.class: Kunstmaan\NodeBundle\EventListener\SlugListener
     kunstmaan_node.helper.url.class: Kunstmaan\NodeBundle\Helper\URLHelper
     kunstmaan_node.url_replace.twig.class: Kunstmaan\NodeBundle\Twig\UrlReplaceTwigExtension
     kunstmaan_node.url_chooser.lazy_increment: 2
@@ -9,55 +9,65 @@ parameters:
     kunstmaan_node.toolbar.collector.node.class: Kunstmaan\NodeBundle\Toolbar\NodeDataCollector
 
 services:
-    kunstmaan_node.nodetranslation.listener:
-        class: Kunstmaan\NodeBundle\EventListener\NodeTranslationListener
+    Kunstmaan\NodeBundle\EventListener\NodeTranslationListener:
         arguments:
-          - '@session.flash_bag'
-          - '@kunstmaan_admin.logger'
-          - '@kunstmaan_utilities.slugifier'
-          - '@request_stack'
-          - '@kunstmaan_admin.domain_configuration'
-          - '@kunstmaan_node.pages_configuration'
+            - '@Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface'
+            - '@kunstmaan_admin.logger'
+            - '@Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface'
+            - '@Symfony\Component\HttpFoundation\RequestStack'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
+            - '@Kunstmaan\NodeBundle\Helper\PagesConfiguration'
         tags:
             - { name: 'doctrine.event_listener', event: 'onFlush', method: 'onFlush' }
             - { name: 'doctrine.event_listener', event: 'prePersist', method: 'prePersist' }
             - { name: 'doctrine.event_listener', event: 'preUpdate', method: 'preUpdate' }
 
-    kunstmaan_node.menu.adaptor.pages:
-        class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor
-        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.acl.native.helper', '@kunstmaan_node.pages_configuration', '@kunstmaan_admin.domain_configuration']
+    Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Kunstmaan\AdminBundle\Helper\Security\Acl\AclNativeHelper'
+            - '@Kunstmaan\NodeBundle\Helper\PagesConfiguration'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_node.form.type.urlchooser:
-        class: Kunstmaan\NodeBundle\Form\Type\URLChooserType
+    Kunstmaan\NodeBundle\Form\Type\URLChooserType:
         tags:
             - { name: 'form.type' }
 
-    kunstmaan_node.form.type.slug:
-        class: Kunstmaan\NodeBundle\Form\Type\SlugType
-        arguments: ['@kunstmaan_utilities.slugifier']
+    Kunstmaan\NodeBundle\Form\Type\SlugType:
+        arguments:
+            - '@Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface'
         tags:
             - { name: 'form.type' }
 
-    kunstmaan_node.form.type.nodechoice:
-        class: Kunstmaan\NodeBundle\Form\NodeChoiceType
+    Kunstmaan\NodeBundle\Form\NodeChoiceType:
         arguments:
             - "@request_stack"
         tags:
             - { name: form.type }
 
-    kunstmaan_node.admin_node.publisher:
-        class: Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher
-        arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.authorization_checker', '@event_dispatcher', '@kunstmaan_admin.clone.helper']
+    Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
+            - '@Kunstmaan\AdminBundle\Helper\CloneHelper'
 
-    kunstmaan_node.admin_node.node_version_lock_helper:
-        class: Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeVersionLockHelper
-        arguments: ['@service_container', '@doctrine.orm.entity_manager']
+    Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeVersionLockHelper:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
 
-    kunstmaan_node.actions_menu_builder:
-        class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration' ]
+    Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder:
+        arguments:
+            - '@knp_menu.factory'
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Kunstmaan\NodeBundle\Helper\PagesConfiguration'
 
     kunstmaan_node.menu.sub_actions:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
@@ -77,109 +87,119 @@ services:
         tags:
             - { name: 'knp_menu.menu', alias: 'top_actions' } # The alias is what is used to retrieve the menu
 
-    kunstmaan_node.fix_date.listener:
-        class: Kunstmaan\NodeBundle\EventListener\FixDateListener
+    Kunstmaan\NodeBundle\EventListener\FixDateListener:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -100 }
 
-    kunstmaan_node.edit_node.listener:
-        class: Kunstmaan\NodeBundle\EventListener\NodeListener
-        arguments: ['@security.authorization_checker', '@kunstmaan_admin.permissionadmin', '@kunstmaan_admin.security.acl.permission.map']
+    Kunstmaan\NodeBundle\EventListener\NodeListener:
+        class:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin'
+            - '@Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
-    kunstmaan_node.log_page_events.subscriber:
-        class: Kunstmaan\NodeBundle\EventListener\LogPageEventsSubscriber
-        arguments: ['@kunstmaan_admin.logger', '@security.token_storage']
+    Kunstmaan\NodeBundle\EventListener\LogPageEventsSubscriber:
+        arguments:
+            - '@kunstmaan_admin.logger'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
         tags:
             - { name: kernel.event_subscriber }
 
-    kunstmaan_node.slugrouter:
-        class: '%kunstmaan_node.slugrouter.class%'
-        arguments: ['@service_container']
+    Kunstmaan\NodeBundle\Router\SlugRouter:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
         tags:
             - { name: router, priority: 0 }
 
-    kunstmaan_node.pages_configuration.twig_extension:
-        class: Kunstmaan\NodeBundle\Twig\PagesConfigurationTwigExtension
+    Kunstmaan\NodeBundle\Twig\PagesConfigurationTwigExtension:
         public: false
-        arguments: [ '@kunstmaan_node.pages_configuration' ]
-        tags:
-            - { name: twig.extension }
-
-    kunstmaan_node.url_replace.twig.extension:
-        class: "%kunstmaan_node.url_replace.twig.class%"
         arguments:
-            - "@kunstmaan_node.helper.url"
+            - '@Kunstmaan\NodeBundle\Helper\PagesConfiguration'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_node.page_creator_service:
-        class: Kunstmaan\NodeBundle\Helper\Services\PageCreatorService
+    Kunstmaan\NodeBundle\Twig\UrlReplaceTwigExtension:
+        arguments:
+            - '@Kunstmaan\NodeBundle\Helper\URLHelper'
+        tags:
+            - { name: twig.extension }
+
+    Kunstmaan\NodeBundle\Helper\Services\PageCreatorService:
         calls:
-            - [ setEntityManager, [ '@doctrine.orm.entity_manager' ] ]
-            - [ setACLPermissionCreatorService, [ '@kunstmaan_node.acl_permission_creator_service' ] ]
+            - [ setEntityManager, [ '@Doctrine\ORM\EntityManagerInterface' ] ]
+            - [ setACLPermissionCreatorService, [ '@Kunstmaan\NodeBundle\Helper\Services\ACLPermissionCreatorService' ] ]
             - [ setUserEntityClass, [ '%fos_user.model.user.class%' ] ]
 
-    kunstmaan_node.acl_permission_creator_service:
-        class: Kunstmaan\NodeBundle\Helper\Services\ACLPermissionCreatorService
+    Kunstmaan\NodeBundle\Helper\Services\ACLPermissionCreatorService:
         calls:
-            - [ setAclProvider, [ '@security.acl.provider' ] ]
+            - [ setAclProvider, [ '@Symfony\Component\Security\Acl\Model\AclProviderInterface' ] ]
             - [ setObjectIdentityRetrievalStrategy, [ '@security.acl.object_identity_retrieval_strategy' ] ]
 
-    kunstmaan_node.doctrine_mapping.listener:
-        class: Kunstmaan\NodeBundle\EventListener\MappingListener
-        arguments: ['%fos_user.model.user.class%']
+    Kunstmaan\NodeBundle\EventListener\MappingListener:
+        arguments:
+            - '%fos_user.model.user.class%'
         tags:
             - { name: doctrine.event_listener, event: loadClassMetadata }
 
-    kunstmaan_node.slug.listener:
-        class: '%kunstmaan_node.sluglistener.class%'
-        arguments: ['@doctrine.orm.entity_manager','@controller_resolver', '@event_dispatcher']
+    Kunstmaan\NodeBundle\EventListener\SlugListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@controller_resolver'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
 
-    kunstmaan_node.slug.security.listener:
-        class: Kunstmaan\NodeBundle\EventListener\SlugSecurityListener
-        arguments: ['@doctrine.orm.entity_manager', '@security.authorization_checker', '@kunstmaan_node.node_menu']
+    Kunstmaan\NodeBundle\EventListener\SlugSecurityListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
+            - '@Kunstmaan\NodeBundle\Helper\NodeMenu'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.slug.security, method: onSlugSecurityEvent }
 
-    kunstmaan_node.render.context.listener:
-        class: Kunstmaan\NodeBundle\EventListener\RenderContextListener
-        arguments: ['@templating', '@doctrine.orm.entity_manager']
+    Kunstmaan\NodeBundle\EventListener\RenderContextListener:
+        arguments:
+            - '@Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
-    kunstmaan_node.node_menu:
-        class: Kunstmaan\NodeBundle\Helper\NodeMenu
-        arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@kunstmaan_admin.acl.helper', '@kunstmaan_admin.domain_configuration']
+    Kunstmaan\NodeBundle\Helper\NodeMenu:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+            - '@Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
 
-    kunstmaan_node.node.twig.extension:
-        class: Kunstmaan\NodeBundle\Twig\NodeTwigExtension
-        arguments: ['@doctrine.orm.entity_manager', '@router', '@kunstmaan_node.node_menu', '@request_stack']
+    Kunstmaan\NodeBundle\Twig\NodeTwigExtension:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Kunstmaan\NodeBundle\Helper\NodeMenu'
+            - '@Symfony\Component\HttpFoundation\RequestStack'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_node.helper.url:
-        class: "%kunstmaan_node.helper.url.class%"
+    Kunstmaan\NodeBundle\Helper\URLHelper:
         arguments:
-            - "@doctrine.orm.entity_manager"
-            - "@router"
-            - "@logger"
-            - "@kunstmaan_admin.domain_configuration"
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Psr\Log\LoggerInterface'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
 
-    kunstmaan_node.url_replace.controller:
-        class: "%kunstmaan_multi_domain.url_replace.controller.class%"
+    Kunstmaan\NodeBundle\Controller\UrlReplaceController:
         arguments:
-            - "@kunstmaan_node.helper.url"
+            - '@Kunstmaan\NodeBundle\Helper\URLHelper'
+
+    Kunstmaan\NodeBundle\Helper\PagesConfiguration: ~
 
     ### TOOLBAR DATA COLLECTOR ###
-    kunstmaan_node.datacollector.node:
-        class: '%kunstmaan_node.toolbar.collector.node.class%'
+    Kunstmaan\NodeBundle\Toolbar\NodeDataCollector:
         parent: Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector
         arguments:
-            - '@kunstmaan_node.node_menu'
-            - '@router'
+            - '@Kunstmaan\NodeBundle\Helper\NodeMenu'
+            - '@Symfony\Component\Routing\RouterInterface'
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: 'KunstmaanNodeBundle:Toolbar:node.html.twig', id: kuma_node}

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/HasCustomSearchDataInterface.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/HasCustomSearchDataInterface.php
@@ -2,12 +2,17 @@
 
 namespace Kunstmaan\NodeSearchBundle\Configuration;
 
+/**
+ * Interface HasCustomSearchDataInterface
+ *
+ * @package Kunstmaan\NodeSearchBundle\Configuration
+ */
 interface HasCustomSearchDataInterface
 {
     /**
      * @param array $doc
      *
-     * @return array
+     * @return mixed
      */
     public function getCustomSearchData(array $doc);
 }

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration;
+use Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener;
+use Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService;
+use Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher;
+use Kunstmaan\NodeSearchBundle\Search\NodeSearcher;
+use Kunstmaan\NodeSearchBundle\Services\SearchService;
+use Kunstmaan\NodeSearchBundle\Twig\KunstmaanNodeSearchTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_node_search.node_index_update.listener', NodeIndexUpdateEventListener::class],
+                ['kunstmaan_node_search.search.abstract_elastica_searcher', AbstractElasticaSearcher::class],
+                ['kunstmaan_node_search.search.node', NodeSearcher::class],
+                ['kunstmaan_node_search.service.indexable_pageparts', IndexablePagePartsService::class],
+                ['kunstmaan_node_search.twig.extension', KunstmaanNodeSearchTwigExtension::class],
+                ['kunstmaan_node_search.search_configuration.node', NodePagesConfiguration::class],
+                ['kunstmaan_node_search.search.service', SearchService::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_node_search.node_index_update.listener.class', NodeIndexUpdateEventListener::class],
+                ['kunstmaan_node_search.search_configuration.node.class', NodePagesConfiguration::class],
+                ['kunstmaan_node_search.search.node.class', NodeSearcher::class],
+                ['kunstmaan_node_search.search_service.class', SearchService::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanNodeSearchBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanNodeSearchBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\NodeSearchBundle\DependencyInjection;
 
+use Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration;
+use Kunstmaan\NodeSearchBundle\Search\NodeSearcher;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -31,11 +33,11 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
         }
 
         if (array_key_exists('use_match_query_for_title', $config)) {
-            $container->getDefinition('kunstmaan_node_search.search.node')
+            $container->getDefinition(NodeSearcher::class)
                 ->addMethodCall('setUseMatchQueryForTitle', [$config['use_match_query_for_title']]);
         }
 
-        $container->getDefinition('kunstmaan_node_search.search_configuration.node')
+        $container->getDefinition(NodePagesConfiguration::class)
             ->addMethodCall('setDefaultProperties', [$config['mapping']]);
 
         $container->setParameter('kunstmaan_node_search.contexts', $config['contexts']);
@@ -48,67 +50,70 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
      */
     public function prepend(ContainerBuilder $container)
     {
-        $container->prependExtensionConfig('kunstmaan_node_search', [
-            'mapping' => [
-                'root_id' => [
-                    'type' => 'integer',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'node_id' => [
-                    'type' => 'integer',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'nodetranslation_id' => [
-                    'type' => 'integer',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'nodeversion_id' => [
-                    'type' => 'integer',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'title' => [
-                    'type' => 'string',
-                    'include_in_all' => true
-                ],
-                'slug' => [
-                    'type' => 'string',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'type' => [
-                    'type' => 'string',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'page_class' => [
-                    'type' => 'string',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'content' => [
-                    'type' => 'string',
-                    'include_in_all' => true
-                ],
-                'created' => [
-                    'type' => 'date',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'updated' => [
-                    'type' => 'date',
-                    'include_in_all' => false,
-                    'index' => 'not_analyzed'
-                ],
-                'view_roles' => [
-                    'type' => 'string',
-                    'include_in_all' => true,
-                    'index' => 'not_analyzed',
+        $container->prependExtensionConfig(
+            'kunstmaan_node_search',
+            [
+                'mapping' => [
+                    'root_id' => [
+                        'type' => 'integer',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'node_id' => [
+                        'type' => 'integer',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'nodetranslation_id' => [
+                        'type' => 'integer',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'nodeversion_id' => [
+                        'type' => 'integer',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'title' => [
+                        'type' => 'string',
+                        'include_in_all' => true,
+                    ],
+                    'slug' => [
+                        'type' => 'string',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'type' => [
+                        'type' => 'string',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'page_class' => [
+                        'type' => 'string',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'content' => [
+                        'type' => 'string',
+                        'include_in_all' => true,
+                    ],
+                    'created' => [
+                        'type' => 'date',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'updated' => [
+                        'type' => 'date',
+                        'include_in_all' => false,
+                        'index' => 'not_analyzed',
+                    ],
+                    'view_roles' => [
+                        'type' => 'string',
+                        'include_in_all' => true,
+                        'index' => 'not_analyzed',
+                    ],
                 ],
             ]
-        ]);
+        );
     }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Event/RenderPageEvent.php
+++ b/src/Kunstmaan/NodeSearchBundle/Event/RenderPageEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Event;
+
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\NodeBundle\Helper\RenderContext;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class RenderPageEvent
+ *
+ * @package Kunstmaan\NodeSearchBundle\Event
+ */
+class RenderPageEvent extends Event
+{
+    const EVENT_RENDER_PAGE = 'kunstmaan_node_search.onRenderPage';
+
+    /** @var HasNodeInterface */
+    private $page;
+
+    /** @var RenderContext */
+    private $renderContext;
+
+    /** @var Request */
+    private $request;
+
+    /**
+     * RenderPageEvent constructor.
+     *
+     * @param HasNodeInterface $page
+     * @param RenderContext    $renderContext
+     * @param Request          $request
+     */
+    public function __construct(HasNodeInterface $page, RenderContext $renderContext, Request $request)
+    {
+        $this->page = $page;
+        $this->renderContext = $renderContext;
+        $this->request = $request;
+    }
+
+    /**
+     * @return HasNodeInterface
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+
+    /**
+     * @return RenderContext
+     */
+    public function getRenderContext()
+    {
+        return $this->renderContext;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/Helper/PageHelper.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/PageHelper.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Helper;
+
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\PageInterface;
+use Kunstmaan\NodeBundle\Helper\RenderContext;
+use Kunstmaan\NodeSearchBundle\Configuration\HasCustomSearchDataInterface;
+use Kunstmaan\NodeSearchBundle\Event\IndexNodeEvent;
+use Kunstmaan\NodeSearchBundle\Event\RenderPageEvent;
+use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Class PageHelper
+ *
+ * @package Kunstmaan\NodeSearchBundle\Helper
+ */
+class PageHelper
+{
+    /** @var EngineInterface */
+    private $templating;
+
+    /** @var RequestStack */
+    private $requestStack;
+
+    /** @var IndexablePagePartsService */
+    private $indexablePagePartsService;
+
+    /** @var RouterInterface */
+    private $router;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    /**
+     * PageHelper constructor.
+     *
+     * @param EngineInterface           $templating
+     * @param RequestStack              $requestStack
+     * @param IndexablePagePartsService $indexablePagePartsService
+     * @param RouterInterface           $router
+     * @param LoggerInterface           $logger
+     * @param EventDispatcherInterface  $eventDispatcher
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RequestStack $requestStack,
+        IndexablePagePartsService $indexablePagePartsService,
+        RouterInterface $router,
+        LoggerInterface $logger,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->templating = $templating;
+        $this->requestStack = $requestStack;
+        $this->indexablePagePartsService = $indexablePagePartsService;
+        $this->router = $router;
+        $this->logger = $logger;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Add page content to the index document
+     *
+     * @param NodeTranslation  $nodeTranslation
+     * @param HasNodeInterface $page
+     * @param array            $doc
+     *
+     * @return null
+     */
+    public function addPageContent(NodeTranslation $nodeTranslation, $page, &$doc)
+    {
+        $this->enterRequestScope($nodeTranslation->getLang());
+        if ($this->logger) {
+            $this->logger->debug(
+                sprintf(
+                    'Indexing page "%s" / lang : %s / type : %s / id : %d / node id : %d',
+                    $page->getTitle(),
+                    $nodeTranslation->getLang(),
+                    \get_class($page),
+                    $page->getId(),
+                    $nodeTranslation->getNode()->getId()
+                )
+            );
+        }
+
+        $doc['content'] = '';
+
+        if ($page instanceof SearchViewTemplateInterface) {
+            $doc['content'] = $this->renderCustomSearchView($nodeTranslation, $page);
+
+            return null;
+        }
+
+        if ($page instanceof HasPagePartsInterface) {
+            $doc['content'] = $this->renderDefaultSearchView($nodeTranslation, $page);
+
+            return null;
+        }
+    }
+
+    /**
+     * Render a custom search view
+     *
+     * @param NodeTranslation             $nodeTranslation
+     * @param SearchViewTemplateInterface $page
+     *
+     * @return string
+     */
+    protected function renderCustomSearchView(NodeTranslation $nodeTranslation, SearchViewTemplateInterface $page)
+    {
+        $view = $page->getSearchView();
+        $renderContext = new RenderContext(
+            [
+                'locale' => $nodeTranslation->getLang(),
+                'page' => $page,
+                'indexMode' => true,
+                'nodetranslation' => $nodeTranslation,
+            ]
+        );
+
+        if ($page instanceof PageInterface) {
+            $request = $this->requestStack->getCurrentRequest();
+
+            if (null !== $request) {
+                $event = new RenderPageEvent($page, $renderContext, $request);
+                $this->eventDispatcher->dispatch(RenderPageEvent::EVENT_RENDER_PAGE, $event);
+
+                $renderContext = $event->getRenderContext();
+            }
+        }
+
+        $content = $this->removeHtml(
+            $this->templating->render(
+                $view,
+                $renderContext->getArrayCopy()
+            )
+        );
+
+        return $content;
+    }
+
+    /**
+     * Render default search view (all indexable pageparts in the main context
+     * of the page)
+     *
+     * @param NodeTranslation       $nodeTranslation
+     * @param HasPagePartsInterface $page
+     *
+     * @return string
+     */
+    protected function renderDefaultSearchView(NodeTranslation $nodeTranslation, HasPagePartsInterface $page)
+    {
+        $pageparts = $this->indexablePagePartsService->getIndexablePageParts($page);
+
+        $content = $this->removeHtml(
+            $this->templating->render(
+                $this->getDefaultSearchViewTemplate(),
+                [
+                    'locale' => $nodeTranslation->getLang(),
+                    'page' => $page,
+                    'pageparts' => $pageparts,
+                    'indexMode' => true,
+                ]
+            )
+        );
+
+        return $content;
+    }
+
+    /**
+     * Add custom data to index document (you can override to add custom fields
+     * to the search index)
+     *
+     * @param HasNodeInterface $page
+     * @param array            $doc
+     */
+    public function addCustomData(HasNodeInterface $page, &$doc)
+    {
+        $event = new IndexNodeEvent($page, $doc);
+        $this->eventDispatcher->dispatch(IndexNodeEvent::EVENT_INDEX_NODE, $event);
+
+        $doc = $event->doc;
+
+        if ($page instanceof HasCustomSearchDataInterface) {
+            $doc += $page->getCustomSearchData($doc);
+        }
+    }
+
+    /**
+     * Removes all HTML markup & decode HTML entities
+     *
+     * @param $text
+     *
+     * @return string
+     */
+    protected function removeHtml($text)
+    {
+        if (!trim($text)) {
+            return '';
+        }
+
+        // Remove Styles and Scripts
+        $crawler = new Crawler($text);
+        $crawler->filter('style, script')->each(
+            function (Crawler $crawler) {
+                foreach ($crawler as $node) {
+                    $node->parentNode->removeChild($node);
+                }
+            }
+        );
+
+        $text = $crawler->html();
+        // Remove HTML markup
+        $result = strip_tags($text);
+        // Decode HTML entities
+        $result = trim(html_entity_decode($result, ENT_QUOTES));
+
+        return $result;
+    }
+
+    /**
+     * Enter request scope if it is not active yet...
+     *
+     * @param string $lang
+     */
+    protected function enterRequestScope($lang)
+    {
+        // If there already is a request, get the locale from it.
+        if ($this->requestStack->getCurrentRequest()) {
+            $locale = $this->requestStack->getCurrentRequest()->getLocale();
+        }
+        // If we don't have a request or the current request locale is different from the node langauge
+        if ((isset($locale) && $locale !== $lang) || !$this->requestStack->getCurrentRequest()) {
+            $request = new Request();
+            $request->setLocale($lang);
+
+            $this->router->getContext()->setParameter('_locale', $lang);
+
+            $this->requestStack->push($request);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultSearchViewTemplate()
+    {
+        return 'KunstmaanNodeSearchBundle:PagePart:view.html.twig';
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
+++ b/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
@@ -2,12 +2,24 @@
 
 namespace Kunstmaan\NodeSearchBundle;
 
+use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanNodeSearchBundle
+ * Class KunstmaanNodeSearchBundle
+ *
+ * @package Kunstmaan\NodeSearchBundle
  */
 class KunstmaanNodeSearchBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -1,50 +1,54 @@
 parameters:
-    kunstmaan_node_search.search_configuration.node.class: Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration
     kunstmaan_node_search.search_configuration.number_of_shards: 1
     kunstmaan_node_search.search_configuration.number_of_replicas: 0
     kunstmaan_node_search.indexname: 'nodeindex'
     kunstmaan_node_search.indextype: 'page'
     kunstmaan_node_search.search.node.class: Kunstmaan\NodeSearchBundle\Search\NodeSearcher
+    kunstmaan_node_search.search_configuration.node.class: Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration
     kunstmaan_node_search.search_service.class: Kunstmaan\NodeSearchBundle\Services\SearchService
 
 services:
-    kunstmaan_node_search.search.abstract_elastica_searcher:
-        class: Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher
+    Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher:
         abstract: true
         calls:
-            - [ setSearch, ['@kunstmaan_search.search']]
+            - [ setSearch, ['@Kunstmaan\SearchBundle\Search\Search']]
 
-    kunstmaan_node_search.search.node:
-        class: "%kunstmaan_node_search.search.node.class%"
-        parent: kunstmaan_node_search.search.abstract_elastica_searcher
+    Kunstmaan\NodeSearchBundle\Search\NodeSearcher:
+        parent: Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher
         calls:
             - [ setIndexName, ['%kunstmaan_node_search.indexname%']]
             - [ setIndexType, ['%kunstmaan_node_search.indextype%']]
-            - [ setTokenStorage, ['@security.token_storage']]
-            - [ setDomainConfiguration, ['@kunstmaan_admin.domain_configuration']]
-            - [ setEntityManager, ['@doctrine.orm.entity_manager']]
+            - [ setTokenStorage, ['@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface']]
+            - [ setDomainConfiguration, ['@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface']]
+            - [ setEntityManager, ['@Doctrine\ORM\EntityManagerInterface']]
 
-    kunstmaan_node_search.service.indexable_pageparts:
-        class: Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService
+    Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
             - '%kunstmaan_node_search.contexts%'
 
-    kunstmaan_node_search.twig.extension:
-        class: Kunstmaan\NodeSearchBundle\Twig\KunstmaanNodeSearchTwigExtension
-        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_node_search.service.indexable_pageparts']
+    Kunstmaan\NodeSearchBundle\Twig\KunstmaanNodeSearchTwigExtension:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_node_search.search_configuration.node:
-        class: "%kunstmaan_node_search.search_configuration.node.class%"
-        arguments: ['@service_container', '@kunstmaan_search.search', '%kunstmaan_node_search.indexname%', '%kunstmaan_node_search.indextype%', '%kunstmaan_node_search.search_configuration.number_of_shards%', '%kunstmaan_node_search.search_configuration.number_of_replicas%']
+    Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
+            - '@Kunstmaan\SearchBundle\Search\Search'
+            - '%kunstmaan_node_search.indexname%'
+            - '%kunstmaan_node_search.indextype%'
+            - '%kunstmaan_node_search.search_configuration.number_of_shards%'
+            - '%kunstmaan_node_search.search_configuration.number_of_replicas%'
         calls:
             - [ setAclProvider, ['@security.acl.provider']]
-            - [ setIndexablePagePartsService, ['@kunstmaan_node_search.service.indexable_pageparts']]
+            - [ setIndexablePagePartsService, ['@Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService']]
         tags:
             - { name: kunstmaan_search.search_configuration, alias: Node }
 
-    kunstmaan_node_search.search.service:
-        class: "%kunstmaan_node_search.search_service.class%"
-        arguments: ['@service_container', '@request_stack']
+    Kunstmaan\NodeSearchBundle\Services\SearchService:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
+            - '@Symfony\Component\HttpFoundation\RequestStack'

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -36,15 +36,19 @@ services:
 
     Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration:
         arguments:
-            - '@Symfony\Component\DependencyInjection\ContainerInterface'
             - '@Kunstmaan\SearchBundle\Search\Search'
+            - '@Kunstmaan\NodeSearchBundle\Helper\PageHelper'
+            - '@Kunstmaan\NodeBundle\Helper\PagesConfiguration'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory'
+            - '%analyzer_languages%'
             - '%kunstmaan_node_search.indexname%'
             - '%kunstmaan_node_search.indextype%'
             - '%kunstmaan_node_search.search_configuration.number_of_shards%'
             - '%kunstmaan_node_search.search_configuration.number_of_replicas%'
         calls:
             - [ setAclProvider, ['@security.acl.provider']]
-            - [ setIndexablePagePartsService, ['@Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService']]
         tags:
             - { name: kunstmaan_search.search_configuration, alias: Node }
 
@@ -52,3 +56,12 @@ services:
         arguments:
             - '@Symfony\Component\DependencyInjection\ContainerInterface'
             - '@Symfony\Component\HttpFoundation\RequestStack'
+
+    Kunstmaan\NodeSearchBundle\Helper\PageHelper:
+        arguments:
+            - '@Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'
+            - '@Symfony\Component\HttpFoundation\RequestStack'
+            - '@Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService'
+            - '@Symfony\Component\Routing\RouterInterface'
+            - '@Psr\Log\LoggerInterface'
+            - '@Symfony\Component\EventDispatcher\EventDispatcherInterface'

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
@@ -2,9 +2,9 @@ parameters:
     kunstmaan_node_search.node_index_update.listener.class: Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener
 
 services:
-    kunstmaan_node_search.node_index_update.listener:
-        class: '%kunstmaan_node_search.node_index_update.listener.class%'
-        arguments: ['@service_container']
+    Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener:
+        arguments:
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
         tags:
             - { name: doctrine.event_listener, event: preUpdate,   method: preUpdate }
             - { name: kernel.event_listener, event: kunstmaan_node.postPublish,   method: onPostPublish }

--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeSearchBundle\Search;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Elastica\Query;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\Match;
@@ -59,12 +60,12 @@ class NodeSearcher extends AbstractElasticaSearcher
 
     /**
      *
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-     public function setEntityManager(EntityManager $em)
-     {
-         $this->em = $em;
-     }
+    public function setEntityManager(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
 
     /**
      * @param bool $useMatchQueryForTitle
@@ -92,15 +93,15 @@ class NodeSearcher extends AbstractElasticaSearcher
         if ($this->useMatchQueryForTitle) {
             $elasticaQueryTitle = new Match();
             $elasticaQueryTitle
-              ->setFieldQuery('title', $query)
-              ->setFieldMinimumShouldMatch('title', '80%')
-              ->setFieldBoost(2);
+                ->setFieldQuery('title', $query)
+                ->setFieldMinimumShouldMatch('title', '80%')
+                ->setFieldBoost(2);
 
         } else {
             $elasticaQueryTitle = new QueryString();
             $elasticaQueryTitle
-              ->setDefaultField('title')
-              ->setQuery($query);
+                ->setDefaultField('title')
+                ->setQuery($query);
         }
 
         $elasticaQueryBool = new BoolQuery();
@@ -130,16 +131,16 @@ class NodeSearcher extends AbstractElasticaSearcher
         $this->query->setQuery($elasticaQueryBool);
         $this->query->setRescore($rescore);
         $this->query->setHighlight(
-            array(
-                'pre_tags'  => array('<strong>'),
-                'post_tags' => array('</strong>'),
-                'fields'    => array(
-                    'content' => array(
-                        'fragment_size'       => 150,
-                        'number_of_fragments' => 3
-                    )
-                )
-            )
+            [
+                'pre_tags' => ['<strong>'],
+                'post_tags' => ['</strong>'],
+                'fields' => [
+                    'content' => [
+                        'fragment_size' => 150,
+                        'number_of_fragments' => 3,
+                    ],
+                ],
+            ]
         );
     }
 
@@ -164,7 +165,7 @@ class NodeSearcher extends AbstractElasticaSearcher
      */
     protected function getCurrentUserRoles()
     {
-        $roles = array();
+        $roles = [];
         if (!is_null($this->tokenStorage)) {
             $user = $this->tokenStorage->getToken()->getUser();
             if ($user instanceof BaseUser) {
@@ -191,10 +192,10 @@ class NodeSearcher extends AbstractElasticaSearcher
 
         //Apply page type boosts
         $pageClasses = $this->em->getRepository('KunstmaanNodeBundle:Node')->findAllDistinctPageClasses();
-        foreach($pageClasses as $pageClass) {
+        foreach ($pageClasses as $pageClass) {
             $page = new $pageClass['refEntityName']();
 
-            if($page instanceof SearchBoostInterface) {
+            if ($page instanceof SearchBoostInterface) {
                 $elasticaQueryTypeBoost = new QueryString();
                 $elasticaQueryTypeBoost
                     ->setBoost($page->getSearchBoost())

--- a/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
@@ -2,16 +2,21 @@
 
 namespace Kunstmaan\NodeSearchBundle\Twig;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 
+/**
+ * Class KunstmaanNodeSearchTwigExtension
+ *
+ * @package Kunstmaan\NodeSearchBundle\Twig
+ */
 class KunstmaanNodeSearchTwigExtension extends \Twig_Extension
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -21,10 +26,10 @@ class KunstmaanNodeSearchTwigExtension extends \Twig_Extension
     private $indexablePagePartsService;
 
     /**
-     * @param EntityManager             $em
+     * @param EntityManagerInterface    $em
      * @param IndexablePagePartsService $indexablePagePartsService
      */
-    public function __construct(EntityManager $em, IndexablePagePartsService $indexablePagePartsService)
+    public function __construct(EntityManagerInterface $em, IndexablePagePartsService $indexablePagePartsService)
     {
         $this->em = $em;
         $this->indexablePagePartsService = $indexablePagePartsService;
@@ -37,10 +42,14 @@ class KunstmaanNodeSearchTwigExtension extends \Twig_Extension
      */
     public function getFunctions()
     {
-        return array(
-            new \Twig_SimpleFunction('get_parent_page', array($this, 'getParentPage')),
-            new \Twig_SimpleFunction('render_indexable_pageparts', array($this, 'renderIndexablePageParts'), array('needs_environment' => true, 'needs_context' => true, 'is_safe' => array('html'))),
-        );
+        return [
+            new \Twig_SimpleFunction('get_parent_page', [$this, 'getParentPage']),
+            new \Twig_SimpleFunction(
+                'render_indexable_pageparts',
+                [$this, 'renderIndexablePageParts'],
+                ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['html']]
+            ),
+        ];
     }
 
     /**
@@ -74,16 +83,15 @@ class KunstmaanNodeSearchTwigExtension extends \Twig_Extension
         array $twigContext,
         HasPagePartsInterface $page,
         $contextName = 'main',
-        array $parameters = array()
-    )
-    {
+        array $parameters = []
+    ) {
         $template = $env->loadTemplate('KunstmaanNodeSearchBundle:PagePart:view.html.twig');
         $pageparts = $this->indexablePagePartsService->getIndexablePageParts($page, $contextName);
         $newTwigContext = array_merge(
             $parameters,
-            array(
-                'pageparts' => $pageparts
-            )
+            [
+                'pageparts' => $pageparts,
+            ]
         );
         $newTwigContext = array_merge($newTwigContext, $twigContext);
 

--- a/src/Kunstmaan/PagePartBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/PagePartBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Kunstmaan\PagePartBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\PagePartBundle\EventListener\CloneListener;
+use Kunstmaan\PagePartBundle\EventListener\NodeListener;
+use Kunstmaan\PagePartBundle\Helper\Services\PagePartCreatorService;
+use Kunstmaan\PagePartBundle\PagePartAdmin\Builder;
+use Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminFactory;
+use Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser;
+use Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader;
+use Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser;
+use Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader;
+use Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService;
+use Kunstmaan\PagePartBundle\Repository\PageTemplateConfigurationRepository;
+use Kunstmaan\PagePartBundle\Twig\Extension\PagePartAdminTwigExtension;
+use Kunstmaan\PagePartBundle\Twig\Extension\PagePartTwigExtension;
+use Kunstmaan\PagePartBundle\Twig\Extension\PageTemplateTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\PagePartBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_pagepart.pageparts', Builder::class],
+                ['kunstmaan_page_part.page_part_configuration_reader', PagePartConfigurationReader::class],
+                ['kunstmaan_page_part.page_part_configuration_parser', PagePartConfigurationParser::class],
+                ['kunstmaan_page_part.page_template_configuration_reader', PageTemplateConfigurationReader::class],
+                ['kunstmaan_page_part.page_template_configuration_parser', PageTemplateConfigurationParser::class],
+                ['kunstmaan_page_part.page_template.page_template_configuration_service', PageTemplateConfigurationService::class],
+                ['kunstmaan_page_part.repository.page_template_configuration', PageTemplateConfigurationRepository::class, false],
+                ['kunstmaan_pagepartadmin.factory', PagePartAdminFactory::class],
+                ['kunstmaan_pagepartadmin.twig.extension', PagePartAdminTwigExtension::class],
+                ['kunstmaan_pageparts.twig.extension', PagePartTwigExtension::class],
+                ['kunstmaan_pagetemplate.twig.extension', PageTemplateTwigExtension::class],
+                ['kunstmaan_pageparts.pagepart_creator_service', PagePartCreatorService::class],
+                ['kunstmaan_pageparts.edit_node.listener', NodeListener::class],
+                ['kunstmaan_pageparts.clone.listener', CloneListener::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_pagepart.page_part_configuration_reader.class', PagePartConfigurationReader::class],
+                ['kunstmaan_pagepart.page_part_configuration_parser.class', PagePartConfigurationParser::class, false],
+                ['kunstmaan_pagepart.page_template_configuration_reader.class', PageTemplateConfigurationReader::class],
+                ['kunstmaan_pagepart.page_template_configuration_parser.class', PageTemplateConfigurationParser::class, false],
+                ['kunstmaan_page_part.page_template.page_template_configuration_service.class', PageTemplateConfigurationService::class],
+                ['kunstmaan_page_part.admin_factory.class', PagePartAdminFactory::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanPagePartBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanPagePartBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/PagePartBundle/DependencyInjection/KunstmaanPagePartExtension.php
+++ b/src/Kunstmaan/PagePartBundle/DependencyInjection/KunstmaanPagePartExtension.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Kunstmaan\PagePartBundle\DependencyInjection;
+
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -19,7 +20,7 @@ class KunstmaanPagePartExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configs = $this->processConfiguration(new Configuration(), $configs);
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
         $container->setParameter('kunstmaan_page_part.extended', $configs['extended_pagepart_chooser']);

--- a/src/Kunstmaan/PagePartBundle/KunstmaanPagePartBundle.php
+++ b/src/Kunstmaan/PagePartBundle/KunstmaanPagePartBundle.php
@@ -2,11 +2,24 @@
 
 namespace Kunstmaan\PagePartBundle;
 
+use Kunstmaan\PagePartBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanPagePartBundle
+ * Class KunstmaanPagePartBundle
+ *
+ * @package Kunstmaan\PagePartBundle
  */
 class KunstmaanPagePartBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
@@ -1,95 +1,88 @@
 parameters:
-    kunstmaan_pagepart.page_part_configuration_reader.class: 'Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader'
-    kunstmaan_pagepart.page_part_configuration_parser.class: 'Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser'
+    kunstmaan_pagepart.page_part_configuration_reader.class: Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader
+    kunstmaan_pagepart.page_part_configuration_parser.class: Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser
 
-    kunstmaan_pagepart.page_template_configuration_reader.class: 'Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader'
-    kunstmaan_pagepart.page_template_configuration_parser.class: 'Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser'
+    kunstmaan_pagepart.page_template_configuration_reader.class: Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader
+    kunstmaan_pagepart.page_template_configuration_parser.class: Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser
 
-    kunstmaan_page_part.page_template.page_template_configuration_service.class: 'Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService'
+    kunstmaan_page_part.page_template.page_template_configuration_service.class: Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService
+    kunstmaan_page_part.admin_factory.class: Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminFactory
 
 services:
-    kunstmaan_pagepart.pageparts:
-        class: 'Kunstmaan\PagePartBundle\PagePartAdmin\Builder'
+    Kunstmaan\PagePartBundle\PagePartAdmin\Builder: ~
 
-    kunstmaan_page_part.page_part_configuration_reader:
-        class: '%kunstmaan_pagepart.page_part_configuration_reader.class%'
-        arguments: [ '@kunstmaan_page_part.page_part_configuration_parser' ]
-
-    kunstmaan_page_part.page_part_configuration_parser:
-        class: '%kunstmaan_pagepart.page_part_configuration_parser.class%'
-        public: false
-        arguments: [ '@kernel', '%kunstmaan_page_part.page_parts_presets%' ]
-
-    kunstmaan_page_part.page_template_configuration_reader:
-        class: '%kunstmaan_pagepart.page_template_configuration_reader.class%'
-        arguments: [ '@kunstmaan_page_part.page_template_configuration_parser' ]
-
-    kunstmaan_page_part.page_template_configuration_parser:
-        class: '%kunstmaan_pagepart.page_template_configuration_parser.class%'
-        public: false
-        arguments: [ '@kernel', '%kunstmaan_page_part.page_templates_presets%' ]
-
-
-    kunstmaan_page_part.page_template.page_template_configuration_service:
-        class: '%kunstmaan_page_part.page_template.page_template_configuration_service.class%'
+    Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader:
         arguments:
-          - '@kunstmaan_page_part.repository.page_template_configuration'
-          - '@kunstmaan_page_part.page_template_configuration_reader'
+          - '@Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser'
 
-    kunstmaan_page_part.repository.page_template_configuration:
-        class: 'Kunstmaan\PagePartBundle\Repository\PageTemplateConfigurationRepository'
+    Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser:
         public: false
-        factory: [ '@doctrine.orm.entity_manager', 'getRepository' ]
+        arguments:
+          - '@kernel'
+          - '%kunstmaan_page_part.page_parts_presets%'
+
+    Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader:
+        arguments:
+          - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser'
+
+    Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser:
+        public: false
+        arguments:
+          - '@kernel'
+          - '%kunstmaan_page_part.page_templates_presets%'
+
+    Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService:
+        arguments:
+          - '@Kunstmaan\PagePartBundle\Repository\PageTemplateConfigurationRepository'
+          - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader'
+
+    Kunstmaan\PagePartBundle\Repository\PageTemplateConfigurationRepository:
+        public: false
+        factory: [ '@Doctrine\ORM\EntityManagerInterface', 'getRepository' ]
         arguments:
           - 'KunstmaanPagePartBundle:PageTemplateConfiguration'
 
-    kunstmaan_pagepartadmin.factory:
-        class: 'Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminFactory'
-        arguments: ['@service_container']
+    Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminFactory:
+        arguments:
+          - '@Symfony\Component\DependencyInjection\ContainerInterface'
 
-    kunstmaan_pagepartadmin.twig.extension:
-        class: 'Kunstmaan\PagePartBundle\Twig\Extension\PagePartAdminTwigExtension'
+    Kunstmaan\PagePartBundle\Twig\Extension\PagePartAdminTwigExtension:
         tags:
             -  { name: twig.extension }
         calls:
             - [ setUsesExtendedPagePartChooser, [ '%kunstmaan_page_part.extended%' ] ]
 
-    kunstmaan_pageparts.twig.extension:
-        class: 'Kunstmaan\PagePartBundle\Twig\Extension\PagePartTwigExtension'
+    Kunstmaan\PagePartBundle\Twig\Extension\PagePartTwigExtension:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_pagetemplate.twig.extension:
-        class: 'Kunstmaan\PagePartBundle\Twig\Extension\PageTemplateTwigExtension'
+    Kunstmaan\PagePartBundle\Twig\Extension\PageTemplateTwigExtension:
         arguments:
-            - '@kunstmaan_page_part.page_template.page_template_configuration_service'
+            - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService'
         tags:
             - { name: twig.extension }
 
-    kunstmaan_pageparts.pagepart_creator_service:
-        class: 'Kunstmaan\PagePartBundle\Helper\Services\PagePartCreatorService'
+    Kunstmaan\PagePartBundle\Helper\Services\PagePartCreatorService:
         calls:
-            - [ setEntityManager, [ '@doctrine.orm.entity_manager' ] ]
+            - [ setEntityManager, [ '@Doctrine\ORM\EntityManagerInterface' ] ]
 
-    kunstmaan_pageparts.edit_node.listener:
-        class: 'Kunstmaan\PagePartBundle\EventListener\NodeListener'
+    Kunstmaan\PagePartBundle\EventListener\NodeListener:
         arguments:
-          - '@doctrine.orm.entity_manager'
-          - '@kunstmaan_pagepartadmin.factory'
-          - '@kunstmaan_page_part.page_template_configuration_reader'
-          - '@kunstmaan_page_part.page_part_configuration_reader'
-          - '@kunstmaan_page_part.page_template.page_template_configuration_service'
+          - '@Doctrine\ORM\EntityManagerInterface'
+          - '@Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminFactory'
+          - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader'
+          - '@Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader'
+          - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
-    kunstmaan_pageparts.clone.listener:
-        class: 'Kunstmaan\PagePartBundle\EventListener\CloneListener'
+    Kunstmaan\PagePartBundle\EventListener\CloneListener:
         arguments:
-          - '@doctrine.orm.entity_manager'
-          - '@kunstmaan_page_part.page_part_configuration_reader'
-          - '@kunstmaan_page_part.page_template.page_template_configuration_service'
+          - '@Doctrine\ORM\EntityManagerInterface'
+          - '@Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader'
+          - '@Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService'
 
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\PagePartBundle\Twig\Extension;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Kunstmaan\PagePartBundle\Repository\PagePartRefRepository;
@@ -13,14 +13,16 @@ use Kunstmaan\PagePartBundle\Repository\PagePartRefRepository;
 class PagePartTwigExtension extends \Twig_Extension
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
     /**
-     * @param EntityManager $em
+     * PagePartTwigExtension constructor.
+     *
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }
@@ -65,7 +67,7 @@ class PagePartTwigExtension extends \Twig_Extension
      *
      * @return PagePartInterface[]
      */
-    public function getPageParts(HasPagePartsInterface $page, $context = "main")
+    public function getPageParts(HasPagePartsInterface $page, $context = 'main')
     {
         /**@var $entityRepository PagePartRefRepository */
         $entityRepository = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');

--- a/src/Kunstmaan/RedirectBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/RedirectBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Kunstmaan\RedirectBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\RedirectBundle\Form\RedirectAdminType;
+use Kunstmaan\RedirectBundle\Helper\Menu\RedirectMenuAdaptor;
+use Kunstmaan\RedirectBundle\Repository\RedirectRepository;
+use Kunstmaan\RedirectBundle\Router\RedirectRouter;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\RedirectBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_redirect.menu.adaptor', RedirectMenuAdaptor::class],
+                ['kunstmaan_redirect.repositories.redirect', RedirectRepository::class],
+                ['kunstmaan_redirect.redirectrouter', RedirectRouter::class],
+                ['kunstmaan_redirect.form.type', RedirectAdminType::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_redirect.menu.adaptor.class', RedirectMenuAdaptor::class],
+                ['kunstmaan_redirect.redirect_repository.class', RedirectRepository::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanRedirectBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanRedirectBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/RedirectBundle/KunstmaanRedirectBundle.php
+++ b/src/Kunstmaan/RedirectBundle/KunstmaanRedirectBundle.php
@@ -2,9 +2,24 @@
 
 namespace Kunstmaan\RedirectBundle;
 
+use Kunstmaan\RedirectBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanRedirectBundle
+ *
+ * @package Kunstmaan\RedirectBundle
+ */
 class KunstmaanRedirectBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
@@ -1,27 +1,27 @@
 parameters:
-    kunstmaan_redirect.menu.adaptor.class: 'Kunstmaan\RedirectBundle\Helper\Menu\RedirectMenuAdaptor'
-    kunstmaan_redirect.redirect_repository.class: 'Kunstmaan\RedirectBundle\Repository\RedirectRepository'
-    kunstmaan_redirect.redirect.class: 'Kunstmaan\RedirectBundle\Entity\Redirect'
+    kunstmaan_redirect.menu.adaptor.class: Kunstmaan\RedirectBundle\Helper\Menu\RedirectMenuAdaptor
+    kunstmaan_redirect.redirect_repository.class: Kunstmaan\RedirectBundle\Repository\RedirectRepository
+    kunstmaan_redirect.redirect.class: Kunstmaan\RedirectBundle\Entity\Redirect
 
 services:
-    kunstmaan_redirect.menu.adaptor:
-        class: '%kunstmaan_redirect.menu.adaptor.class%'
+    Kunstmaan\RedirectBundle\Helper\Menu\RedirectMenuAdaptor:
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_redirect.repositories.redirect:
-        class:            '%kunstmaan_redirect.redirect_repository.class%'
-        factory:          ['@doctrine.orm.entity_manager', getRepository]
-        arguments:        ['%kunstmaan_redirect.redirect.class%']
+    Kunstmaan\RedirectBundle\Repository\RedirectRepository:
+        factory: ['@Doctrine\ORM\EntityManagerInterface', getRepository]
+        arguments:
+            - '%kunstmaan_redirect.redirect.class%'
 
-    kunstmaan_redirect.redirectrouter:
-        class: Kunstmaan\RedirectBundle\Router\RedirectRouter
-        arguments: ['@kunstmaan_redirect.repositories.redirect', '@kunstmaan_admin.domain_configuration']
+    Kunstmaan\RedirectBundle\Router\RedirectRouter:
+        arguments:
+            - '@Kunstmaan\RedirectBundle\Repository\RedirectRepository'
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
             - { name: router, priority: 1 }
 
-    kunstmaan_redirect.form.type:
-        class: Kunstmaan\RedirectBundle\Form\RedirectAdminType
-        arguments: ['@kunstmaan_admin.domain_configuration']
+    Kunstmaan\RedirectBundle\Form\RedirectAdminType:
+        arguments:
+            - '@Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface'
         tags:
             - { name: form.type, alias: kunstmaan_redirect_form_type }

--- a/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Kunstmaan\SearchBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\SearchBundle\Command\DeleteIndexCommand;
+use Kunstmaan\SearchBundle\Command\PopulateIndexCommand;
+use Kunstmaan\SearchBundle\Command\SetupIndexCommand;
+use Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain;
+use Kunstmaan\SearchBundle\Provider\ElasticaProvider;
+use Kunstmaan\SearchBundle\Provider\SearchProviderChain;
+use Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory;
+use Kunstmaan\SearchBundle\Search\Search;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\SearchBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_search.search', Search::class],
+                ['kunstmaan_search.search.factory.analysis', LanguageAnalysisFactory::class],
+                ['kunstmaan_search.search_provider_chain', SearchProviderChain::class],
+                ['kunstmaan_search.search_provider.elastica', ElasticaProvider::class],
+                ['kunstmaan_search.search_configuration_chain', SearchConfigurationChain::class],
+                ['kunstmaan_search.command.setup', SetupIndexCommand::class],
+                ['kunstmaan_search.command.delete', DeleteIndexCommand::class],
+                ['kunstmaan_search.command.populate', PopulateIndexCommand::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_search.search_configuration_chain.class', SearchConfigurationChain::class],
+                ['kunstmaan_search.search_provider_chain.class', SearchProviderChain::class],
+                ['kunstmaan_search.search.class', Search::class],
+                ['kunstmaan_search.search_provider.elastica.class', ElasticaProvider::class],
+                ['kunstmaan_search.search.factory.analysis.class', LanguageAnalysisFactory::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanSearchBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanSearchBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/SearchConfigurationCompilerPass.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/SearchConfigurationCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SearchBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,18 +20,18 @@ class SearchConfigurationCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_search.search_configuration_chain')) {
+        if (!$container->hasDefinition(SearchConfigurationChain::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_search.search_configuration_chain');
+        $definition = $container->getDefinition(SearchConfigurationChain::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_search.search_configuration');
 
         foreach ($taggedServices as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
                 $definition->addMethodCall(
                     'addConfiguration',
-                    array(new Reference($id), $attributes['alias'])
+                    [new Reference($id), $attributes['alias']]
                 );
             }
         }

--- a/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/SearchProviderCompilerPass.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/SearchProviderCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SearchBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\SearchBundle\Provider\SearchProviderChain;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -18,11 +19,11 @@ class SearchProviderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('kunstmaan_search.search_provider_chain')) {
+        if (!$container->hasDefinition(SearchProviderChain::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('kunstmaan_search.search_provider_chain');
+        $definition = $container->getDefinition(SearchProviderChain::class);
         $taggedServices = $container->findTaggedServiceIds('kunstmaan_search.search_provider');
 
         foreach ($taggedServices as $id => $tagAttributes) {

--- a/src/Kunstmaan/SearchBundle/DependencyInjection/KunstmaanSearchExtension.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/KunstmaanSearchExtension.php
@@ -2,7 +2,10 @@
 
 namespace Kunstmaan\SearchBundle\DependencyInjection;
 
+use Kunstmaan\SearchBundle\Provider\SearchProviderChain;
+use Kunstmaan\SearchBundle\Provider\SearchProviderChainInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -21,19 +24,24 @@ class KunstmaanSearchExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $config        = $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
-        if (count($config['analyzer_languages']) <= 0) {
+        if (\count($config['analyzer_languages']) <= 0) {
             $config['analyzer_languages'] = $this->getDefaultAnalyzerLanguages();
         }
-        $container->setParameter('analyzer_languages', \array_change_key_case($config['analyzer_languages']), \CASE_LOWER);
+        $container->setParameter('analyzer_languages', \array_change_key_case($config['analyzer_languages'], \CASE_LOWER));
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $container->setAlias(SearchProviderChainInterface::class, new Alias(SearchProviderChain::class));
     }
 
+    /**
+     * @return mixed
+     */
     public function getDefaultAnalyzerLanguages()
     {
-        return Yaml::parse(file_get_contents(__DIR__ . '/../Resources/config/analyzer_languages.yml'));
+        return Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/analyzer_languages.yml'));
     }
 }

--- a/src/Kunstmaan/SearchBundle/KunstmaanSearchBundle.php
+++ b/src/Kunstmaan/SearchBundle/KunstmaanSearchBundle.php
@@ -2,21 +2,28 @@
 
 namespace Kunstmaan\SearchBundle;
 
+use Kunstmaan\SearchBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\SearchBundle\DependencyInjection\Compiler\SearchConfigurationCompilerPass;
 use Kunstmaan\SearchBundle\DependencyInjection\Compiler\SearchProviderCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanSearchBundle
+ * Class KunstmaanSearchBundle
+ *
+ * @package Kunstmaan\SearchBundle
  */
 class KunstmaanSearchBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
         $container->addCompilerPass(new SearchConfigurationCompilerPass());
         $container->addCompilerPass(new SearchProviderCompilerPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/SearchBundle/Provider/SearchProviderInterface.php
+++ b/src/Kunstmaan/SearchBundle/Provider/SearchProviderInterface.php
@@ -47,7 +47,7 @@ interface SearchProviderInterface
      *
      * @return mixed
      */
-    public function createDocument($document, $uid, $indexName = '', $indexType = '');
+    public function createDocument($uid, $document, $indexName = '', $indexType = '');
 
     /**
      * Add a document to the index

--- a/src/Kunstmaan/SearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SearchBundle/Resources/config/services.yml
@@ -2,11 +2,11 @@ parameters:
     kunstmaan_search.hostname: 'localhost'
     kunstmaan_search.port: 9200
     kunstmaan_search.search_provider: 'Elastica'
-    kunstmaan_search.search_configuration_chain.class: Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain
-    kunstmaan_search.search_provider_chain.class: Kunstmaan\SearchBundle\Provider\SearchProviderChain
     kunstmaan_search.search.class: Kunstmaan\SearchBundle\Search\Search
-    kunstmaan_search.search_provider.elastica.class: Kunstmaan\SearchBundle\Provider\ElasticaProvider
     kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory
+    kunstmaan_search.search_provider_chain.class: Kunstmaan\SearchBundle\Provider\SearchProviderChain
+    kunstmaan_search.search_provider.elastica.class: Kunstmaan\SearchBundle\Provider\ElasticaProvider
+    kunstmaan_search.search_configuration_chain.class: Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain
     # Default analysis factory provides language aware analyzers. if you need nGram analyzers you
     # can use the provided nGramAnalysisFactory by overriding the following parameter.
     #kunstmaan_search.search.factory.analysis.class: Kunstmaan\SearchBundle\Search\NGramAnalysisFactory
@@ -15,45 +15,40 @@ parameters:
     # documentation of this SearchBundle
 
 services:
-    kunstmaan_search.search:
-        class: '%kunstmaan_search.search.class%'
-        arguments: ['@kunstmaan_search.search_provider_chain', '%searchindexprefix%', '%kunstmaan_search.search_provider%']
+    Kunstmaan\SearchBundle\Search\Search:
+        arguments:
+            - '@Kunstmaan\SearchBundle\Provider\SearchProviderChain'
+            - '%searchindexprefix%'
+            - '%kunstmaan_search.search_provider%'
 
-    kunstmaan_search.search.factory.analysis:
-        class: '%kunstmaan_search.search.factory.analysis.class%'
+    Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory: ~
 
     # Providers
-    kunstmaan_search.search_provider_chain:
-        class: '%kunstmaan_search.search_provider_chain.class%'
+    Kunstmaan\SearchBundle\Provider\SearchProviderChain: ~
 
-    kunstmaan_search.search_provider.elastica:
-        class: '%kunstmaan_search.search_provider.elastica.class%'
+    Kunstmaan\SearchBundle\Provider\ElasticaProvider:
         calls:
             - [ addNode, ['%kunstmaan_search.hostname%', '%kunstmaan_search.port%'] ]
         tags:
             - { name: kunstmaan_search.search_provider, alias: Elastica }
 
     # Configurations
-    kunstmaan_search.search_configuration_chain:
-        class: '%kunstmaan_search.search_configuration_chain.class%'
+    Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain: ~
 
-    kunstmaan_search.command.setup:
-        class: Kunstmaan\SearchBundle\Command\SetupIndexCommand
+    Kunstmaan\SearchBundle\Command\SetupIndexCommand:
         calls:
-            - [setContainer, ['@service_container'] ]
+            - [setContainer, ['@Symfony\Component\DependencyInjection\ContainerInterface'] ]
         tags:
             - { name: console.command }
 
-    kunstmaan_search.command.delete:
-        class: Kunstmaan\SearchBundle\Command\DeleteIndexCommand
+    Kunstmaan\SearchBundle\Command\DeleteIndexCommand:
         calls:
-            - [setContainer, ['@service_container'] ]
+            - [setContainer, ['@Symfony\Component\DependencyInjection\ContainerInterface'] ]
         tags:
             - { name: console.command }
 
-    kunstmaan_search.command.populate:
-        class: Kunstmaan\SearchBundle\Command\PopulateIndexCommand
+    Kunstmaan\SearchBundle\Command\PopulateIndexCommand:
         calls:
-            - [setContainer, ['@service_container'] ]
+            - [setContainer, ['@Symfony\Component\DependencyInjection\ContainerInterface'] ]
         tags:
             - { name: console.command }

--- a/src/Kunstmaan/SeoBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/SeoBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Kunstmaan\SeoBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\SeoBundle\EventListener\CloneListener;
+use Kunstmaan\SeoBundle\EventListener\NodeListener;
+use Kunstmaan\SeoBundle\Helper\Menu\SeoManagementMenuAdaptor;
+use Kunstmaan\SeoBundle\Helper\OrderConverter;
+use Kunstmaan\SeoBundle\Helper\OrderPreparer;
+use Kunstmaan\SeoBundle\Twig\GoogleAnalyticsTwigExtension;
+use Kunstmaan\SeoBundle\Twig\SeoTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\SeoBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_seo.twig.extension', SeoTwigExtension::class],
+                ['kunstmaan_seo.google_analytics.order_preparer', OrderPreparer::class],
+                ['kunstmaan_seo.google_analytics.order_converter', OrderConverter::class],
+                ['kunstmaan_seo.google_analytics.twig.extension', GoogleAnalyticsTwigExtension::class],
+                ['kunstmaan_seo.node.listener', NodeListener::class],
+                ['kunstmaan_seo.clone.listener', CloneListener::class],
+                ['kunstmaanseobundle.seo_management_menu_adaptor', SeoManagementMenuAdaptor::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanSeoBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/SeoBundle/DependencyInjection/KunstmaanSeoExtension.php
+++ b/src/Kunstmaan/SeoBundle/DependencyInjection/KunstmaanSeoExtension.php
@@ -9,7 +9,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Yaml\Yaml;
 
-
 /**
  * This is the class that loads and manages your bundle configuration
  *
@@ -32,7 +31,7 @@ class KunstmaanSeoExtension extends Extension implements PrependExtensionInterfa
 
     public function prepend(ContainerBuilder $container)
     {
-        $liipConfig = Yaml::parse(file_get_contents(__DIR__ . '/../Resources/config/imagine_filters.yml'));
+        $liipConfig = Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/imagine_filters.yml'));
         $container->prependExtensionConfig('liip_imagine', $liipConfig['liip_imagine']);
 
         $configs = $container->getExtensionConfig($this->getAlias());

--- a/src/Kunstmaan/SeoBundle/EventListener/CloneListener.php
+++ b/src/Kunstmaan/SeoBundle/EventListener/CloneListener.php
@@ -2,8 +2,7 @@
 
 namespace Kunstmaan\SeoBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
-
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
 use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
 use Kunstmaan\AdminBundle\Helper\CloneHelper;
@@ -14,9 +13,8 @@ use Kunstmaan\SeoBundle\Entity\Seo;
  */
 class CloneListener
 {
-
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -26,10 +24,10 @@ class CloneListener
     private $cloneHelper;
 
     /**
-     * @param EntityManager $em          The entity manager
-     * @param CloneHelper   $cloneHelper The clone helper
+     * @param EntityManagerInterface $em          The entity manager
+     * @param CloneHelper            $cloneHelper The clone helper
      */
-    public function __construct(EntityManager $em, CloneHelper $cloneHelper)
+    public function __construct(EntityManagerInterface $em, CloneHelper $cloneHelper)
     {
         $this->em = $em;
         $this->cloneHelper = $cloneHelper;

--- a/src/Kunstmaan/SeoBundle/EventListener/NodeListener.php
+++ b/src/Kunstmaan/SeoBundle/EventListener/NodeListener.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\SeoBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\FormWidget;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\Tab;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
@@ -17,14 +17,14 @@ use Kunstmaan\SeoBundle\Form\SocialType;
 class NodeListener
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }

--- a/src/Kunstmaan/SeoBundle/KunstmaanSeoBundle.php
+++ b/src/Kunstmaan/SeoBundle/KunstmaanSeoBundle.php
@@ -2,12 +2,24 @@
 
 namespace Kunstmaan\SeoBundle;
 
+use Kunstmaan\SeoBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanSeoBundle
+ * Class KunstmaanSeoBundle
+ *
+ * @package Kunstmaan\SeoBundle
  */
 class KunstmaanSeoBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/SeoBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/services.yml
@@ -1,20 +1,17 @@
 services:
-    kunstmaan_seo.twig.extension:
-        class: Kunstmaan\SeoBundle\Twig\SeoTwigExtension
-        arguments: ['@doctrine.orm.entity_manager']
+    Kunstmaan\SeoBundle\Twig\SeoTwigExtension:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
         calls:
             - [setWebsiteTitle, ['%websitetitle%']]
         tags:
             - { name: twig.extension }
 
-    kunstmaan_seo.google_analytics.order_preparer:
-        class: Kunstmaan\SeoBundle\Helper\OrderPreparer
+    Kunstmaan\SeoBundle\Helper\OrderPreparer: ~
 
-    kunstmaan_seo.google_analytics.order_converter:
-        class: Kunstmaan\SeoBundle\Helper\OrderConverter
+    Kunstmaan\SeoBundle\Helper\OrderConverter: ~
 
-    kunstmaan_seo.google_analytics.twig.extension:
-        class: Kunstmaan\SeoBundle\Twig\GoogleAnalyticsTwigExtension
+    Kunstmaan\SeoBundle\Twig\GoogleAnalyticsTwigExtension:
         tags:
             - { name: twig.extension }
         calls:
@@ -22,20 +19,21 @@ services:
             - [ setOrderPreparer, [ '@kunstmaan_seo.google_analytics.order_preparer' ] ]
             - [ setOrderConverter, [ '@kunstmaan_seo.google_analytics.order_converter' ] ]
 
-    kunstmaan_seo.node.listener:
-        class: Kunstmaan\SeoBundle\EventListener\NodeListener
-        arguments: ['@doctrine.orm.entity_manager']
+    Kunstmaan\SeoBundle\EventListener\NodeListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
-    kunstmaan_seo.clone.listener:
-        class: Kunstmaan\SeoBundle\EventListener\CloneListener
-        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.clone.helper']
+    Kunstmaan\SeoBundle\EventListener\CloneListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '@Kunstmaan\AdminBundle\Helper\CloneHelper'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }
 
-    kunstmaanseobundle.seo_management_menu_adaptor:
-        class: Kunstmaan\SeoBundle\Helper\Menu\SeoManagementMenuAdaptor
-        arguments: ['@security.authorization_checker']
+    Kunstmaan\SeoBundle\Helper\Menu\SeoManagementMenuAdaptor:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }

--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -2,15 +2,10 @@
 
 namespace Kunstmaan\SeoBundle\Twig;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
-
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
-
 use Kunstmaan\SeoBundle\Entity\Seo;
-
-use Twig_Environment;
-
 use Twig_Extension;
 
 /**
@@ -18,14 +13,14 @@ use Twig_Extension;
  */
 class SeoTwigExtension extends Twig_Extension
 {
-
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
     /**
      * Website title defined in your parameters
+     *
      * @var string
      */
     private $websiteTitle;
@@ -33,14 +28,15 @@ class SeoTwigExtension extends Twig_Extension
     /**
      * Saves querying the db multiple times, if you happen to use any of the defined
      * functions more than once in your templates
+     *
      * @var array
      */
     private $seoCache = [];
 
     /**
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }
@@ -52,14 +48,16 @@ class SeoTwigExtension extends Twig_Extension
      */
     public function getFunctions()
     {
-        return array(
-            new \Twig_SimpleFunction('render_seo_metadata_for', array($this, 'renderSeoMetadataFor'), array('is_safe' => array('html'), 'needs_environment' => true)),
-            new \Twig_SimpleFunction('get_seo_for', array($this, 'getSeoFor')),
-            new \Twig_SimpleFunction('get_title_for', array($this, 'getTitleFor')),
-            new \Twig_SimpleFunction('get_title_for_page_or_default', array($this, 'getTitleForPageOrDefault')),
-            new \Twig_SimpleFunction('get_absolute_url', array($this, 'getAbsoluteUrl')),
-            new \Twig_SimpleFunction('get_image_dimensions', array($this, 'getImageDimensions')),
-        );
+        return [
+            new \Twig_SimpleFunction(
+                'render_seo_metadata_for', [$this, 'renderSeoMetadataFor'], ['is_safe' => ['html'], 'needs_environment' => true]
+            ),
+            new \Twig_SimpleFunction('get_seo_for', [$this, 'getSeoFor']),
+            new \Twig_SimpleFunction('get_title_for', [$this, 'getTitleFor']),
+            new \Twig_SimpleFunction('get_title_for_page_or_default', [$this, 'getTitleForPageOrDefault']),
+            new \Twig_SimpleFunction('get_absolute_url', [$this, 'getAbsoluteUrl']),
+            new \Twig_SimpleFunction('get_image_dimensions', [$this, 'getImageDimensions']),
+        ];
     }
 
     /**
@@ -68,6 +66,7 @@ class SeoTwigExtension extends Twig_Extension
      *
      * @param string $url
      * @param string $host
+     *
      * @return string
      */
     public function getAbsoluteUrl($url, $host = null)
@@ -114,7 +113,7 @@ class SeoTwigExtension extends Twig_Extension
      */
     public function getTitleFor(AbstractPage $entity)
     {
-        $arr = array();
+        $arr = [];
 
         $arr[] = $this->getSeoTitle($entity);
 
@@ -135,7 +134,7 @@ class SeoTwigExtension extends Twig_Extension
             return $default;
         }
 
-        $arr = array();
+        $arr = [];
 
         $arr[] = $this->getSeoTitle($entity);
 
@@ -154,17 +153,21 @@ class SeoTwigExtension extends Twig_Extension
      *
      * @return string
      */
-    public function renderSeoMetadataFor(\Twig_Environment $environment, AbstractEntity $entity, $currentNode = null, $template = 'KunstmaanSeoBundle:SeoTwigExtension:metadata.html.twig')
-    {
+    public function renderSeoMetadataFor(
+        \Twig_Environment $environment,
+        AbstractEntity $entity,
+        $currentNode = null,
+        $template = 'KunstmaanSeoBundle:SeoTwigExtension:metadata.html.twig'
+    ) {
         $seo = $this->getSeoFor($entity);
         $template = $environment->loadTemplate($template);
 
         return $template->render(
-            array(
+            [
                 'seo' => $seo,
                 'entity' => $entity,
                 'currentNode' => $currentNode,
-            )
+            ]
         );
     }
 
@@ -245,6 +248,6 @@ class SeoTwigExtension extends Twig_Extension
             return null;
         }
 
-        return array('width' => $width, 'height' => $height);
+        return ['width' => $width, 'height' => $height];
     }
 }

--- a/src/Kunstmaan/SitemapBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/SitemapBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\SitemapBundle\Twig\SitemapTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\SitemapBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_sitemapbundle.sitemap.twig.extension', SitemapTwigExtension::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanSitemapBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/KunstmaanSitemapBundle.php
+++ b/src/Kunstmaan/SitemapBundle/KunstmaanSitemapBundle.php
@@ -2,9 +2,24 @@
 
 namespace Kunstmaan\SitemapBundle;
 
+use Kunstmaan\SitemapBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanSitemapBundle
+ *
+ * @package Kunstmaan\SitemapBundle
+ */
 class KunstmaanSitemapBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/SitemapBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SitemapBundle/Resources/config/services.yml
@@ -1,5 +1,4 @@
 services:
-    kunstmaan_sitemapbundle.sitemap.twig.extension:
-        class: Kunstmaan\SitemapBundle\Twig\SitemapTwigExtension
+    Kunstmaan\SitemapBundle\Twig\SitemapTwigExtension:
         tags:
             - { name: twig.extension }

--- a/src/Kunstmaan/TaggingBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/TaggingBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kunstmaan\TaggingBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\TaggingBundle\Entity\TagManager;
+use Kunstmaan\TaggingBundle\EventListener\CloneListener;
+use Kunstmaan\TaggingBundle\EventListener\IndexNodeEventListener;
+use Kunstmaan\TaggingBundle\EventListener\TagsListener;
+use Kunstmaan\TaggingBundle\Form\TagsAdminType;
+use Kunstmaan\TaggingBundle\Helper\Menu\TagMenuAdaptor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\TaggingBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kuma_tagging.tag_manager', TagManager::class],
+                ['kuma_tagging.listener', TagsListener::class],
+                ['kuma_tagging.clone.listener', CloneListener::class],
+                ['kuma_tagging.index_node.listener', IndexNodeEventListener::class],
+                ['kuma_tagging.menu.adaptor', TagMenuAdaptor::class],
+                ['form.type.tags', TagsAdminType::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanTaggingBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/TaggingBundle/Entity/TagManager.php
+++ b/src/Kunstmaan/TaggingBundle/Entity/TagManager.php
@@ -11,7 +11,6 @@ use Kunstmaan\NodeBundle\Entity\AbstractPage;
 
 class TagManager extends BaseTagManager
 {
-
     const TAGGING_HYDRATOR = 'taggingHydrator';
 
     public function loadTagging(BaseTaggable $resource)

--- a/src/Kunstmaan/TaggingBundle/EventListener/CloneListener.php
+++ b/src/Kunstmaan/TaggingBundle/EventListener/CloneListener.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\TaggingBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use DoctrineExtensions\Taggable\Taggable;
 use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
 
@@ -11,10 +11,10 @@ use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
  */
 class CloneListener
 {
-
+    /** @var EntityManagerInterface */
     protected $em;
 
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }

--- a/src/Kunstmaan/TaggingBundle/KunstmaanTaggingBundle.php
+++ b/src/Kunstmaan/TaggingBundle/KunstmaanTaggingBundle.php
@@ -2,9 +2,24 @@
 
 namespace Kunstmaan\TaggingBundle;
 
+use Kunstmaan\TaggingBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanTaggingBundle
+ *
+ * @package Kunstmaan\TaggingBundle
+ */
 class KunstmaanTaggingBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TaggingBundle/Resources/config/services.yml
@@ -1,13 +1,13 @@
-parameters:
-
 services:
-    kuma_tagging.tag_manager:
-        class: Kunstmaan\TaggingBundle\Entity\TagManager
-        arguments: ['@doctrine.orm.entity_manager', 'Kunstmaan\TaggingBundle\Entity\Tag', 'Kunstmaan\TaggingBundle\Entity\Tagging']
+    Kunstmaan\TaggingBundle\Entity\TagManager:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - 'Kunstmaan\TaggingBundle\Entity\Tag'
+            - 'Kunstmaan\TaggingBundle\Entity\Tagging'
 
-    kuma_tagging.listener:
-        class: Kunstmaan\TaggingBundle\EventListener\TagsListener
-        arguments: ['@kuma_tagging.tag_manager']
+    Kunstmaan\TaggingBundle\EventListener\TagsListener:
+        arguments:
+            - '@Kunstmaan\TaggingBundle\Entity\TagManager'
         tags:
             - { name: doctrine.event_listener, event: postUpdate }
             - { name: doctrine.event_listener, event: postPersist }
@@ -15,24 +15,22 @@ services:
             - { name: kernel.event_listener, event: kunstmaan_node.postPersist, method: postNodePersist }
             - { name: kernel.event_listener, event: kunstmaan_pagepart.postPersist, method: postPagePartPersist }
 
-    kuma_tagging.clone.listener:
-        class: Kunstmaan\TaggingBundle\EventListener\CloneListener
-        arguments: ['@doctrine.orm.entity_manager']
+    Kunstmaan\TaggingBundle\EventListener\CloneListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_admin.postDeepCloneAndSave, method: postDeepCloneAndSave }
 
-    kuma_tagging.index_node.listener:
-        class: Kunstmaan\TaggingBundle\EventListener\IndexNodeEventListener
+    Kunstmaan\TaggingBundle\EventListener\IndexNodeEventListener:
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node_search.onIndexNode, method: onIndexNode }
 
-    kuma_tagging.menu.adaptor:
-        class: Kunstmaan\TaggingBundle\Helper\Menu\TagMenuAdaptor
+    Kunstmaan\TaggingBundle\Helper\Menu\TagMenuAdaptor:
         tags:
           -  { name: kunstmaan_admin.menu.adaptor }
 
-    form.type.tags:
-        class: Kunstmaan\TaggingBundle\Form\TagsAdminType
-        arguments: ['@kuma_tagging.tag_manager']
+    Kunstmaan\TaggingBundle\Form\TagsAdminType:
+        arguments:
+            - '@Kunstmaan\TaggingBundle\Entity\TagManager'
         tags:
             - { name: form.type }

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Kunstmaan\TranslatorBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\TranslatorBundle\Repository\TranslationRepository;
+use Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler;
+use Kunstmaan\TranslatorBundle\Service\Command\DiffCommand;
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\CSVFileExporter;
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler;
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter;
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\YamlFileExporter;
+use Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler;
+use Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer;
+use Kunstmaan\TranslatorBundle\Service\Menu\TranslatorMenuAdaptor;
+use Kunstmaan\TranslatorBundle\Service\Migrations\MigrationsService;
+use Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer;
+use Kunstmaan\TranslatorBundle\Service\TranslationGroupManager;
+use Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator;
+use Kunstmaan\TranslatorBundle\Service\Translator\Loader;
+use Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher;
+use Kunstmaan\TranslatorBundle\Service\Translator\Translator;
+use Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator;
+use Kunstmaan\TranslatorBundle\Toolbar\TranslatorDataCollector;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\TranslatorBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_translator.menu.adaptor', TranslatorMenuAdaptor::class],
+                ['kunstmaan_translator.service.abstract_command_handler', AbstractCommandHandler::class],
+                ['kunstmaan_translator.service.importer.command_handler', ImportCommandHandler::class],
+                ['kunstmaan_translator.service.exporter.command_handler', ExportCommandHandler::class],
+                ['kunstmaan_translator.service.exporter.exporter', Exporter::class],
+                ['kunstmaan_translator.service.exporter.yaml', YamlFileExporter::class],
+                ['kunstmaan_translator.service.exporter.csv', CSVFileExporter::class],
+                ['kunstmaan_translator.service.file_explorer', TranslationFileExplorer::class],
+                ['kunstmaan_translator.service.importer.importer', Importer::class],
+                ['kunstmaan_translator.service.group_manager', TranslationGroupManager::class],
+                ['kunstmaan_translator.service.translator.loader', Loader::class],
+                ['kunstmaan_translator.service.translator.resource_cacher', ResourceCacher::class],
+                ['kunstmaan_translator.service.translator.cache_validator', CacheValidator::class],
+                ['kunstmaan_translator.service.translator.translator', Translator::class],
+                ['kunstmaan_translator.service.migrations.migrations', MigrationsService::class],
+                ['kunstmaan_translator.service.command.diff', DiffCommand::class],
+                ['kunstmaan_translator.datacollector', DataCollectorTranslator::class],
+                ['kunstmaan_translator.datacollector.translations', TranslatorDataCollector::class],
+                ['kunstmaan_translator.repository.translation', TranslationRepository::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_translator.menu.adaptor.class', TranslatorMenuAdaptor::class],
+                ['kunstmaan_translator.service.exporter.csv.class', CSVFileExporter::class],
+                ['kunstmaan_translator.toolbar.collector.translator.class', TranslatorDataCollector::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanTranslatorBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanTranslatorBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\TranslatorBundle\DependencyInjection\Compiler;
 
+use Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter;
+use Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer;
+use Kunstmaan\TranslatorBundle\Service\Translator\Translator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,12 +28,12 @@ class KunstmaanTranslatorCompilerPass implements CompilerPassInterface
             }
         }
 
-        if ($container->hasDefinition('kunstmaan_translator.service.importer.importer')) {
-            $container->getDefinition('kunstmaan_translator.service.importer.importer')->addMethodCall('setLoaders', array($loaderRefs));
+        if ($container->hasDefinition(Importer::class)) {
+            $container->getDefinition(Importer::class)->addMethodCall('setLoaders', array($loaderRefs));
         }
 
-        if ($container->hasDefinition('kunstmaan_translator.service.translator.translator')) {
-            $container->getDefinition('kunstmaan_translator.service.translator.translator')->replaceArgument(2, $loaderAliases);
+        if ($container->hasDefinition(Translator::class)) {
+            $container->getDefinition(Translator::class)->replaceArgument(2, $loaderAliases);
         }
 
         // add all exporter into the translation exporter
@@ -38,8 +41,8 @@ class KunstmaanTranslatorCompilerPass implements CompilerPassInterface
             $exporterRefs[$attributes[0]['alias']] = new Reference($id);
         }
 
-        if ($container->hasDefinition('kunstmaan_translator.service.exporter.exporter')) {
-            $container->getDefinition('kunstmaan_translator.service.exporter.exporter')->addMethodCall('setExporters', array($exporterRefs));
+        if ($container->hasDefinition(Exporter::class)) {
+            $container->getDefinition(Exporter::class)->addMethodCall('setExporters', array($exporterRefs));
         }
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\TranslatorBundle\DependencyInjection;
 
+use Kunstmaan\TranslatorBundle\Service\Translator\Translator;
+use Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,30 +38,30 @@ class KunstmaanTranslatorExtension extends Extension
         $container->setParameter('kuma_translator.file_formats', $config['file_formats']);
         $container->setParameter('kuma_translator.storage_engine.type', $config['storage_engine']['type']);
         $container->setParameter('kuma_translator.profiler', $container->getParameter('kernel.debug'));
-        $container->setParameter('kuma_translator.debug', is_null($config['debug']) ? $container->getParameter('kernel.debug') : $config['debug']);
+        $container->setParameter('kuma_translator.debug', \is_null($config['debug']) ? $container->getParameter('kernel.debug') : $config['debug']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('repositories.yml');
 
         $this->setTranslationConfiguration($config, $container);
-        $container->getDefinition('kunstmaan_translator.datacollector')->setDecoratedService('translator');
+        $container->getDefinition(DataCollectorTranslator::class)->setDecoratedService('translator');
     }
 
-    public function setTranslationConfiguration($config, $container)
+    public function setTranslationConfiguration($config, ContainerBuilder $container)
     {
-        $container->setAlias('translator', 'kunstmaan_translator.service.translator.translator');
-        $container->setAlias('translator.default', 'kunstmaan_translator.service.translator.translator');
-        $translator = $container->getDefinition('kunstmaan_translator.service.translator.translator');
+        $container->setAlias('translator', Translator::class);
+        $container->setAlias('translator.default', Translator::class);
+        $translator = $container->getDefinition(Translator::class);
         $this->registerTranslatorConfiguration($config, $container);
 
         // overwrites everything
-        $translator->addMethodCall('addDatabaseResources', array());
+        $translator->addMethodCall('addDatabaseResources', []);
 
-        $translator->addMethodCall('setFallbackLocales', array(array('en')));
+        $translator->addMethodCall('setFallbackLocales', [['en']]);
 
-        if($container->hasParameter('defaultlocale')) {
-            $translator->addMethodCall('setFallbackLocales', array(array($container->getParameter('defaultlocale'))));
+        if ($container->hasParameter('defaultlocale')) {
+            $translator->addMethodCall('setFallbackLocales', [[$container->getParameter('defaultlocale')]]);
         }
     }
 
@@ -68,25 +70,25 @@ class KunstmaanTranslatorExtension extends Extension
      * $this->registerTranslatorConfiguration($config['translator'], $container);
      * Used to load all other translation files
      */
-    public function registerTranslatorConfiguration($config, $container)
+    public function registerTranslatorConfiguration($config, ContainerBuilder $container)
     {
-        $translator = $container->getDefinition('kunstmaan_translator.service.translator.translator');
+        $translator = $container->getDefinition(Translator::class);
 
-        $dirs = array();
+        $dirs = [];
         if (class_exists('Symfony\Component\Validator\Validation')) {
             $r = new \ReflectionClass('Symfony\Component\Validator\Validation');
 
-            $dirs[] = dirname($r->getFilename()).'/Resources/translations';
+            $dirs[] = \dirname($r->getFileName()).'/Resources/translations';
         }
         if (class_exists('Symfony\Component\Form\Form')) {
             $r = new \ReflectionClass('Symfony\Component\Form\Form');
 
-            $dirs[] = dirname($r->getFilename()).'/Resources/translations';
+            $dirs[] = \dirname($r->getFileName()).'/Resources/translations';
         }
         $overridePath = $container->getParameter('kernel.root_dir').'/Resources/%s/translations';
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
             $reflection = new \ReflectionClass($class);
-            if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/translations')) {
+            if (is_dir($dir = \dirname($reflection->getFileName()).'/Resources/translations')) {
                 $dirs[] = $dir;
             }
             if (is_dir($dir = sprintf($overridePath, $bundle))) {
@@ -98,7 +100,7 @@ class KunstmaanTranslatorExtension extends Extension
         }
 
         // Register translation resources
-        if (count($dirs) > 0) {
+        if (\count($dirs) > 0) {
             foreach ($dirs as $dir) {
                 $container->addResource(new DirectoryResource($dir));
             }
@@ -106,16 +108,18 @@ class KunstmaanTranslatorExtension extends Extension
             $finder = Finder::create();
             $finder->files();
 
-                $finder->filter(function (\SplFileInfo $file) {
+            $finder->filter(
+                function (\SplFileInfo $file) {
                     return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
-                });
+                }
+            );
 
             $finder->in($dirs);
 
             foreach ($finder as $file) {
                 // filename is domain.locale.format
                 list($domain, $locale, $format) = explode('.', $file->getBasename());
-                $translator->addMethodCall('addResource', array($format, (string) $file, $locale, $domain));
+                $translator->addMethodCall('addResource', [$format, (string) $file, $locale, $domain]);
             }
         }
     }

--- a/src/Kunstmaan/TranslatorBundle/KunstmaanTranslatorBundle.php
+++ b/src/Kunstmaan/TranslatorBundle/KunstmaanTranslatorBundle.php
@@ -2,16 +2,26 @@
 
 namespace Kunstmaan\TranslatorBundle;
 
+use Kunstmaan\TranslatorBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
 use Kunstmaan\TranslatorBundle\DependencyInjection\Compiler\KunstmaanTranslatorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanTranslatorBundle
+ *
+ * @package Kunstmaan\TranslatorBundle
+ */
 class KunstmaanTranslatorBundle extends Bundle
 {
-
+    /**
+     * @param ContainerBuilder $container
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
         $container->addCompilerPass(new KunstmaanTranslatorCompilerPass());
+        $container->addCompilerPass(new DeprecationsCompilerPass());
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/repositories.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/repositories.yml
@@ -1,9 +1,5 @@
 services:
-#    kunstmaan_translator_list.example:
-#        class: '%kunstmaan_translater_list.example.class%'
-#        arguments: ['@service_id', 'plain_value', '%parameter%']
-
-    kunstmaan_translator.repository.translation:
-        factory: ['@doctrine.orm.entity_manager', getRepository]
-        class: 'Kunstmaan\TranslatorBundle\Repository\TranslationRepository'
-        arguments: ['Kunstmaan\TranslatorBundle\Entity\Translation']
+    Kunstmaan\TranslatorBundle\Repository\TranslationRepository:
+        factory: ['@Doctrine\ORM\EntityManagerInterface', getRepository]
+        arguments:
+            - 'Kunstmaan\TranslatorBundle\Entity\Translation'

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -1,114 +1,96 @@
 parameters:
-    kunstmaan_translator.menu.adaptor.class: 'Kunstmaan\TranslatorBundle\Service\Menu\TranslatorMenuAdaptor'
+    kunstmaan_translator.menu.adaptor.class: Kunstmaan\TranslatorBundle\Service\Menu\TranslatorMenuAdaptor
     kunstmaan_translator.service.exporter.csv.class: Kunstmaan\TranslatorBundle\Service\Command\Exporter\CSVFileExporter
     kunstmaan_translator.toolbar.collector.translator.class: Kunstmaan\TranslatorBundle\Toolbar\TranslatorDataCollector
 
 services:
-    kunstmaan_translator.menu.adaptor:
-        class: '%kunstmaan_translator.menu.adaptor.class%'
+    Kunstmaan\TranslatorBundle\Service\Menu\TranslatorMenuAdaptor:
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor' }
 
-    kunstmaan_translator.service.abstract_command_handler:
+    Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler:
         abstract: true
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler'
         calls:
             - [setManagedLocales, ['%kuma_translator.managed_locales%']]
             - [setKernel, ['@kernel']]
 
-    kunstmaan_translator.service.importer.command_handler:
-        parent: kunstmaan_translator.service.abstract_command_handler
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler'
+    Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler:
+        parent: Kunstmaan\TranslatorBundle\Service\Command\AbstractCommandHandler
         calls:
-            - [setTranslationFileExplorer, ['@kunstmaan_translator.service.file_explorer']]
-            - [setImporter, ['@kunstmaan_translator.service.importer.importer']]
+            - [setTranslationFileExplorer, ['@Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer']]
+            - [setImporter, ['@Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer']]
 
-    kunstmaan_translator.service.exporter.command_handler:
+    Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler:
         parent: kunstmaan_translator.service.abstract_command_handler
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler'
         calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
-            - [setExporter, ['@kunstmaan_translator.service.exporter.exporter']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
+            - [setExporter, ['@Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter']]
 
-    kunstmaan_translator.service.exporter.exporter:
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter'
+    Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter: ~
 
-    kunstmaan_translator.service.exporter.yaml:
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\YamlFileExporter'
+    Kunstmaan\TranslatorBundle\Service\Command\Exporter\YamlFileExporter:
         tags:
             - { name: 'translation.exporter', alias: 'yml' }
 
-    kunstmaan_translator.service.exporter.csv:
-        class: "%kunstmaan_translator.service.exporter.csv.class%"
+    Kunstmaan\TranslatorBundle\Service\Command\Exporter\CSVFileExporter:
         tags:
             - { name: 'translation.exporter', alias: 'csv' }
 
-    kunstmaan_translator.service.file_explorer:
-        class: 'Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer'
+    Kunstmaan\TranslatorBundle\Service\TranslationFileExplorer:
         calls:
             - [setFileFormats, ['%kuma_translator.file_formats%']]
 
-    kunstmaan_translator.service.importer.importer:
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer'
+    Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer:
         calls:
-            - [setTranslationGroupManager, ['@kunstmaan_translator.service.group_manager']] # default, maken via config var
+            - [setTranslationGroupManager, ['@Kunstmaan\TranslatorBundle\Service\TranslationGroupManager']] # default, maken via config var
 
-    kunstmaan_translator.service.group_manager:
-        class: 'Kunstmaan\TranslatorBundle\Service\TranslationGroupManager'
+    Kunstmaan\TranslatorBundle\Service\TranslationGroupManager:
         calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
 
-    kunstmaan_translator.service.translator.loader:
-        class: Kunstmaan\TranslatorBundle\Service\Translator\Loader
+    Kunstmaan\TranslatorBundle\Service\Translator\Loader:
         tags:
             - { name: 'translation.loader', alias: 'database' }
         calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
 
-    kunstmaan_translator.service.translator.resource_cacher:
-        class: Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher
+    Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher:
         calls:
             - [setDebug, ['%kuma_translator.debug%']]
             - [setCacheDir, ['%kuma_translator.cache_dir%']]
-            - [setLogger, ['@logger']]
+            - [setLogger, ['@Psr\Log\LoggerInterface']]
 
-    kunstmaan_translator.service.translator.cache_validator:
-        class: Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator
+    Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator:
         calls:
             - [setCacheDir, ['%kuma_translator.cache_dir%']]
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
 
-    kunstmaan_translator.service.translator.translator:
-        class: Kunstmaan\TranslatorBundle\Service\Translator\Translator
+    Kunstmaan\TranslatorBundle\Service\Translator\Translator:
         arguments:
-            - '@service_container'
+            - '@Symfony\Component\DependencyInjection\ContainerInterface'
             - '@translator.selector'
             - {}
             - { cache_dir: '%kuma_translator.cache_dir%', debug: '%kuma_translator.debug%' }
-            - ['@session']
+            - ['@Symfony\Component\HttpFoundation\Session\SessionInterface']
         calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
-            - [setResourceCacher, ['@kunstmaan_translator.service.translator.resource_cacher']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
+            - [setResourceCacher, ['@Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher']]
 
-    kunstmaan_translator.service.migrations.migrations:
-        class: 'Kunstmaan\TranslatorBundle\Service\Migrations\MigrationsService'
+    Kunstmaan\TranslatorBundle\Service\Migrations\MigrationsService:
         calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+            - [setTranslationRepository, ['@Kunstmaan\TranslatorBundle\Repository\TranslationRepository']]
             - [setEntityManager, ['@doctrine.orm.default_entity_manager']]
 
-    kunstmaan_translator.service.command.diff:
-        class: 'Kunstmaan\TranslatorBundle\Service\Command\DiffCommand'
+    Kunstmaan\TranslatorBundle\Service\Command\DiffCommand: ~
 
-    kunstmaan_translator.datacollector:
-        class: Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator
+    Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator:
         arguments:
-            - '@translator.default'
+            - '@Kunstmaan\TranslatorBundle\Service\Translator\Translator'
 
-    kunstmaan_translator.datacollector.translations:
-        class: '%kunstmaan_translator.toolbar.collector.translator.class%'
+    Kunstmaan\TranslatorBundle\Toolbar\TranslatorDataCollector:
         parent: Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector
         arguments:
-            - '@kunstmaan_translator.datacollector'
-            - '@router'
+            - '@Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator'
+            - '@Symfony\Component\Routing\RouterInterface'
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: 'KunstmaanTranslatorBundle:Toolbar:translations.html.twig', id: kuma_translation}

--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
@@ -4,25 +4,22 @@ namespace Kunstmaan\TranslatorBundle\Service\Translator;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
+use Kunstmaan\TranslatorBundle\Repository\TranslationRepository;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator as SymfonyTranslator;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Translator
  */
 class Translator extends SymfonyTranslator
 {
-
+    /** @var TranslationRepository */
     private $translationRepository;
 
-    /**
-     * Resource Cacher
-     * @var Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher
-     */
+    /** @var ResourceCacher */
     private $resourceCacher;
 
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
+    /** @var Request */
     protected $request;
 
     /**
@@ -36,7 +33,7 @@ class Translator extends SymfonyTranslator
             $this->addResourcesFromDatabaseAndCacheThem();
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -75,7 +72,7 @@ class Translator extends SymfonyTranslator
             if ($cacheResources === true) {
                 $this->resourceCacher->cacheResources($resources);
             }
-        } catch (\Exception $ex){
+        } catch (\Exception $ex) {
             // don't load if the database doesn't work
         }
     }
@@ -107,7 +104,7 @@ class Translator extends SymfonyTranslator
         return parent::loadCatalogue($locale);
     }
 
-    public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
     {
         if (!$this->request = $this->container->get('request_stack')->getCurrentRequest()) {
             return parent::trans($id, $parameters, $domain, $locale);
@@ -148,7 +145,7 @@ class Translator extends SymfonyTranslator
             $translationCollection = new ArrayCollection;
         }
 
-        $translationCollection->set($domain . $id . $locale, $translation);
+        $translationCollection->set($domain.$id.$locale, $translation);
 
         $this->request->request->set('usedTranslations', $translationCollection);
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/security.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/security.yml
@@ -17,13 +17,13 @@ security:
     firewalls:
         main:
             pattern: .*
+            provider: fos_userbundle
             guard:
                 authenticators:
                     - kunstmaan_admin.oauth_authenticator
             form_login:
                 login_path: fos_user_security_login
                 check_path: fos_user_security_check
-                provider: fos_userbundle
             logout:
                 path:   fos_user_security_logout
                 target: KunstmaanAdminBundle_homepage

--- a/src/Kunstmaan/TranslatorBundle/Toolbar/TranslatorDataCollector.php
+++ b/src/Kunstmaan/TranslatorBundle/Toolbar/TranslatorDataCollector.php
@@ -6,6 +6,7 @@ use Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\DataCollectorTranslator;
 
 class TranslatorDataCollector extends AbstractDataCollector
 {

--- a/src/Kunstmaan/UserManagementBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/UserManagementBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kunstmaan\UserManagementBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\UserManagementBundle\AdminList\UserAdminListConfigurator;
+use Kunstmaan\UserManagementBundle\Helper\Menu\UserManagementMenuAdaptor;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\UserManagementBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_user_management.menu.adaptor', UserManagementMenuAdaptor::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_user_management.user_admin_list_configurator.class', UserAdminListConfigurator::class],
+                ['kunstmaan_user_management.menu.adaptor.class', UserManagementMenuAdaptor::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanUserManagementBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanUserManagementBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/UserManagementBundle/KunstmaanUserManagementBundle.php
+++ b/src/Kunstmaan/UserManagementBundle/KunstmaanUserManagementBundle.php
@@ -2,8 +2,24 @@
 
 namespace Kunstmaan\UserManagementBundle;
 
+use Kunstmaan\UserManagementBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * Class KunstmaanUserManagementBundle
+ *
+ * @package Kunstmaan\UserManagementBundle
+ */
 class KunstmaanUserManagementBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ parameters:
   kunstmaan_user_management.menu.adaptor.class: Kunstmaan\UserManagementBundle\Helper\Menu\UserManagementMenuAdaptor
 
 services:
-    kunstmaan_user_management.menu.adaptor:
-        class: '%kunstmaan_user_management.menu.adaptor.class%'
-        arguments: ['@security.authorization_checker']
+    Kunstmaan\UserManagementBundle\Helper\Menu\UserManagementMenuAdaptor:
+        arguments:
+            - '@Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
         tags:
             -  { name: 'kunstmaan_admin.menu.adaptor', priority: 100 }

--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\UtilitiesBundle\Helper\Cipher\UrlSafeCipher;
+use Kunstmaan\UtilitiesBundle\Helper\Shell\Shell;
+use Kunstmaan\UtilitiesBundle\Helper\Slugifier;
+use Kunstmaan\UtilitiesBundle\Twig\UtilitiesTwigExtension;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_utilities.shell', Shell::class],
+                ['kunstmaan_utilities.cipher', UrlSafeCipher::class],
+                ['kunstmaan_utilities.slugifier', Slugifier::class],
+                ['kunstmaan_utilities.twig.extension', UtilitiesTwigExtension::class],
+            ]
+        );
+
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_utilities.slugifier.class', Slugifier::class],
+                ['kunstmaan_utilities.shell.class', Shell::class],
+                ['kunstmaan_utilities.cipher.class', UrlSafeCipher::class],
+            ],
+            true
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     * @param bool             $parametered
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations, $parametered = false)
+    {
+        foreach ($deprecations as $deprecation) {
+            // Don't allow service with same name as class.
+            if ($parametered && $container->getParameter($deprecation[0]) === $deprecation[1]) {
+                continue;
+            }
+
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            if ($parametered) {
+                $class = $container->getParameter($deprecation[0]);
+                $definition->setClass($class);
+                $definition->setDeprecated(
+                    true,
+                    'Override service class with "%service_id%" is deprecated since KunstmaanUtilitiesBundle 5.1 and will be removed in 6.0. Override the service instance instead.'
+                );
+                $container->setDefinition($class, $definition);
+            } else {
+                $definition->setClass($deprecation[1]);
+                $definition->setDeprecated(
+                    true,
+                    'Passing a "%service_id%" instance is deprecated since KunstmaanUtilitiesBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+                );
+                $container->setDefinition($deprecation[0], $definition);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
@@ -2,7 +2,10 @@
 
 namespace Kunstmaan\UtilitiesBundle\DependencyInjection;
 
+use Kunstmaan\UtilitiesBundle\Helper\Slugifier;
+use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -24,5 +27,7 @@ class KunstmaanUtilitiesExtension extends Extension
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $container->setAlias(SlugifierInterface::class, new Alias(Slugifier::class));
     }
 }

--- a/src/Kunstmaan/UtilitiesBundle/KunstmaanUtilitiesBundle.php
+++ b/src/Kunstmaan/UtilitiesBundle/KunstmaanUtilitiesBundle.php
@@ -2,11 +2,24 @@
 
 namespace Kunstmaan\UtilitiesBundle;
 
+use Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanUtilitiesBundle
+ * Class KunstmaanUtilitiesBundle
+ *
+ * @package Kunstmaan\UtilitiesBundle
  */
 class KunstmaanUtilitiesBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/UtilitiesBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/UtilitiesBundle/Resources/config/services.yml
@@ -5,19 +5,17 @@ parameters:
     kunstmaan_utilities.cipher.secret: ''
 
 services:
-    kunstmaan_utilities.shell:
-        class: '%kunstmaan_utilities.shell.class%'
+    Kunstmaan\UtilitiesBundle\Helper\Shell\Shell: ~
 
-    kunstmaan_utilities.cipher:
-        class: '%kunstmaan_utilities.cipher.class%'
-        arguments: ['%kunstmaan_utilities.cipher.secret%']
+    Kunstmaan\UtilitiesBundle\Helper\Cipher\UrlSafeCipher:
+        arguments:
+            - '%kunstmaan_utilities.cipher.secret%'
 
-    kunstmaan_utilities.slugifier:
-        class: '%kunstmaan_utilities.slugifier.class%'
+    Kunstmaan\UtilitiesBundle\Helper\Slugifier: ~
 
-    kunstmaan_utilities.twig.extension:
-        class: Kunstmaan\UtilitiesBundle\Twig\UtilitiesTwigExtension
-        arguments: ['@kunstmaan_utilities.slugifier']
+    Kunstmaan\UtilitiesBundle\Twig\UtilitiesTwigExtension:
+        arguments:
+            - '@Kunstmaan\UtilitiesBundle\Helper\Slugifier'
         tags:
             - { name: twig.extension }
 

--- a/src/Kunstmaan/VotingBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
+++ b/src/Kunstmaan/VotingBundle/DependencyInjection/Compiler/DeprecationsCompilerPass.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Kunstmaan\VotingBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\VotingBundle\EventListener\AbstractVoteListener;
+use Kunstmaan\VotingBundle\EventListener\Facebook\FacebookLikeEventListener;
+use Kunstmaan\VotingBundle\EventListener\Facebook\FacebookSendEventListener;
+use Kunstmaan\VotingBundle\EventListener\LinkedIn\LinkedInShareEventListener;
+use Kunstmaan\VotingBundle\EventListener\UpDown\DownVoteEventListener;
+use Kunstmaan\VotingBundle\EventListener\UpDown\UpVoteEventListener;
+use Kunstmaan\VotingBundle\Helper\AbstractVotingHelper;
+use Kunstmaan\VotingBundle\Helper\Facebook\FacebookLikeHelper;
+use Kunstmaan\VotingBundle\Helper\Facebook\FacebookSendHelper;
+use Kunstmaan\VotingBundle\Helper\LinkedIn\LinkedInShareHelper;
+use Kunstmaan\VotingBundle\Helper\UpDown\DownVoteHelper;
+use Kunstmaan\VotingBundle\Helper\UpDown\UpVoteHelper;
+use Kunstmaan\VotingBundle\Services\RepositoryResolver;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DeprecationsCompilerPass
+ *
+ * @package Kunstmaan\VotingBundle\DependencyInjection\Compiler
+ */
+class DeprecationsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->addDeprecatedChildDefinitions(
+            $container,
+            [
+                ['kunstmaan_voting.listener.vote', AbstractVoteListener::class],
+                ['kunstmaan_voting.helper.vote', AbstractVotingHelper::class],
+                ['kunstmaan_voting.upvote', UpVoteEventListener::class],
+                ['kunstmaan_voting.helper.upvote', UpVoteHelper::class],
+                ['kunstmaan_voting.downvote', DownVoteEventListener::class],
+                ['kunstmaan_voting.helper.downvote', DownVoteHelper::class],
+                ['kunstmaan_voting.facebooklike', FacebookLikeEventListener::class],
+                ['kunstmaan_voting.helper.facebook.like', FacebookLikeHelper::class],
+                ['kunstmaan_voting.facebooksend', FacebookSendEventListener::class],
+                ['kunstmaan_voting.helper.facebook.send', FacebookSendHelper::class],
+                ['kunstmaan_voting.linkedinshare', LinkedInShareEventListener::class],
+                ['kunstmaan_voting.helper.linkedin.share', LinkedInShareHelper::class],
+                ['kunstmaan_voting.services.repository_resolver', RepositoryResolver::class],
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $deprecations
+     */
+    private function addDeprecatedChildDefinitions(ContainerBuilder $container, array $deprecations)
+    {
+        foreach ($deprecations as $deprecation) {
+            $definition = new ChildDefinition($deprecation[1]);
+            if (isset($deprecation[2])) {
+                $definition->setPublic($deprecation[2]);
+            }
+
+            $definition->setClass($deprecation[1]);
+            $definition->setDeprecated(
+                true,
+                'Passing a "%service_id%" instance is deprecated since KunstmaanVotingBundle 5.1 and will be removed in 6.0. Use the FQCN instead.'
+            );
+            $container->setDefinition($deprecation[0], $definition);
+        }
+    }
+}

--- a/src/Kunstmaan/VotingBundle/DependencyInjection/KunstmaanVotingExtension.php
+++ b/src/Kunstmaan/VotingBundle/DependencyInjection/KunstmaanVotingExtension.php
@@ -56,8 +56,8 @@ class KunstmaanVotingExtension extends Extension
 
         // When no values are defined, initialize with defaults
         foreach($possibleActions as $action) {
-            if (!isset($config['actions'][$action]) || !is_array($config['actions'][$action])) {
-                $config['actions'][$action]['default_value'] = ( $action == 'down_vote' ? -1 * $votingDefaultValue : $votingDefaultValue );
+            if (!isset($config['actions'][$action]) || !\is_array($config['actions'][$action])) {
+                $config['actions'][$action]['default_value'] = ( $action === 'down_vote' ? -1 * $votingDefaultValue : $votingDefaultValue );
             }
         }
 

--- a/src/Kunstmaan/VotingBundle/KunstmaanVotingBundle.php
+++ b/src/Kunstmaan/VotingBundle/KunstmaanVotingBundle.php
@@ -2,12 +2,24 @@
 
 namespace Kunstmaan\VotingBundle;
 
+use Kunstmaan\VotingBundle\DependencyInjection\Compiler\DeprecationsCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * KunstmaanVotingBundle
+ * Class KunstmaanVotingBundle
+ *
+ * @package Kunstmaan\VotingBundle
  */
 class KunstmaanVotingBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new DeprecationsCompilerPass());
+    }
 }

--- a/src/Kunstmaan/VotingBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/VotingBundle/Resources/config/services.yml
@@ -1,82 +1,60 @@
-parameters:
-#    kunstmaan_voting_list.example.class: Kunstmaan\VotingBundle\Example
-
 services:
-#    kunstmaan_voting_list.example:
-#        class: %kunstmaan_voting_list.example.class%
-#        arguments: [@service_id, 'plain_value', %parameter%]
-
-    kunstmaan_voting.listener.vote:
-        class: Kunstmaan\VotingBundle\EventListener\AbstractVoteListener
-        arguments: ['@doctrine.orm.entity_manager', '%kuma_voting.actions%']
+    Kunstmaan\VotingBundle\EventListener\AbstractVoteListener:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
+            - '%kuma_voting.actions%'
         abstract: true
 
-    kunstmaan_voting.helper.vote:
-        class: Kunstmaan\VotingBundle\Helper\AbstractVotingHelper
-        arguments: ['@doctrine.orm.entity_manager']
+    Kunstmaan\VotingBundle\Helper\AbstractVotingHelper:
+        arguments:
+            - '@Doctrine\ORM\EntityManagerInterface'
         abstract: true
 
     ## UP VOTE
-
-    kunstmaan_voting.upvote:
-        class: Kunstmaan\VotingBundle\EventListener\UpDown\UpVoteEventListener
-        parent: 'kunstmaan_voting.listener.vote'
+    Kunstmaan\VotingBundle\EventListener\UpDown\UpVoteEventListener:
+        parent: 'Kunstmaan\VotingBundle\EventListener\AbstractVoteListener'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.upVote, method: onUpVote }
 
-    kunstmaan_voting.helper.upvote:
-        class: Kunstmaan\VotingBundle\Helper\UpDown\UpVoteHelper
-        parent: 'kunstmaan_voting.helper.vote'
+    Kunstmaan\VotingBundle\Helper\UpDown\UpVoteHelper:
+        parent: 'Kunstmaan\VotingBundle\Helper\AbstractVotingHelper'
 
     ## Down VOTE
-
-    kunstmaan_voting.downvote:
-        class: Kunstmaan\VotingBundle\EventListener\UpDown\DownVoteEventListener
-        parent: 'kunstmaan_voting.listener.vote'
+    Kunstmaan\VotingBundle\EventListener\UpDown\DownVoteEventListener:
+        parent: 'Kunstmaan\VotingBundle\EventListener\AbstractVoteListener'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.downVote, method: onDownVote }
 
-    kunstmaan_voting.helper.downvote:
-        class: Kunstmaan\VotingBundle\Helper\UpDown\DownVoteHelper
-        parent: 'kunstmaan_voting.helper.vote'
+    Kunstmaan\VotingBundle\Helper\UpDown\DownVoteHelper:
+        parent: 'Kunstmaan\VotingBundle\Helper\AbstractVotingHelper'
 
     ## FACEBOOK LIKE
-
-    kunstmaan_voting.facebooklike:
-        class: Kunstmaan\VotingBundle\EventListener\Facebook\FacebookLikeEventListener
-        parent: 'kunstmaan_voting.listener.vote'
+    Kunstmaan\VotingBundle\EventListener\Facebook\FacebookLikeEventListener:
+        parent: 'Kunstmaan\VotingBundle\EventListener\AbstractVoteListener'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.facebookLike, method: onFacebookLike }
 
-    kunstmaan_voting.helper.facebook.like:
-        class: Kunstmaan\VotingBundle\Helper\Facebook\FacebookLikeHelper
-        parent: 'kunstmaan_voting.helper.vote'
+    Kunstmaan\VotingBundle\Helper\Facebook\FacebookLikeHelper:
+        parent: 'Kunstmaan\VotingBundle\Helper\AbstractVotingHelper'
 
     ## FACEBOOK SEND
-
-    kunstmaan_voting.facebooksend:
-        class: Kunstmaan\VotingBundle\EventListener\Facebook\FacebookSendEventListener
-        parent: 'kunstmaan_voting.listener.vote'
+    Kunstmaan\VotingBundle\EventListener\Facebook\FacebookSendEventListener:
+        parent: 'Kunstmaan\VotingBundle\EventListener\AbstractVoteListener'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.facebookSend, method: onFacebookSend }
 
-    kunstmaan_voting.helper.facebook.send:
-        class: Kunstmaan\VotingBundle\Helper\Facebook\FacebookSendHelper
-        parent: 'kunstmaan_voting.helper.vote'
+    Kunstmaan\VotingBundle\Helper\Facebook\FacebookSendHelper:
+        parent: 'Kunstmaan\VotingBundle\Helper\AbstractVotingHelper'
 
     ## LINKEDIN SHARE
-
-    kunstmaan_voting.linkedinshare:
-        class: Kunstmaan\VotingBundle\EventListener\LinkedIn\LinkedInShareEventListener
-        parent: 'kunstmaan_voting.listener.vote'
+    Kunstmaan\VotingBundle\EventListener\LinkedIn\LinkedInShareEventListener:
+        parent: 'Kunstmaan\VotingBundle\EventListener\AbstractVoteListener'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_voting.linkedInShare, method: onLinkedInShare }
 
-    kunstmaan_voting.helper.linkedin.share:
-        class: Kunstmaan\VotingBundle\Helper\LinkedIn\LinkedInShareHelper
-        parent: 'kunstmaan_voting.helper.vote'
+    Kunstmaan\VotingBundle\Helper\LinkedIn\LinkedInShareHelper:
+        parent: 'Kunstmaan\VotingBundle\Helper\AbstractVotingHelper'
 
     # SERVICES
-    kunstmaan_voting.services.repository_resolver:
-        class: Kunstmaan\VotingBundle\Services\RepositoryResolver
+    Kunstmaan\VotingBundle\Services\RepositoryResolver:
         arguments: ['@doctrine.orm.entity_manager']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Fixed tickets |

The NodePagesConfiguration class was to large. I've created an extra helper "PageHelper" to split things up. 

Another big thing is that the "service" action is being removed. I will add a PR to the master branch to deprecate this function. The use of this service action was actually "ugly" because it needed to be added to the entity itself. You need to use the SlugActionInterface for this. The NodePagesConfiguration class also used the service action to add extra content to the search view. This is now changed to an event that you can subscribe to.

Changes:

- PageHelper class
- getDefaultSearchViewTemplate function
- Remove of container
- Inject correct services
- Remove of "service" action
- Add of event on indexing search view

**#1814 needs to be merged first.**