### PR TITLE
[NodeBundle][TranslatorBundle] Mark extra services public

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -132,6 +132,7 @@ services:
         calls:
             - [ setAclProvider, [ '@security.acl.provider' ] ]
             - [ setObjectIdentityRetrievalStrategy, [ '@security.acl.object_identity_retrieval_strategy' ] ]
+        public: true
 
     kunstmaan_node.doctrine_mapping.listener:
         class: Kunstmaan\NodeBundle\EventListener\MappingListener
@@ -180,6 +181,7 @@ services:
         class: "%kunstmaan_multi_domain.url_replace.controller.class%"
         arguments:
             - "@kunstmaan_node.helper.url"
+        public: true
 
     ### TOOLBAR DATA COLLECTOR ###
     kunstmaan_node.datacollector.node:

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -54,6 +54,7 @@ services:
         class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer'
         calls:
             - [setTranslationGroupManager, ['@kunstmaan_translator.service.group_manager']] # default, maken via config var
+        public: true
 
     kunstmaan_translator.service.group_manager:
         class: 'Kunstmaan\TranslatorBundle\Service\TranslationGroupManager'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Mark services used in our controllers as public. The urlReplaceController is marked as public because all controllers should be public for symfony.