### PR TITLE
[TranslatorBundle] Mark the translator service aliases as public

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -52,8 +52,8 @@ class KunstmaanTranslatorExtension extends Extension
 
     public function setTranslationConfiguration($config, $container)
     {
-        $container->setAlias('translator', 'kunstmaan_translator.service.translator.translator');
-        $container->setAlias('translator.default', 'kunstmaan_translator.service.translator.translator');
+        $container->setAlias('translator', 'kunstmaan_translator.service.translator.translator')->setPublic(true);
+        $container->setAlias('translator.default', 'kunstmaan_translator.service.translator.translator')->setPublic(true);
         $translator = $container->getDefinition('kunstmaan_translator.service.translator.translator');
         $this->registerTranslatorConfiguration($config, $container);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Symfony marks the translator aliases default as public because of usage in controllers. We override these aliases with our custom translator so we should also mark them as public