### PR TITLE
[AdminBundle] Use FOS service ID instead of class

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
@@ -21,7 +21,7 @@ KunstmaanAdminBundle_settings_exception:
 # Change user password route
 KunstmaanAdminBundle_user_change_password:
     path: /%kunstmaan_admin.admin_prefix%/settings/users/{id}/edit
-    defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
+    defaults: { _controller: fos_user.change_password.controller:changePasswordAction }
     methods: [GET, POST]
 
 ###########################
@@ -50,7 +50,7 @@ fos_user_resetting:
 
 fos_user_change_password:
     path: /%kunstmaan_admin.admin_prefix%/profile/change-password
-    defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
+    defaults: { _controller: fos_user.change_password.controller:changePasswordAction }
     methods: [GET, POST]
 
 ##########################


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1975 

FOS\UserBundle\Controller\ChangePasswordController requires constructor arguments and is registered as a service by ID rather than class - the routing config needs to call that controller by service ID, rather than class name.