### PR TITLE
[KunstmaanAdminBundle]: access level for google should add groups

### DIFF
--- a/docs/cookbook/enabling-google-auth-login.md
+++ b/docs/cookbook/enabling-google-auth-login.md
@@ -19,8 +19,8 @@ user upon first login.
         ¦   client_id:  some_client_id.apps.googleusercontent
         ¦   client_secret: some_secret
         ¦   hosted_domains:
-        ¦   ¦   - { domain_name: kunstmaan.be, access_levels: ['ROLE_SUPER_ADMIN'] }
-                - { domain_name: mydomain.example, access_levels: ['ROLE_USER'] }
+        ¦   ¦   - { domain_name: kunstmaan.be, access_levels: ['Super administrators'] }
+                - { domain_name: mydomain.example, access_levels: ['Guests'] }
 ```
 
 ## 2) Configure the guard component in your app/config/security.yml

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
@@ -3,11 +3,12 @@
 namespace Kunstmaan\AdminBundle\Helper\Security\OAuth;
 
 use Doctrine\ORM\EntityManagerInterface;
+use FOS\UserBundle\Model\GroupInterface;
 use Kunstmaan\AdminBundle\Entity\User;
 
 class OAuthUserCreator implements OAuthUserCreatorInterface
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     private $em;
 
     /** @var array */
@@ -21,9 +22,10 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
 
     /**
      * OAuthUserCreator constructor.
+     *
      * @param EntityManagerInterface   $em
-     * @param                          $hostedDomains
-     * @param                          $userClass
+     * @param array                    $hostedDomains
+     * @param string                   $userClass
      * @param OAuthUserFinderInterface $userFinder
      */
     public function __construct(EntityManagerInterface $em, $hostedDomains, $userClass, OAuthUserFinderInterface $userFinder)
@@ -56,7 +58,11 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
             }
 
             foreach ($this->getAccessLevels($email) as $accessLevel) {
-                $user->addRole($accessLevel);
+                /** @var GroupInterface $group */
+                $group = $this->em->getRepository('KunstmaanAdminBundle:Group')->findOneBy(['name' => $accessLevel]);
+                if (null !== $group) {
+                    $user->addGroup($group);
+                }
             }
             $user->setGoogleId($googleId);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When logging in with Google, the user will receive the ROLES given in access_roles in your configuration. This should not add roles, but should add the kuma groups instead.
