### PR TITLE
[AllBundles] Mark services used in controller as public

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -88,6 +88,7 @@ services:
     kunstmaan_admin.acl.helper:
         class: '%kunstmaan_admin.acl.helper.class%'
         arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@security.role_hierarchy']
+        public: true
 
     kunstmaan_admin.acl.native.helper:
         class: '%kunstmaan_admin.acl.native.helper.class%'
@@ -160,6 +161,7 @@ services:
     kunstmaan_admin.versionchecker:
         class: Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker
         arguments: ['@service_container', '@kunstmaan_admin.cache']
+        public: true
 
     kunstmaan_admin.cache:
         class: Doctrine\Common\Cache\FilesystemCache
@@ -214,6 +216,7 @@ services:
     kunstmaan_admin.domain_configuration:
         class: '%kunstmaan_admin.domain_configuration.class%'
         arguments: ['@service_container']
+        public: true
 
     kunstmaan_admin.oauth_authenticator:
         class: Kunstmaan\AdminBundle\Security\OAuthAuthenticator

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -4,6 +4,7 @@ parameters:
 services:
     kunstmaan_adminlist.factory:
         class: Kunstmaan\AdminListBundle\AdminList\AdminListFactory
+        public: true
 
     kunstmaan_adminlist.service.export:
         class:  '%kunstmaan_adminlist.service.export.class%'

--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ parameters:
 services:
     kunstmaan_dashboard.manager.widgets:
         class: Kunstmaan\DashboardBundle\Manager\WidgetManager
+        public: true
 
     kunstmaan_dashboard.widget.googleanalytics:
         class: Kunstmaan\DashboardBundle\Widget\DashboardWidget
@@ -40,6 +41,7 @@ services:
     kunstmaan_dashboard.helper.google.analytics.config:
         class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper'
         arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@doctrine.orm.entity_manager']
+        public: true
 
     # query helper
     kunstmaan_dashboard.helper.google.analytics.query:

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -17,6 +17,7 @@ services:
         class: '%kunstmaan_media.media_manager.class%'
         calls:
             - [ setDefaultHandler, [ '@kunstmaan_media.media_handlers.file' ] ]
+        public: true
 
     kunstmaan_media.listener.doctrine:
         class: '%kunstmaan_media.listener.doctrine.class%'
@@ -71,6 +72,7 @@ services:
     kunstmaan_media.folder_manager:
         class: '%kunstmaan_media.folder_manager.class%'
         arguments: ['@kunstmaan_media.repository.folder']
+        public: true
 
     kunstmaan_media.mimetype_guesser.factory:
         class: '%kunstmaan_media.mimetype_guesser.factory.class%'

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -58,6 +58,7 @@ services:
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
         arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration' ]
+        public: true
 
     kunstmaan_node.menu.sub_actions:
         class: Knp\Menu\MenuItem # the service definition requires setting the class
@@ -158,6 +159,7 @@ services:
     kunstmaan_node.node_menu:
         class: Kunstmaan\NodeBundle\Helper\NodeMenu
         arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@kunstmaan_admin.acl.helper', '@kunstmaan_admin.domain_configuration']
+        public: true
 
     kunstmaan_node.node.twig.extension:
         class: Kunstmaan\NodeBundle\Twig\NodeTwigExtension

--- a/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/PagePartBundle/Resources/config/services.yml
@@ -14,6 +14,7 @@ services:
     kunstmaan_page_part.page_part_configuration_reader:
         class: '%kunstmaan_pagepart.page_part_configuration_reader.class%'
         arguments: [ '@kunstmaan_page_part.page_part_configuration_parser' ]
+        public: true
 
     kunstmaan_page_part.page_part_configuration_parser:
         class: '%kunstmaan_pagepart.page_part_configuration_parser.class%'

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -22,6 +22,7 @@ services:
         calls:
             - [setTranslationFileExplorer, ['@kunstmaan_translator.service.file_explorer']]
             - [setImporter, ['@kunstmaan_translator.service.importer.importer']]
+        public: true
 
     kunstmaan_translator.service.exporter.command_handler:
         parent: kunstmaan_translator.service.abstract_command_handler
@@ -29,6 +30,7 @@ services:
         calls:
             - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
             - [setExporter, ['@kunstmaan_translator.service.exporter.exporter']]
+        public: true
 
     kunstmaan_translator.service.exporter.exporter:
         class: 'Kunstmaan\TranslatorBundle\Service\Command\Exporter\Exporter'
@@ -71,6 +73,7 @@ services:
             - [setDebug, ['%kuma_translator.debug%']]
             - [setCacheDir, ['%kuma_translator.cache_dir%']]
             - [setLogger, ['@logger']]
+        public: true
 
     kunstmaan_translator.service.translator.cache_validator:
         class: Kunstmaan\TranslatorBundle\Service\Translator\CacheValidator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

These changes will allow us to support sf4 quicker and afterwards we can do refactor iterations to cleanup certain controllers. This pr marks a first batch of services as public but I will create more pr's as I discover more deprecations. This covers  a lot of the private service deprecations from a clean install with demo site.
