### PR TITLE
[NodeBundle] Deprecate container usage in the slug router

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -36,6 +36,7 @@ NodeBundle
  * `CronUpdateNodeCommand` and `InitAclCommand` have been marked as final.
  * `Possibility to change the icon of your page.`: The possibility already exists to change the icon in the sidebar tree of your page. This was already available by yml configuration. I've added a new interface, TreeIconInterface that can be implemented and that will return the icon that should be used.
  * The unused `WidgetsController::selectNodesLazySearch` action is deprecated and will be removed in 6.0. 
+ * Injecting the container in the `SlugRouter` is deprecated and will be removed in 6.0. Inject the required services instead.
 
 TranslatorBundle
 ----------------

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -96,7 +96,11 @@ services:
 
     kunstmaan_node.slugrouter:
         class: '%kunstmaan_node.slugrouter.class%'
-        arguments: ['@service_container']
+        arguments:
+            - '@kunstmaan_admin.domain_configuration'
+            - '@request_stack'
+            - '@doctrine.orm.entity_manager'
+            - '%kunstmaan_admin.admin_prefix%'
         tags:
             - { name: router, priority: 0 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Deprecate the usage of the service container and inject the required services instead.
