### PR TITLE
[AdminListBundle] Start and end form using tab pane form view, if it exists

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig
@@ -15,7 +15,12 @@
         </div>
     {% endif %}
 
-    {{ form_start(form, {'method': 'POST', 'action': path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')), 'attr': {'novalidate': 'novalidate'}}) }}
+    {% set formParams = {'method': 'POST', 'action': path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')), 'attr': {'novalidate': 'novalidate'}} %}
+    {% if tabPane is defined %}
+        {{ form_start(tabPane.formView, formParams) }}
+    {% else %}
+        {{ form_start(form, formParams) }}
+    {% endif %}
     {{ parent() }}
 {% endblock %}
 
@@ -73,5 +78,9 @@
                 {% endif %}
             {% endblock %}
         </fieldset>
-    </form>
+    {% if tabPane is defined %}
+        {{ form_end(tabPane.formView) }}
+    {% else %}
+        {{ form_end(form) }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1716 

This PR checks to see whether an admin list's add/edit for has tabs, and, if it does, uses the form view from the tab pane instead of the entity's default form type.

This is necessary because if a field in your form class uses Symfony's `FileType` class, `form_start()` automatically gives your `<form>` tag the `enctype="multipart/form-data"` attribute.

However, this currently only works if your Admin List's entity's main form class is the one that has the `FileType` class. If you are trying to use this field type in a tab's form type, and not in the main one, your form will not have the `enctype` attribute. This PR fixes this issue.