### PR TITLE
[AllBundles] Bump the framework-extra-bundle version for sf4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
         "sensio/distribution-bundle": "^5.0",
-        "sensio/framework-extra-bundle": "^3.0.2",
+        "sensio/framework-extra-bundle": "^5.0",
         "incenteev/composer-parameter-handler": "^2.0",
 
         "friendsofsymfony/user-bundle": "2.0.*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Bump the version of sensio/framework-extra-bundle to 5.0. This version supports both symfony ^3.3 and ^4.0. 