### PR TITLE
[UtilitiesBundle] Fix UtilitiesExtensionTest after upmerge from 5.0

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Tests/DependencyInjection/KunstmaanUtilitiesExtensionTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/DependencyInjection/KunstmaanUtilitiesExtensionTest.php
@@ -23,6 +23,7 @@ class KunstmaanUtilitiesExtensionTest extends AbstractPrependableExtensionTestCa
     public function testCorrectParametersHaveBeenSet()
     {
         $this->container->setParameter('empty_extension', true);
+        $this->container->setParameter('secret', 'super_secret_value');
         $this->load();
 
         $this->assertContainerBuilderHasParameter('empty_extension', true );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

UtilitiesExtensionTest was broken after the merge of pr #1939 in 5.0 and the upmerge of 5.0 in master. Master contains a lot more tests, so this was broken.
