### PR TITLE
[UserManagementBundle][SeoBundle] Deprecate direct container access i…

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -55,6 +55,11 @@ SearchBundle
  * `SetupIndexCommand::__construct()`, `PopulateIndexCommand::__construct()` and `DeleteIndexCommand::__construct()` now takes an instance of `Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
  * `SetupIndexCommand`, `PopulateIndexCommand` and `DeleteIndexCommand` have been marked as final.
  
+SeoBundle
+---------
+
+ * Getting services directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary dependencies.
+ * Getting parameters directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary parameters.
 
 TranslatorBundle
 ----------------
@@ -64,6 +69,12 @@ TranslatorBundle
  * `TranslationCacheCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
  * `TranslationFlagCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Repository\TranslationRepository` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
  * `ExportTranslationsCommand`, `ImportTranslationsCommand`, `MigrationsDiffCommand`, `TranslationCacheCommand` and `TranslationFlagCommand` have been marked as final.
+
+UserManagementBundle
+--------------------
+
+ * Getting services directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary dependencies.
+ * Getting parameters directly from the container in list controllers is deprecated and will be removed in 6.0. Register your controllers as services and inject the necessary parameters.
 
 UtilitiesBundle
 ---------------

--- a/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
@@ -6,5 +6,27 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class BaseSettingsController extends Controller
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get($id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
 
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter($name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
 }

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -30,7 +30,7 @@ class SettingsController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
         $repo = $this->getDoctrine()->getRepository("KunstmaanSeoBundle:Robots");
         $robot = $repo->findOneBy(array());
-        $default = $this->getParameter('robots_default');
+        $default = $this->container->getParameter('robots_default');
         $isSaved = true;
 
         if (!$robot) {
@@ -59,7 +59,7 @@ class SettingsController extends BaseSettingsController
         if (!$isSaved) {
             $this->addFlash(
                 FlashTypes::WARNING,
-                $this->get('translator')->trans('seo.robots.warning')
+                $this->container->get('translator')->trans('seo.robots.warning')
             );
         }
 

--- a/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
@@ -40,7 +40,7 @@ class GroupsController extends BaseSettingsController
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
         /* @var AdminList $adminlist */
-        $adminlist = $this->get("kunstmaan_adminlist.factory")->createList(new GroupAdminListConfigurator($em));
+        $adminlist = $this->container->get("kunstmaan_adminlist.factory")->createList(new GroupAdminListConfigurator($em));
         $adminlist->bindRequest($request);
 
         return array(
@@ -75,7 +75,7 @@ class GroupsController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.group.add.flash.success', array(
+                    $this->container->get('translator')->trans('kuma_user.group.add.flash.success', array(
                         '%groupname%' => $group->getName()
                     ))
                 );
@@ -119,7 +119,7 @@ class GroupsController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.group.edit.flash.success', array(
+                    $this->container->get('translator')->trans('kuma_user.group.edit.flash.success', array(
                         '%groupname%' => $group->getName()
                     ))
                 );
@@ -159,7 +159,7 @@ class GroupsController extends BaseSettingsController
 
             $this->addFlash(
                 FlashTypes::SUCCESS,
-                $this->get('translator')->trans('kuma_user.group.delete.flash.success', array(
+                $this->container->get('translator')->trans('kuma_user.group.delete.flash.success', array(
                     '%groupname%' => $group->getName()
                 ))
             );

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -37,7 +37,7 @@ class RolesController extends BaseSettingsController
 
         $em        = $this->getDoctrine()->getManager();
         /* @var AdminList $adminlist */
-        $adminlist = $this->get("kunstmaan_adminlist.factory")->createList(new RoleAdminListConfigurator($em));
+        $adminlist = $this->container->get("kunstmaan_adminlist.factory")->createList(new RoleAdminListConfigurator($em));
         $adminlist->bindRequest($request);
 
         return array(
@@ -72,7 +72,7 @@ class RolesController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.roles.add.flash.success.%role%', [
+                    $this->container->get('translator')->trans('kuma_user.roles.add.flash.success.%role%', [
                         '%role%' => $role->getRole()
                     ])
                 );
@@ -116,7 +116,7 @@ class RolesController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.roles.edit.flash.success.%role%', [
+                    $this->container->get('translator')->trans('kuma_user.roles.edit.flash.success.%role%', [
                         '%role%' => $role->getRole()
                     ])
                 );
@@ -156,7 +156,7 @@ class RolesController extends BaseSettingsController
 
             $this->addFlash(
                 FlashTypes::SUCCESS,
-                $this->get('translator')->trans('kuma_user.roles.delete.flash.success.%role%', [
+                $this->container->get('translator')->trans('kuma_user.roles.delete.flash.success.%role%', [
                     '%role%' => $role->getRole()
                 ])
             );

--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -43,7 +43,7 @@ class UsersController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
         $configuratorClassName = '';
         if ($this->container->hasParameter('kunstmaan_user_management.user_admin_list_configurator.class')) {
-            $configuratorClassName = $this->getParameter(
+            $configuratorClassName = $this->container->getParameter(
                 'kunstmaan_user_management.user_admin_list_configurator.class'
             );
         }
@@ -51,7 +51,7 @@ class UsersController extends BaseSettingsController
         $configurator = new $configuratorClassName($em);
 
         /* @var AdminList $adminList */
-        $adminList = $this->get("kunstmaan_adminlist.factory")->createList($configurator);
+        $adminList = $this->container->get("kunstmaan_adminlist.factory")->createList($configurator);
         $adminList->bindRequest($request);
 
         return array(
@@ -66,7 +66,7 @@ class UsersController extends BaseSettingsController
      */
     private function getUserClassInstance()
     {
-        $userClassName = $this->getParameter('fos_user.model.user.class');
+        $userClassName = $this->container->getParameter('fos_user.model.user.class');
 
         return new $userClassName();
     }
@@ -113,7 +113,7 @@ class UsersController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.users.add.flash.success.%username%', [
+                    $this->container->get('translator')->trans('kuma_user.users.add.flash.success.%username%', [
                         '%username%' => $user->getUsername()
                     ])
                 );
@@ -142,7 +142,7 @@ class UsersController extends BaseSettingsController
     public function editAction(Request $request, $id)
     {
         // The logged in user should be able to change his own password/username/email and not for other users
-        if ($id == $this->get('security.token_storage')->getToken()->getUser()->getId()) {
+        if ($id == $this->container->get('security.token_storage')->getToken()->getUser()->getId()) {
             $requiredRole = 'ROLE_ADMIN';
         } else {
             $requiredRole = 'ROLE_SUPER_ADMIN';
@@ -153,7 +153,7 @@ class UsersController extends BaseSettingsController
         $em = $this->getDoctrine()->getManager();
 
         /** @var UserInterface $user */
-        $user = $em->getRepository($this->getParameter('fos_user.model.user.class'))->find($id);
+        $user = $em->getRepository($this->container->getParameter('fos_user.model.user.class'))->find($id);
         if ($user === null) {
             throw new NotFoundHttpException(sprintf('User with ID %s not found', $id));
         }
@@ -192,7 +192,7 @@ class UsersController extends BaseSettingsController
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
-                    $this->get('translator')->trans('kuma_user.users.edit.flash.success.%username%', [
+                    $this->container->get('translator')->trans('kuma_user.users.edit.flash.success.%username%', [
                         '%username%' => $user->getUsername()
                     ])
                 );
@@ -237,7 +237,7 @@ class UsersController extends BaseSettingsController
         /* @var $em EntityManager */
         $em = $this->getDoctrine()->getManager();
         /* @var UserInterface $user */
-        $user = $em->getRepository($this->getParameter('fos_user.model.user.class'))->find($id);
+        $user = $em->getRepository($this->container->getParameter('fos_user.model.user.class'))->find($id);
         if (!is_null($user)) {
             $userEvent = new UserEvent($user, $request);
             $this->container->get('event_dispatcher')->dispatch(UserEvents::USER_DELETE_INITIALIZE, $userEvent);
@@ -247,7 +247,7 @@ class UsersController extends BaseSettingsController
 
             $this->addFlash(
                 FlashTypes::SUCCESS,
-                $this->get('translator')->trans('kuma_user.users.delete.flash.success.%username%', [
+                $this->container->get('translator')->trans('kuma_user.users.delete.flash.success.%username%', [
                     '%username%' => $user->getUsername()
                 ])
             );
@@ -266,7 +266,7 @@ class UsersController extends BaseSettingsController
             $this->generateUrl(
                 'KunstmaanUserManagementBundle_settings_users_edit',
                 array(
-                    'id' => $this->get('security.token_storage')->getToken()->getUser()->getId(),
+                    'id' => $this->container->get('security.token_storage')->getToken()->getUser()->getId(),
                 )
             )
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

This PR prepares the code to move away from direct container access in controllers. All `$this->get()` usages are replaced by `$this->container->get()` to avoid triggering deprecations in non-user code. In 6.0 we should:
- remove the `get` and `getParameter` overrides
- extend from the symfony `AbstractController`
- override the `getSubscribedServices` method to extend the list of services to make sure we have all the "default" symfony services and the ones controllers extending the BaseSettingsController need in the service locator. Users extending from this BaseSettingsController should just register their controllers as services.
  - @acrobat  thinks that for 6.0 we should support sf4.1+ so we can use the newly introduced "parameter bag" to access the parameters-as-a-service. See [symfony/symfony#25288](https://github.com/symfony/symfony/pull/25288)

This is just for controllers extending the base. Separate PRs will handle further container access deprecations.
