### PR TITLE
[AllBundles] Remove unused sensio/distribution-bundle

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -6,6 +6,7 @@ General
 
  * The `symfony/assetic-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on assetic, add the dependency to your project `composer.json`.
  * The `symfony/swiftmailer-bundle` package was removed from our dependencies as it was unused. If your code depends on `symfony/swiftmailer-bundle`, add the dependency to your project `composer.json`.
+ * The `sensio/distribution-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on `sensio/distribution-bundle` for executing composer after update/install scripts, add the dependency to your project `composer.json`.
 
 AdminBundle
 -----------

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
-        "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^5.0",
         "incenteev/composer-parameter-handler": "^2.0",
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The `sensio/distribution-bundle` was an unused dependency and blocking the sf4 upgrade. So remove it from the package itself, but I will create a PR to add to the standard edition for new installs.