### PR TITLE
[AllBundles] Remove unused symfony/swiftmailer-bundle

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -5,6 +5,7 @@ General
 -------
 
  * The `symfony/assetic-bundle` package was removed from our dependencies as it was unused since version 5.0. If your code depends on assetic, add the dependency to your project `composer.json`.
+ * The `symfony/swiftmailer-bundle` package was removed from our dependencies as it was unused. If your code depends on `symfony/swiftmailer-bundle`, add the dependency to your project `composer.json`.
 
 AdminBundle
 -----------

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^1.3",
-        "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
         "sensio/distribution-bundle": "^5.0",

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/AppKernel.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/AppKernel.php
@@ -16,7 +16,6 @@ class AppKernel extends Kernel
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Kunstmaan\UtilitiesBundle\KunstmaanUtilitiesBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new \Kunstmaan\AdminBundle\KunstmaanAdminBundle(),
             new \Kunstmaan\TranslatorBundle\KunstmaanTranslatorBundle(),
             new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
@@ -54,3 +54,5 @@ fos_user:
     from_email:
         address:        admin@kunstmaan.be
         sender_name:    Admin
+    service:
+        mailer: fos_user.mailer.noop


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The `symfony/swiftmailer-bundle` is no "real" dependency of the `bundle-cms` package but should be installed by the `standard-edition`. So I will create a PR to add it to the `standard-edition`.
