### PR TITLE
[NodeBundle]: deprecate service function

### DIFF
--- a/src/Kunstmaan/NodeBundle/Entity/AbstractPage.php
+++ b/src/Kunstmaan/NodeBundle/Entity/AbstractPage.php
@@ -127,9 +127,12 @@ abstract class AbstractPage extends AbstractEntity implements PageInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated Using the service action is deprecated in KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0. Use the SlugActionInterface instead
      */
     public function service(ContainerInterface $container, Request $request, RenderContext $context)
     {
+        @trigger_error('Using the service action is deprecated in KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0. Use the SlugActionInterface instead', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Entity/PageInterface.php
+++ b/src/Kunstmaan/NodeBundle/Entity/PageInterface.php
@@ -2,7 +2,6 @@
 
 namespace Kunstmaan\NodeBundle\Entity;
 
-use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Helper\RenderContext;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,6 +18,8 @@ interface PageInterface extends HasNodeInterface
      * @param ContainerInterface $container The Container
      * @param Request            $request   The Request
      * @param RenderContext      $context   The Render context
+     *
+     * @deprecated Using the service action is deprecated in KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0. Use the SlugActionInterface instead.
      *
      * @return void|RedirectResponse
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

As said in #1839 we are removing the service function in 6.0. This PR will add deprecation notice for the master branch.