### PR TITLE
[KunstmaanNodeSearchBundle]: remove check for class

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
@@ -18,7 +18,7 @@ final class ElasticSearchUtil
      */
     public static function useVersion6()
     {
-        if (PHP_MAJOR_VERSION < 7 || !class_exists('\Elastica\Tool\CrossIndex')) {
+        if (PHP_MAJOR_VERSION < 7) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

The check for existing class is not needed anymore en also not existing in 6.0 version.
