### PR TITLE
[PagePartBundle] Fix for PHP 7.2 - value passed to count() cannot be null

### DIFF
--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -265,7 +265,7 @@ class PagePartAdmin
         $ppRefRepo = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
 
         // Add new pageparts on the correct position + Re-order and save pageparts if needed
-        $sequences = $request->get($this->context.'_sequence');
+        $sequences = $request->get($this->context.'_sequence', []);
         $sequencescount = count($sequences);
         for ($i = 0; $i < $sequencescount; $i++) {
             $pagePartRefId = $sequences[$i];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This PR solves the issue stated in the closed #1802 PR due to no reaction.
