### PR TITLE
[AdminBundle] Added console exception subscriber/ deprecated listener

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/ConsoleCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/ConsoleCompilerPass.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener;
+use Kunstmaan\AdminBundle\EventListener\ConsoleExceptionSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class ConsoleCompilerPass.
+ */
+final class ConsoleCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // if the old listener is no longer in use
+        if (!$container->hasDefinition('kunstmaan_admin.consolelogger.listener')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('kunstmaan_admin.consolelogger.listener');
+
+        // if the default setup is in use, the subscriber / listener take care of correctly handling the errors
+        if (
+            $container->hasParameter('kunstmaan_admin.consoleexception.class') &&
+            ConsoleExceptionListener::class === $container->getParameter('kunstmaan_admin.consoleexception.class') &&
+            '%kunstmaan_admin.consoleexception.class%' === $definition->getClass()
+        ) {
+            return;
+        }
+
+        // if the listener has been overwritten in any way, a deprecation warning is needed
+        @trigger_error(
+            sprintf(
+                'The %s is deprecated and replaced by %s since KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0.',
+                ConsoleExceptionListener::class,
+                ConsoleExceptionSubscriber::class
+            ),
+            E_USER_DEPRECATED
+        );
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/ConsoleCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/ConsoleCompilerPass.php
@@ -36,7 +36,7 @@ final class ConsoleCompilerPass implements CompilerPassInterface
         // if the listener has been overwritten in any way, a deprecation warning is needed
         @trigger_error(
             sprintf(
-                'The %s is deprecated and replaced by %s since KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0.',
+                'The "%s" is deprecated and replaced by "%s" since KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0.',
                 ConsoleExceptionListener::class,
                 ConsoleExceptionSubscriber::class
             ),

--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
@@ -2,16 +2,15 @@
 
 namespace Kunstmaan\AdminBundle\EventListener;
 
-use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Psr\Log\LoggerInterface;
 
 /**
- * Class ConsoleExceptionListener.
- *
- * @deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0.
+ * Class ConsoleExceptionSubscriber.
  */
-class ConsoleExceptionListener
+final class ConsoleExceptionSubscriber implements EventSubscriberInterface
 {
     /** @var LoggerInterface */
     private $logger;
@@ -26,19 +25,24 @@ class ConsoleExceptionListener
     }
 
     /**
-     * @param ConsoleExceptionEvent $event
+     * @return array
      */
-    public function onConsoleException(ConsoleExceptionEvent $event)
+    public static function getSubscribedEvents()
     {
-        // if the newer error event exists, don't bother with the old exception, our subscriber will handle this
-        if (class_exists(ConsoleErrorEvent::class)){
-            return;
-        }
+        return [
+            ConsoleEvents::ERROR => 'onConsoleError'
+        ];
+    }
 
+    /**
+     * @param ConsoleErrorEvent $event
+     */
+    public function onConsoleError(ConsoleErrorEvent $event)
+    {
         $command = $event->getCommand();
-        $exception = $event->getException();
+        $error = $event->getError();
 
-        $this->logCommandError($command, $exception);
+        $this->logCommandError($command, $error);
     }
 
     /**

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle;
 
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AddLogProcessorsCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AdminPanelCompilerPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\ConsoleCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorAfterPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
@@ -31,6 +32,7 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new AddLogProcessorsCompilerPass());
         $container->addCompilerPass(new DataCollectorPass());
         $container->addCompilerPass(new DomainConfigurationPass());
+        $container->addCompilerPass(new ConsoleCompilerPass());
 
         $container->registerExtension(new KunstmaanAdminExtension());
     }

--- a/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/console_listener.yml
@@ -9,3 +9,10 @@ services:
             - '@logger'
         tags:
             - { name: kernel.event_listener, event: console.exception }
+
+    kunstmaan_admin.consolelogger.subscriber:
+        class: "Kunstmaan\\AdminBundle\\EventListener\\ConsoleExceptionSubscriber"
+        arguments:
+            - '@logger'
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Added a new (and final) console exception subscriber, using the new error event, to replace the console exception listener.