### PR TITLE
[AdminBundle][AdminListBundle]Fixed yaml translation file deprecations

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.nl.yml
@@ -40,6 +40,9 @@ toolbar:
     toupdate: Verouderd
     version: Bundle versie
     status: Bundle status
+  exception:
+    title: Exceptions
+    message: "<strong>%X%</strong> exception triggered by <strong>%Y%</strong> events"
 
 tools:
   title: Hulpmiddelen
@@ -130,7 +133,3 @@ kuma_admin:
 kuma_js:
   auto_collapse:
     more_button_label: Meer
-toolbar:
-  exception:
-    title: Exceptions
-    message: "<strong>%X%</strong> exception triggered by <strong>%Y%</strong> events"

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.de.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.es.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.fr.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.hu.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.it.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Move up
     move_down: Move down
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: before
   after: after
   in: contains

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.nl.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Verplaats omhoog
     move_down: Verplaats omlaag
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: voor
   after: na
   in: bevat

--- a/src/Kunstmaan/AdminListBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/translations/messages.pl.yml
@@ -13,8 +13,8 @@ kuma_admin_list:
     move_up: Przesuń w górę
     move_down: Przesuń w dół
 filter:
-  true: "true"
-  false: "false"
+  "true": "true"
+  "false": "false"
   before: przed
   after: za
   in: zawiera


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Removed a duplicate translation key and fixed unquoted non-string key. When merging crowdin translation pr's we should check that we don't add duplicate yaml keys and unquoted non-string keys as this won't work on sf4.0+

Fixed deprecations:

> Duplicate key "toolbar" detected whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since Symfony 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0

> Implicit casting of non-string key to string is deprecated since Symfony 3.3 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0. Quote your evaluable mapping keys instead