### PR TITLE
[FormBundle] added deletable formsubmissions

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -24,6 +24,14 @@ ConfigBundle
 
  * Passing the `container` as the sixth argument in `Kunstmaan\ConfigBundle\Controller\ConfigController` is deprecated in and will be removed in 6.0.
 
+FormBundle
+-----------
+ * Added the optional `deletable_formsubmissions` config parameter, when set to true, form submissions can be deleted from the adminlist.
+     ```yaml
+     kunstmaan_form:
+         deletable_formsubmissions: true
+     ```
+
 MediaBundle
 -----------
 

--- a/src/Kunstmaan/FormBundle/AdminList/FormSubmissionAdminListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormSubmissionAdminListConfigurator.php
@@ -22,13 +22,20 @@ class FormSubmissionAdminListConfigurator extends AbstractDoctrineORMAdminListCo
     protected $nodeTranslation;
 
     /**
-     * @param EntityManager   $em              The entity manager
-     * @param NodeTranslation $nodeTranslation The node translation
+     * @var bool
      */
-    public function __construct(EntityManager $em, $nodeTranslation)
+    protected $deletableFormsubmissions;
+
+    /**
+     * @param EntityManager   $em                       The entity manager
+     * @param NodeTranslation $nodeTranslation          The node translation
+     * @param bool            $deletableFormsubmissions Can formsubmissions be deleted or not
+     */
+    public function __construct(EntityManager $em, $nodeTranslation, $deletableFormsubmissions = false)
     {
         parent::__construct($em);
         $this->nodeTranslation = $nodeTranslation;
+        $this->deletableFormsubmissions = $deletableFormsubmissions;
     }
 
     /**
@@ -130,7 +137,7 @@ class FormSubmissionAdminListConfigurator extends AbstractDoctrineORMAdminListCo
      */
     public function canDelete($item)
     {
-        return false;
+        return $this->deletableFormsubmissions;
     }
 
 
@@ -153,7 +160,14 @@ class FormSubmissionAdminListConfigurator extends AbstractDoctrineORMAdminListCo
      */
     public function getDeleteUrlFor($item)
     {
-        return array();
+        if (!$this->deletableFormsubmissions) {
+            return [];
+        }
+        
+        return [
+            'path' => 'KunstmaanFormBundle_formsubmissions_delete',
+            'params' => ['id' => $item->getId()],
+        ];
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/FormBundle/DependencyInjection/Configuration.php
@@ -22,6 +22,13 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $treeBuilder->root('kunstmaan_form');
 
+        $rootNode = $treeBuilder->root('kunstmaan_form');
+        $rootNode
+            ->children()
+                ->booleanNode('deletable_formsubmissions')->defaultFalse()->end()
+            ->end()
+        ;
+
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.

--- a/src/Kunstmaan/FormBundle/DependencyInjection/KunstmaanFormExtension.php
+++ b/src/Kunstmaan/FormBundle/DependencyInjection/KunstmaanFormExtension.php
@@ -22,7 +22,9 @@ class KunstmaanFormExtension extends Extension implements PrependExtensionInterf
     {
 
         $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('kunstmaan_form.deletable_formsubmissions' , $config['deletable_formsubmissions']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Kunstmaan/FormBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/FormBundle/Resources/translations/messages.en.yml
@@ -101,6 +101,10 @@ formsubmissions:
         title: Form submissions for page
     edit:
         title: Form submission for page
+    delete:
+        flash:
+            success: The form submission is deleted!
+            error: Deleting the form submission failed!
 
 subaction:
     formsubmissions: "Submissions"

--- a/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/edit.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/edit.html.twig
@@ -5,21 +5,35 @@
         <div class="page-header">
             <h1>{{ adminmenu.current.label | trans }} {% block page_header_addition %}{% endblock %}</h1>
             <small><strong>date</strong>: {{ formsubmission.created|date }} / <strong>language</strong>: {{ formsubmission.lang }} / <strong>ip</strong>: {{ formsubmission.ipAddress }}</small>
-            {% block extra_actions_header %}{% endblock %}
+            {% block extra_actions_header %}
+                {% if adminlist.canDelete(formsubmission) %}
+                    <div class="js-auto-collapse-buttons page-main-actions page-main-actions--no-tabs page-main-actions--inside-extra-actions-header">
+                        <div class="btn-group">
+                            <a class="btn btn--raise-on-hover btn-danger" href="#" data-toggle="modal" data-target="#sure-modal-{{ formsubmission.id }}">
+                                {{ 'action.delete' | trans }}
+                            </a>
+                        </div>
+                    </div>
+                {% endif %}
+            {% endblock %}
         </div>
     {% endif %}
 {% endblock %}
 
 {% block content %}
-            {% for field in formsubmission.fields %}
-                    <p><strong>{{ field.label }}</strong></p>
-                    <p>
-                        {% if (field.submissionTemplate is defined) %}
-                            {% include field.submissionTemplate with {'resource' : field, 'host' : ''} %}
-                        {% else %}
-                            {{ field }}
-                        {% endif %}
-                    </p>
-            {% endfor %}
+        {% for field in formsubmission.fields %}
+                <p><strong>{{ field.label }}</strong></p>
+                <p>
+                    {% if (field.submissionTemplate is defined) %}
+                        {% include field.submissionTemplate with {'resource' : field, 'host' : ''} %}
+                    {% else %}
+                        {{ field }}
+                    {% endif %}
+                </p>
+        {% endfor %}
 
+    {% if adminlist.canDelete(formsubmission) %}
+        {% set item = formsubmission %}
+        {% include '@KunstmaanAdminList/AdminListTwigExtension/sure-modal.html.twig' %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Added the optional `deletable_formsubmissions` config parameter, when set to true, form submissions can be deleted from the adminlist.

