### PR TITLE
Utf8 redirect fix

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -123,15 +123,14 @@ class RedirectRouter implements RouterInterface
             // Only add the route when the domain matches or the domain is empty
             if ($redirect->getDomain() == $domain || !$redirect->getDomain()) {
                 $needsUtf8 = (preg_match('/[\x80-\xFF]/', $redirect->getTarget()));
-                $this->routeCollection->add(
-                    new Route(
-                        $redirect->getOrigin(), array(
-                        '_controller' => 'FrameworkBundle:Redirect:urlRedirect',
-                        'path'        => $redirect->getTarget(),
-                        'permanent'   => $redirect->isPermanent(),
-                    ), array(), array('utf8' => $needsUtf8)
 
-                    )
+                $this->routeCollection->add(
+                    '_redirect_route_' . $redirect->getId(),
+                    new Route($redirect->getOrigin(), array(
+                        '_controller' => 'FrameworkBundle:Redirect:urlRedirect',
+                        'path' => $redirect->getTarget(),
+                        'permanent' => $redirect->isPermanent(),
+                    ), array(), array('utf8' => $needsUtf8))
                 );
             }
         }

--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -122,13 +122,16 @@ class RedirectRouter implements RouterInterface
 
             // Only add the route when the domain matches or the domain is empty
             if ($redirect->getDomain() == $domain || !$redirect->getDomain()) {
+                $needsUtf8 = (preg_match('/[\x80-\xFF]/', $redirect->getTarget()));
                 $this->routeCollection->add(
-                    '_redirect_route_' . $redirect->getId(),
-                    new Route($redirect->getOrigin(), array(
+                    new Route(
+                        $redirect->getOrigin(), array(
                         '_controller' => 'FrameworkBundle:Redirect:urlRedirect',
-                        'path' => $redirect->getTarget(),
-                        'permanent' => $redirect->isPermanent(),
-                    ))
+                        'path'        => $redirect->getTarget(),
+                        'permanent'   => $redirect->isPermanent(),
+                    ), array(), array('utf8' => $needsUtf8)
+
+                    )
                 );
             }
         }


### PR DESCRIPTION
This PR replaces PR  #1761 - it is just a cherrypic + minor fix of the original commit on top of branch 5.0.


See http://symfony.com/blog/new-in-symfony-3-2-unicode-routing-support

Also, this removes a deprecation notice.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #1761 
