### PR TITLE
[AdminBundle] Messages are already translated by symfony

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -280,11 +280,7 @@
 {% spaceless %}
     {% if errors|length > 0 %}
         {% for error in errors %}
-            <span class="help-block text-danger">{{
-                error.messagePluralization is null
-                ? error.messageTemplate|trans(error.messageParameters)
-                : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters)
-                }}</span>
+            <span class="help-block text-danger">{{ error.message }}</span>
         {% endfor %}
     {% endif %}
 {% endspaceless %}

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.en.yml
@@ -14,8 +14,8 @@ kuma_admin_list:
 
 # Filters
 filter:
-  "true": "true"
-  "false": "false"
+    "true": "true"
+    "false": "false"
     before: before
     after: after
     in: contains


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1902, #1903 

Removing the translation domain in #1730 broke the translate of the error message. But symfony already translates this message so we just can print it.

Second commit is a bugfix for the standard edition build