### PR TITLE
[Composer][GeneratorBundle] Fixes for testing StandardEdition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
 
-        "friendsofsymfony/user-bundle": "~2.0",
+        "friendsofsymfony/user-bundle": "2.0.*",
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",
@@ -89,6 +89,9 @@
         "kunstmaan/voting-bundle": "self.version",
         "kunstmaan/languagechooser-bundle": "self.version",
         "kunstmaan/tagging-bundle": "self.version"
+    },
+    "conflict": {
+        "friendsofsymfony/user-bundle": "<2.0.0, >=2.1.0"
     },
     "autoload": {
         "psr-4": {"Kunstmaan\\": "src/Kunstmaan/"}

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5.0",
         "symfony/symfony": "~2.8",
         "doctrine/orm": "~2.2,>=2.2.3",
-        "friendsofsymfony/user-bundle": "2.0.*@dev",
+        "friendsofsymfony/user-bundle": "2.0.*",
         "knplabs/knp-menu-bundle": "~2.0",
         "sensio/framework-extra-bundle": "*",
         "kunstmaan/utilities-bundle": "~3.2",

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/admintests/Features/Context/FeatureContext.php
@@ -137,7 +137,7 @@ class FeatureContext extends AbstractContext
         $this->fillField('fos_user_change_password_form_plainPassword_first', $newPassword);
         $this->fillField('fos_user_change_password_form_plainPassword_second', $newPassword);
         $this->iScrollToBottom();
-        $this->pressButton('_submit');
+        $this->pressButton('Change password');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

During the fixing of the standard edition I noticed that we needed to limit FOS user to 2.0.* because of BC break.
