### PR TITLE
[GeneratorBundle] Replace deprecated twig raw tag in scss file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "symfony-cmf/routing-bundle": "~2.0",
         "fpn/doctrine-extensions-taggable": "~0.9",
         "sensio/generator-bundle": "~3.0",
+        "twig/twig": "^1.12|^2.0",
         "twig/extensions": "~1.0",
         "egulias/email-validator": "~1.2",
         "box/spout": "^2.5",

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/ui/scss/config/general/_colors.scss
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/Resources/ui/scss/config/general/_colors.scss
@@ -63,7 +63,7 @@ $link-color--hover:     darken($link-color, 15%);
  */
 
 {% if demosite %}
-{% raw %}
+{% verbatim %}
 /**
  * @section Greyscale
  * @sectionof Colors
@@ -85,9 +85,9 @@ $link-color--hover:     darken($link-color, 15%);
 * @color {#053046} Brand primary dark - [Colors.Brand colors]
 * @color {#FF4600} Brand danger - [Colors.Brand colors]
 */
-{% endraw %}
+{% endverbatim %}
 {% else %}
-{% raw %}
+{% verbatim %}
 /**
  * @section Greyscale
  * @sectionof Colors
@@ -104,6 +104,6 @@ $link-color--hover:     darken($link-color, 15%);
 * @color {#053046} Brand primary dark - [Colors.Brand colors]
 * @color {#FF4600} Brand danger - [Colors.Brand colors]
 */
-{% endraw %}
+{% endverbatim %}
 {% endif %}
 

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -19,7 +19,8 @@
         "doctrine/orm": "^2.2.3",
         "sensio/generator-bundle": "~2.5|~3.0",
         "fzaninotto/faker": "~1.4.0",
-        "kunstmaan/utilities-bundle": "~3.2"
+        "kunstmaan/utilities-bundle": "~3.2",
+        "twig/twig": "^1.12|^2.0",
     },
     "suggest": {
         "kunstmaan/admin-bundle": "~3.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #1926 

Replace the deprecated `raw` tag by `verbatim` to support twig 2