### PR TITLE
[AdminListBundle] avoid translations freakout when the key is true or false without escaping

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.de.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
@@ -14,8 +14,8 @@ kuma_admin_list:
 
 # Filters
 filter:
-    true: true
-    false: false
+  "true": "true"
+  "false": "false"
     before: before
     after: after
     in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.es.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.fr.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.hu.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.it.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.nl.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Verplaats omhoog
     move_down: Verplaats omlaag
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: voor
   after: na
   in: bevat

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.pl.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Przesuń w górę
     move_down: Przesuń w dół
 filter:
-  "true": true
-  "false": false
+  "true": "true"
+  "false": "false"
   before: przed
   after: za
   in: zawiera


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1899

Translations would freak out and display 1 or '' in english locale without adding these quotes.
