### PR TITLE
[AdminListBundle] Allow sorting by association

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
@@ -166,7 +166,7 @@ abstract class AbstractDoctrineORMAdminListConfigurator extends AbstractAdminLis
                 $orderBy = $this->orderBy;
                 if ($this->getEntityManager()->getClassMetadata($this->getRepositoryName())->hasAssociation($this->orderBy)) {
                     $queryBuilder->leftJoin('b.' . $orderBy, 'A' . $orderBy);
-                    $orderBy = 'A' . $orderBy . ".id";
+                    $orderBy = 'A' . $orderBy . '.id';
                 } elseif (!strpos($orderBy, '.')) {
                     $orderBy = 'b.' . $orderBy;
                 }

--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
@@ -164,7 +164,10 @@ abstract class AbstractDoctrineORMAdminListConfigurator extends AbstractAdminLis
             // Apply sorting
             if (!empty($this->orderBy)) {
                 $orderBy = $this->orderBy;
-                if (!strpos($orderBy, '.')) {
+                if ($this->getEntityManager()->getClassMetadata($this->getRepositoryName())->hasAssociation($this->orderBy)) {
+                    $queryBuilder->leftJoin('b.' . $orderBy, 'A' . $orderBy);
+                    $orderBy = 'A' . $orderBy . ".id";
+                } elseif (!strpos($orderBy, '.')) {
                     $orderBy = 'b.' . $orderBy;
                 }
                 $queryBuilder->orderBy($orderBy, ($this->orderDirection == 'DESC' ? 'DESC' : 'ASC'));

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Configurator/AbstractDoctrineORMAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Configurator/AbstractDoctrineORMAdminListConfiguratorTest.php
@@ -3,6 +3,8 @@
 namespace Kunstmaan\AdminListBundle\Tests\AdminList\Configurator;
 
 use ArrayIterator;
+use Codeception\Stub;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\ORM\AbstractQuery;
@@ -110,6 +112,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
         $fakeConfig->expects($this->any())->method('getDefaultQueryHints')->willReturn($fakeConfig);
         $fakeConfig->expects($this->any())->method('isSecondLevelCacheEnabled')->willReturn($fakeConfig);
         $fakeConfig->expects($this->any())->method('getSecondLevelCacheConfiguration')->willReturn($cacheConfig);
+        $fakeClassMetaData = Stub::makeEmpty(ClassMetadata::class, ['hasAssociation' => false]);
         $qb = $this->createMock(QueryBuilder::class);
         $qb->expects($this->any())->method('setParameters')->willReturn($qb);
         $qb->expects($this->any())->method('setMaxResults')->willReturn($qb);
@@ -117,6 +120,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
         $em->expects($this->any())->method('getRepository')->willReturn($em);
         $em->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
         $em->expects($this->any())->method('getConfiguration')->willReturn($fakeConfig);
+        $em->expects($this->any())->method('getClassMetadata')->willReturn($fakeClassMetaData);
         $query = new Query($em);
         $qb->expects($this->any())->method('getQuery')->willReturn($query);
         $query = $config->getQuery();
@@ -172,6 +176,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
         $platform = $this->createMock(MySQL57Platform::class);
         $platform->expects($this->any())->method('getSQLResultCasing')->willReturn('string');
 
+        $fakeClassMetaData = Stub::makeEmpty(ClassMetadata::class, ['hasAssociation' => false]);
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->any())->method('getDatabasePlatform')->willReturn($platform);
 
@@ -183,6 +188,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
         $em->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
         $em->expects($this->any())->method('getConfiguration')->willReturn($fakeConfig);
         $em->expects($this->any())->method('getConnection')->willReturn($connection);
+        $em->expects($this->any())->method('getClassMetadata')->willReturn($fakeClassMetaData);
         $qb->expects($this->any())->method('getQuery')->willReturn(new Query($em));
 
         $pager = $config->getPagerfanta();
@@ -224,6 +230,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
 
     /**
      * @throws \ReflectionException
+     * @throws \Exception
      */
     public function testGetQueryWithAclEnabled()
     {
@@ -237,12 +244,14 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends PHPUnit_Framework_Tes
         $fakeConfig->expects($this->any())->method('isSecondLevelCacheEnabled')->willReturn($fakeConfig);
         $fakeConfig->expects($this->any())->method('getSecondLevelCacheConfiguration')->willReturn($cacheConfig);
         $qb = $this->createMock(QueryBuilder::class);
+        $fakeClassMetaData = Stub::makeEmpty(ClassMetadata::class, ['hasAssociation' => false]);
         $qb->expects($this->any())->method('setParameters')->willReturn($qb);
         $qb->expects($this->any())->method('setMaxResults')->willReturn($qb);
         $em->expects($this->any())->method('createQuery')->willReturn($qb);
         $em->expects($this->any())->method('getRepository')->willReturn($em);
         $em->expects($this->any())->method('createQueryBuilder')->willReturn($qb);
         $em->expects($this->any())->method('getConfiguration')->willReturn($fakeConfig);
+        $em->expects($this->any())->method('getClassMetadata')->willReturn($fakeClassMetaData);
 
         $query = new Query($em);
         $aclHelper = $this->createMock(AclHelper::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This change makes it possible to sort an admin list by a 1:many association, which is quite useful.
