### PR TITLE
[GeneratorBundle] Fix unquoted parameter in routing generator

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_partial.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Resources/config/routing_partial.yml
@@ -4,4 +4,4 @@
     type:     annotation
     prefix:   /{_locale}/admin/{{ entity_class|lower }}{{ type|lower }}/
     requirements:
-         _locale: %requiredlocales%
+         _locale: "%requiredlocales%"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When generating a new site this creates a deprecation out-of-the-box. 
