### PR TITLE
[AllBundles] Remove unused "symfony/assetic-bundle" dependency

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.0 to 5.1
 =======================
 
+General
+-------
+
+ * The `symfony/assetic-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on assetic, add the dependency to your project `composer.json`.
+
 AdminBundle
 -----------
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^1.3",
-        "symfony/assetic-bundle": "~2.7",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | closes #2007 

Assetic is not the recommended way since symfony 3.x and is unused the cms since 5.0. It also blocks updating to sf4
