### PR TITLE
[NodeSearchBundle]: elasticsearch util should check the running version of elasticsearch

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
@@ -2,16 +2,52 @@
 
 namespace Kunstmaan\NodeSearchBundle\Helper;
 
+use Elasticsearch\ClientBuilder;
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+
 /**
  * Class ElasticSearchUtil
  */
 final class ElasticSearchUtil
 {
+    /** @var array */
+    private static $esClientInfo;
+
     /**
      * @return bool
      */
     public static function useVersion6()
     {
-        return (PHP_MAJOR_VERSION == 7 && !class_exists('\Elastica\Tool\CrossIndex'));
+        if (PHP_MAJOR_VERSION < 7 || !class_exists('\Elastica\Tool\CrossIndex')) {
+            return false;
+        }
+
+        $info = self::getESVersionInfo();
+
+        if (null !== $info) {
+            $versionParts = explode('.', $info['version']['number']);
+            $majorVersion = $versionParts[0];
+
+            return ($majorVersion > 2);
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    private static function getESVersionInfo()
+    {
+        try {
+            if (null === self::$esClientInfo) {
+                $client = ClientBuilder::create()->build();
+                self::$esClientInfo = $client->info();
+            }
+        } catch (NoNodesAvailableException $e) {
+            self::$esClientInfo = null;
+        }
+
+        return self::$esClientInfo;
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When running elasticsearch 2.4 on a PHP 7 environment, the current check will still return that it has to use version 6. This extra check will create a connection to elasticsearch and will get the version.
