### PR TITLE
[TranslatorBundle]: change toolbar data collector to show message instead of key

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Toolbar/toolbar_item.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Toolbar/toolbar_item.html.twig
@@ -6,5 +6,5 @@
     {% if link is defined and link %}
         </a>
     {% endif %}
-    <div class="sf-toolbar-info">{{ text|default('') }}</div>
+    <div class="sf-toolbar-info"{% if overflow is defined and overflow %} style="overflow: auto;"{% endif %}>{{ text|default('') }}</div>
 </div>

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Toolbar/translations.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Toolbar/translations.html.twig
@@ -13,13 +13,15 @@
         {% set text %}
             {% for translation in data.translations %}
                 <div class="sf-toolbar-info-piece">
-                    <a href="{{ translation.route }}" style="text-decoration: none !important;">
-                        <b> {{ translation.id }}</b>
-                    </a>
+                    <b>
+                        <a href="{{ translation.route }}" style="text-decoration: none !important;">
+                            {{ translation.message }}
+                        </a>
+                    </b>
                 </div>
             {% endfor %}
         {% endset %}
 
-        {% include '@KunstmaanAdmin/Toolbar/toolbar_item.html.twig' with {'link': data.route} %}
+        {% include '@KunstmaanAdmin/Toolbar/toolbar_item.html.twig' with {'link': data.route, 'overflow': true} %}
     {% endif %}
 {% endblock %}

--- a/src/Kunstmaan/TranslatorBundle/Toolbar/TranslatorDataCollector.php
+++ b/src/Kunstmaan/TranslatorBundle/Toolbar/TranslatorDataCollector.php
@@ -60,10 +60,11 @@ class TranslatorDataCollector extends AbstractDataCollector
         $translations = [];
 
         foreach ($this->translator->getCollectedMessages() as $message) {
-            if ($message['state'] !== DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK) {
+            if ($message['state'] !== DataCollectorTranslator::MESSAGE_EQUALS_FALLBACK && !empty($message['id'])) {
                 $options['filter_value_1'] = $message['id'];
-                $translations[] = [
+                $translations[$message['id']] = [
                     'id' => $message['id'],
+                    'message' => $message['translation'],
                     'route' => $this->urlGenerator->generate('KunstmaanTranslatorBundle_settings_translations', $options)
                 ];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Translation data collector should show the translation instead of the key, key is meaningless for clients.
