### PR TITLE
[NodeBundle] Mark the router service alias as public

### DIFF
--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/FixRouterPass.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/FixRouterPass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FixRouterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        // Mark the router alias specifically as public.
+        // This compiler pass can be removed when symfony-cmf/routing-bundle is upgraded to >=2.1.0
+        $container->getAlias('router')->setPublic(true);
+    }
+}

--- a/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
+++ b/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\NodeBundle;
 
+use Kunstmaan\NodeBundle\DependencyInjection\Compiler\FixRouterPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,5 +12,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanNodeBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        // Use -1 priority to run this compiler pass after the symfony-cmf/router compiler pass
+        $container->addCompilerPass(new FixRouterPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Symfony marks the router alias default as public because of the usage in controllers but symfony-cmf/routerBundle overrides this alias and doesn't mark it as public. This is resolved in symfony-cmf/routing-bundle#404. This fix is only included in 2.1.0RC1 and they only support >= php7.1, so we can't use that fix/version yet. This is a workaround to fix this deprecation and can be removed after we upgrade the symfony-cmf router bundle version to 2.1.0+
