### PR TITLE
[AllBundles] Use the same version constraints as symfony for egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "fpn/doctrine-extensions-taggable": "~0.9",
         "sensio/generator-bundle": "~3.0",
         "twig/extensions": "~1.0",
-        "egulias/email-validator": "~1.2",
+        "egulias/email-validator": "^1.2.8|^2.0",
         "box/spout": "^2.5",
         "ruflin/elastica": "^5.1|^6.0",
         "behat/transliterator": "~1.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

We don't use this library ourself, it's a dependency of the symfony/validator. So use the same version constraint as they "suggest". I had problems with current version constraint while testing sf4 support.