### PR TITLE
[ConfigBundle] Set the correct configuration entity as active

### DIFF
--- a/src/Kunstmaan/ConfigBundle/Helper/Menu/ConfigMenuAdaptor.php
+++ b/src/Kunstmaan/ConfigBundle/Helper/Menu/ConfigMenuAdaptor.php
@@ -61,7 +61,7 @@ class ConfigMenuAdaptor implements MenuAdaptorInterface
                       ->setUniqueId($entity->getInternalName())
                       ->setParent($parent);
 
-                    if (stripos($request->attributes->get('_route'), $menuItem->getRoute()) === 0) {
+					if ($request->attributes->get('_route') === $menuItem->getRoute() && $request->attributes->get('internalName') === $entity->getInternalName()) {
                         $menuItem->setActive(true);
                         $parent->setActive(true);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When using more than one configuration entity, the original code would set all of them active, which causes weird problems