### PR TITLE
[AllBundles] Allow fos/user-bundle 2.1

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -7,6 +7,7 @@ General
  * The `symfony/assetic-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on assetic, add the dependency to your project `composer.json`.
  * The `symfony/swiftmailer-bundle` package was removed from our dependencies as it was unused. If your code depends on `symfony/swiftmailer-bundle`, add the dependency to your project `composer.json`.
  * The `sensio/distribution-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on `sensio/distribution-bundle` for executing composer after update/install scripts, add the dependency to your project `composer.json`.
+ * The version constraint for `fos/user-bundle` is updated to `^2.0` to allow new minor releases. If your code isn't compatible with the new changes of the user-bundle, update/add a custom version constraint for the `fos/user-bundle` in your `composer.json`. Eg `"friendsofsymfony/user-bundle": "2.0.*"`
 
 AdminBundle
 -----------

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "sensio/framework-extra-bundle": "^5.0",
         "incenteev/composer-parameter-handler": "^2.0",
 
-        "friendsofsymfony/user-bundle": "2.0.*",
+        "friendsofsymfony/user-bundle": "^2.0",
         "knplabs/knp-menu-bundle": "~2.0",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",
@@ -94,7 +94,7 @@
         "kunstmaan/tagging-bundle": "self.version"
     },
     "conflict": {
-        "friendsofsymfony/user-bundle": "<2.0.0, >=2.1.0"
+        "friendsofsymfony/user-bundle": "<2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Kunstmaan/AdminBundle/Helper/AdminPanel/DefaultAdminPanelAdaptor.php
+++ b/src/Kunstmaan/AdminBundle/Helper/AdminPanel/DefaultAdminPanelAdaptor.php
@@ -47,7 +47,7 @@ class DefaultAdminPanelAdaptor implements AdminPanelAdaptorInterface
 
         return new AdminPanelAction(
             array(
-                'path' => 'KunstmaanAdminBundle_user_change_password',
+                'path' => 'KunstmaanUserManagementBundle_settings_users_edit',
                 'params' => array('id' => $user->getId())
             ),
             ucfirst($user->getUsername()),

--- a/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/routing.yml
@@ -18,27 +18,13 @@ KunstmaanAdminBundle_settings_exception:
     type:     annotation
     prefix:   /%kunstmaan_admin.admin_prefix%/settings/exception
 
-# Change user password route
-KunstmaanAdminBundle_user_change_password:
-    path: /%kunstmaan_admin.admin_prefix%/settings/users/{id}/edit
-    defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
-    methods: [GET, POST]
-
 ###########################
 ## fos_userbundle routes ##
 ###########################
 
-fos_user_security_login:
-    path: /%kunstmaan_admin.admin_prefix%/login
-    defaults: { _controller: FOSUserBundle:Security:login }
-
-fos_user_security_check:
-    path: /%kunstmaan_admin.admin_prefix%/login_check
-    defaults: { _controller: FOSUserBundle:Security:check }
-
-fos_user_security_logout:
-    path: /%kunstmaan_admin.admin_prefix%/logout
-    defaults: { _controller: FOSUserBundle:Security:logout }
+fos_user_security:
+    resource: '@FOSUserBundle/Resources/config/routing/security.xml'
+    prefix: /%kunstmaan_admin.admin_prefix%
 
 fos_user_profile:
     resource: '@FOSUserBundle/Resources/config/routing/profile.xml'
@@ -49,9 +35,8 @@ fos_user_resetting:
     prefix: /%kunstmaan_admin.admin_prefix%/resetting
 
 fos_user_change_password:
-    path: /%kunstmaan_admin.admin_prefix%/profile/change-password
-    defaults: { _controller: FOSUserBundle:ChangePassword:changePassword }
-    methods: [GET, POST]
+    resource: '@FOSUserBundle/Resources/config/routing/change_password.xml'
+    prefix: /%kunstmaan_admin.admin_prefix%/profile
 
 ##########################
 ## Google OAuth Sign In ##

--- a/src/Kunstmaan/AdminBundle/Resources/views/Resetting/check_email.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Resetting/check_email.html.twig
@@ -1,8 +1,10 @@
 {% extends "@FOSUser/layout.html.twig" %}
 
+{% trans_default_domain 'FOSUserBundle' %}
+
 {% block fos_user_content %}
     <div class="alert alert-success">
-        {{ 'We have sent you an email with a link to reset your password.' | trans }}
+        {{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
         <a class="btn alert__action" href="{{ path('fos_user_security_login') }}">
             <i class="fa fa-times"></i>
         </a>

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/routing.yml
@@ -12,9 +12,3 @@ KunstmaanUserManagementBundle_role_settings:
     resource: '@KunstmaanUserManagementBundle/Controller/RolesController.php'
     type:     annotation
     prefix:   /%kunstmaan_admin.admin_prefix%/settings/roles
-
-# Override default user change password route...
-KunstmaanAdminBundle_user_change_password:
-    path: /%kunstmaan_admin.admin_prefix%/settings/users/{id}/edit
-    defaults: { _controller: KunstmaanUserManagementBundle:Users:edit, id: '' }
-    methods: [GET]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

fos/user-bundle 2.1+ supports sf4 but our bundles "work" with the new versions. So relax the version contraint to allow 2.1. If users have custom code that is not compatible they should just add the correct version constraint to their `composer.json` (`"friendsofsymfony/user-bundle": "2.0.*"`)