### PR TITLE
5.1 upgrade file with all current changes

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -1,0 +1,45 @@
+UPGRADE FROM 5.0 to 5.1
+=======================
+
+AdminBundle
+-----------
+
+ * Passing the `logger` service as the second argument in `Kunstmaan\AdminBundle\Toolbar\BundleVersionDataCollector` is deprecated and will be removed in 6.0.
+
+AdminListBundle
+---------------
+
+ * Getting services directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary dependencies.
+ * Getting parameters directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary parameters.
+
+ArticleBundle
+-------------
+
+ * Passing the `request_stack` service as the third argument in `Kunstmaan\ArticleBundle\Twig\ArticleTwigExtension` is deprecated and will be removed in 6.0.
+
+ConfigBundle
+------------
+
+ * Passing the `container` as the sixth argument in `Kunstmaan\ConfigBundle\Controller\ConfigController` is deprecated in and will be removed in 6.0.
+
+NodeBundle
+----------
+
+ * `CronUpdateNodeCommand::__construct()` now takes an instance of `Doctrine\ORM\EntityManagerInterface` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `InitAclCommand::__construct()` now takes an instance of `Doctrine\ORM\EntityManagerInterface` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `CronUpdateNodeCommand` and `InitAclCommand` have been marked as final.
+
+TranslatorBundle
+----------------
+
+ * `ExportTranslationsCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Service\Command\Exporter\ExportCommandHandler` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `ImportTranslationsCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Service\Command\Importer\ImportCommandHandler` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `TranslationCacheCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `TranslationFlagCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Repository\TranslationRepository` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `ExportTranslationsCommand`, `ImportTranslationsCommand`, `MigrationsDiffCommand`, `TranslationCacheCommand` and `TranslationFlagCommand` have been marked as final.
+
+UtilitiesBundle
+---------------
+
+ * `CipherCommand::__construct()` now takes an instance of `Kunstmaan\UtilitiesBundle\Helper\Cipher\CipherInterface` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
+ * `CipherCommand` has been marked as final.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I've added a 5.1 upgrade file (the same way as symfony it does) and included all the current changes/deprecations. This file should be kept up-to-date when adding deprecations. This way the user has the deprecation warnings in his toolbar and this document to follow when upgrading minor versions. 
