### PR TITLE
[TranslatorBundle][UserManagementBundle] Replace getParameter calls so our code doesn't trigger deprecations

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -214,11 +214,11 @@ class TranslatorController extends AdminListController
         if (Request::METHOD_POST === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
-                $locales = explode('|', $this->getParameter('requiredlocales'));
+                $locales = explode('|', $this->container->getParameter('requiredlocales'));
                 $data = $form->getData();
                 $file = $data['file'];
                 $force = $data['force'];
-                $imported = $this->get('kunstmaan_translator.service.importer.importer')->importFromSpreadsheet($file, $locales, $force);
+                $imported = $this->container->get('kunstmaan_translator.service.importer.importer')->importFromSpreadsheet($file, $locales, $force);
                 $this->addFlash(FlashTypes::SUCCESS, sprintf("Translation imported: %d", $imported));
             }
         }

--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -88,7 +88,7 @@ class UsersController extends BaseSettingsController
 
         $user = $this->getUserClassInstance();
 
-        $options = array('password_required' => true, 'langs' => $this->getParameter('kunstmaan_admin.admin_locales'), 'validation_groups' => array('Registration'), 'data_class' => get_class($user));
+        $options = array('password_required' => true, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'), 'validation_groups' => array('Registration'), 'data_class' => get_class($user));
         $formTypeClassName = $user->getFormTypeClass();
         $formType = new $formTypeClassName();
 
@@ -161,7 +161,7 @@ class UsersController extends BaseSettingsController
         $userEvent = new UserEvent($user, $request);
         $this->container->get('event_dispatcher')->dispatch(UserEvents::USER_EDIT_INITIALIZE, $userEvent);
 
-        $options = array('password_required' => false, 'langs' => $this->getParameter('kunstmaan_admin.admin_locales'), 'data_class' => get_class($user));
+        $options = array('password_required' => false, 'langs' => $this->container->getParameter('kunstmaan_admin.admin_locales'), 'data_class' => get_class($user));
         $formFqn = $user->getFormTypeClass();
         $formType = new $formFqn();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Previously we deprecated container access in adminlist controllers and settings controller. So replace some get parameter calls so we don't trigger deprecations in our code.
