### PR TITLE
[AdminBundle] Fix escaping of img src attributes in WYSIWYG fields

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
+++ b/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
@@ -63,10 +63,21 @@ class MediaTokenTransformer implements DataTransformerInterface
                 if (isset($query['token'])) {
                     $image->setAttribute('src', $query['token']);
                 }
-                $image->setAttribute('data-src', urldecode($src));
+                $image->setAttribute('data-src', $src);
             }
         );
 
-        return $crawler->filter('body')->html();
+        $html = $crawler->filter('body')->html();
+
+        // URL-decode square brackets in img and a tags
+        $html = preg_replace_callback(
+            '/<(img|a)\s+[^>]*>/',
+            function($matches) {
+                return str_replace(['%5B', '%5D'], ['[', ']'], $matches[0]);
+            },
+            $html
+        );
+
+        return $html;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Tests/Form/MediaTokenTransformerTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Form/MediaTokenTransformerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\Form;
+
+use Kunstmaan\AdminBundle\Form\MediaTokenTransformer;
+
+/**
+ * Class MediaTokenTransformerTest
+ *
+ * @package Kunstmaan\AdminBundle\Tests\Form
+ */
+class MediaTokenTransformerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testTransformCopiesDataSrcToSrc()
+    {
+        $transformer = new MediaTokenTransformer();
+
+        $content = '<img src="[M1]" data-src="image.jpg?token=[M1]">';
+
+        $expected = '<img src="image.jpg?token=%5BM1%5D">';
+
+        $this->assertContains($expected, $transformer->transform($content));
+    }
+
+    public function testReverseTransformSetsSrcAndDataSrc()
+    {
+        $transformer = new MediaTokenTransformer();
+
+        $content = '<img src="image.jpg?token=%5BM1%5D">';
+
+        $expected = '<img src="[M1]" data-src="image.jpg?token=[M1]">';
+
+        $this->assertEquals($expected, $transformer->reverseTransform($content));
+    }
+
+    public function testReverseTransformPreservesAnchorHrefs()
+    {
+        $transformer = new MediaTokenTransformer();
+
+        $content = '<a href="%5BNT1%5D"></a>';
+
+        $expected = '<a href="[NT1]"></a>';
+
+        $this->assertEquals($expected, $transformer->reverseTransform($content));
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1857

The `MediaTokenTransformer::reverseTransform()` method uses the `Crawler::html()` method to produce the HTML it returns, but this method automatically URL-encodes the `src` attribute of image tags.

This PR does a search and replace on the final HTML to make sure that the square brackets used for the tokens are preserved.

_NB: the Symfony docs mention that the DomCrawler Component is not designed to re-dump HTML, and so it might be worth considering looking for a different tool to use in this class. (See https://symfony.com/doc/current/components/dom_crawler.html#component-dom-crawler-dumping)._