### PR TITLE
[TranslatorBundle] Fix container deprecations with translation loaders

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -64,6 +64,7 @@ TranslatorBundle
  * `TranslationCacheCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Service\Translator\ResourceCacher` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
  * `TranslationFlagCommand::__construct()` now takes an instance of `Kunstmaan\TranslatorBundle\Repository\TranslationRepository` as the first argument. Not passing it is deprecated and will throw a `TypeError` in 6.0.
  * `ExportTranslationsCommand`, `ImportTranslationsCommand`, `MigrationsDiffCommand`, `TranslationCacheCommand` and `TranslationFlagCommand` have been marked as final.
+ * The `usedTranslations` request parameter added by `Kunstmaan\TranslatorBundle\Service\Translator\Translator` is deprecated and will be removed in 6.0. Get the collected messages from the `Kunstmaan\TranslatorBundle\Toolbar\DataCollectorTranslator` service.
 
 UtilitiesBundle
 ---------------

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -90,6 +90,7 @@ services:
             - '%kernel.default_locale%'
             - {}
             - { cache_dir: '%kuma_translator.cache_dir%', debug: '%kuma_translator.debug%' }
+            - '%kuma_translator.profiler%'
         calls:
             - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
             - [setResourceCacher, ['@kunstmaan_translator.service.translator.resource_cacher']]

--- a/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
@@ -10,6 +10,7 @@ use Kunstmaan\TranslatorBundle\Service\TranslationGroupManager;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\Loader\LoaderInterface;
 
 class Importer
 {
@@ -167,6 +168,17 @@ class Importer
     public function setLoaders(array $loaders)
     {
         $this->loaders = $loaders;
+    }
+
+    /**
+     * Adds a loader to the translation importer.
+     *
+     * @param string          $format The format of the loader
+     * @param LoaderInterface $loader
+     */
+    public function addLoader($format, LoaderInterface $loader)
+    {
+        $this->loaders[$format] = $loader;
     }
 
     public function setTranslationGroupManager(TranslationGroupManager $translationGroupManager)

--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
@@ -4,13 +4,18 @@ namespace Kunstmaan\TranslatorBundle\Service\Translator;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
+use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator as SymfonyTranslator;
 
 /**
  * Translator
+ *
+ * NEXT_MAJOR remove the $profilerEnable constructor parameter en remove the profileTranslation method.
  */
 class Translator extends SymfonyTranslator
 {
+    /** @var bool */
+    private $profilerEnabled;
 
     private $translationRepository;
 
@@ -25,6 +30,13 @@ class Translator extends SymfonyTranslator
      */
     protected $request;
 
+    public function __construct(ContainerInterface $container, $formatter, $defaultLocale = null, array $loaderIds = array(), array $options = array(), $profilerEnable = false)
+    {
+        parent::__construct($container, $formatter, $defaultLocale, $loaderIds, $options);
+
+        $this->profilerEnabled = $profilerEnable;
+    }
+
     /**
      * Add resources from the database
      * So the translator knows where to look (first) for specific translations
@@ -36,7 +48,7 @@ class Translator extends SymfonyTranslator
             $this->addResourcesFromDatabaseAndCacheThem();
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -125,10 +137,13 @@ class Translator extends SymfonyTranslator
         return $trans;
     }
 
+    /**
+     * @deprecated This method is deprecated since KunstmaanTranslatorBundle version 5.1 and will be removed in KunstmaanTranslatorBundle version 6.0
+     */
     public function profileTranslation($id, $parameters, $domain, $locale, $trans)
     {
 
-        if (!$this->request || $this->container->getParameter('kuma_translator.profiler') === false) {
+        if (!$this->request || $this->profilerEnabled === false) {
             return;
         }
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPassTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPassTest.php
@@ -33,8 +33,14 @@ class KunstmaanTranslatorCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             $svcId,
-            'setLoaders',
-            [['someAlias' => new Reference($svcId), 'someLegacyAlias' => new Reference($svcId)]]
+            'addLoader',
+            ['someAlias', new Reference($svcId)]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            $svcId,
+            'addLoader',
+            ['someLegacyAlias', new Reference($svcId)]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I've made our override of the translator compatible with how symfony handles the translator. This will fix the private service deprecations for all the translation file extension loaders (only happens with a cache). This change is not considered a BC break as users who want to override the translator themself should not switch the class of the `kunstmaan_translator.service.translator.translator`, but create a new custom service and add an alias for the kunstmaan translator service to their service. 

The `usedTranslations` request parameter is also deprecated because this was a leftover of the switch to the `TranslatorDataCollector`. I can't trigger a deprecation easily when a user "get's" this parameter from the request, but it's clearly stated in the upgrade file that this parameter is deprecated. 
 
Also with changing the compiler pass logic to match the symfony logic I had to add an extra method to the importer class to add a loader instead of setting them through an array.