### PR TITLE
[AdminBundle] Messages are already translated by symfony

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -280,11 +280,7 @@
 {% spaceless %}
     {% if errors|length > 0 %}
         {% for error in errors %}
-            <span class="help-block text-danger">{{
-                error.messagePluralization is null
-                ? error.messageTemplate|trans(error.messageParameters)
-                : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters)
-                }}</span>
+            <span class="help-block text-danger">{{ error.message }}</span>
         {% endfor %}
     {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1902, #1903 

Removing the translation domain in #1730 broke the translate of the error message. But symfony already translates this message so we just can print it.