### PR TITLE
[NodeBundle] Select correct root node for the urlchooser in a multidomain setup

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -104,7 +104,14 @@ class WidgetsController extends Controller
         $depth = $this->getParameter('kunstmaan_node.url_chooser.lazy_increment');
 
         if (!$id || $id == '#') {
-            $rootItems = $em->getRepository('KunstmaanNodeBundle:Node')->getAllTopNodes();
+            $domainConfig = $this->get('kunstmaan_admin.domain_configuration');
+
+            if ($domainConfig->isMultiDomainHost()) {
+                $switchedHost = $domainConfig->getHostSwitched();
+                $rootItems = [$domainConfig->getRootNode($switchedHost['host'])];
+            } else {
+                $rootItems = $em->getRepository('KunstmaanNodeBundle:Node')->getAllTopNodes();
+            }
         } else {
             $rootItems = $em->getRepository('KunstmaanNodeBundle:Node')->find($id)->getChildren();
         }
@@ -176,8 +183,8 @@ class WidgetsController extends Controller
         /** @var DomainConfiguration $domainconfig */
         $domainconfig = $this->get('kunstmaan_admin.domain_configuration');
         $isMultiDomain = $domainconfig->isMultiDomainHost();
-        $switchedHost = $domainconfig->getHostSwitched()['host'];
-        $switched = $domainconfig->getHost() == $switchedHost;
+        $switchedHost = $domainconfig->getHostSwitched();
+        $switched = $domainconfig->getHost() == $switchedHost['host'];
 
         $results = [];
 
@@ -185,7 +192,7 @@ class WidgetsController extends Controller
         foreach ($rootNodes as $rootNode) {
             if ($nodeTranslation = $rootNode->getNodeTranslation($locale, true)) {
                 if ($isMultiDomain && !$switched) {
-                    $slug = sprintf("[%s:%s]", $switchedHost, "NT" . $nodeTranslation->getId());
+                    $slug = sprintf("[%s:%s]", $switchedHost['id'], "NT" . $nodeTranslation->getId());
                 } else {
                     $slug = sprintf("[%s]", "NT" . $nodeTranslation->getId());
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Currently the whole node/pages (all nodes for all domains) tree is shown when picking an url in a multidomain setup instead of only showing the nodes/pages related to the selected domain. The incorrect tree also causes incorrect urls to be selected. The generated url slug was also incorrect as it used the host instead of the config id.
