### PR TITLE
[TranslatorBundle] add status field on translations for later use in rest api

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineDBALAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\EnumerationFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\StringFilterType;
+use Kunstmaan\TranslatorBundle\Entity\Translation;
 
 /**
  * TranslationAdminListConfigurator
@@ -40,6 +41,7 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
      */
     public function buildFilters()
     {
+        $this->addFilter('status', new StringFilterType('status'), 'kuma_translator.adminlist.filter.status');
         $this->addFilter('domain', new StringFilterType('domain'), 'kuma_translator.adminlist.filter.domain');
         $this->addFilter('keyword', new StringFilterType('keyword'), 'kuma_translator.adminlist.filter.keyword');
         $this->addFilter('text', new StringFilterType('text'), 'kuma_translator.adminlist.filter.text');
@@ -55,6 +57,7 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
     {
         $this->addField('domain', 'kuma_translator.adminlist.header.domain', true);
         $this->addField('keyword', 'kuma_translator.adminlist.header.keyword', true);
+        $this->addField('status', 'kuma_translator.adminlist.header.status', true);
     }
 
     /**
@@ -132,8 +135,10 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
         if (is_null($this->queryBuilder)) {
             $this->queryBuilder = new QueryBuilder($this->connection);
             $this->queryBuilder
-                ->select('DISTINCT b.translation_id AS id, b.keyword, b.domain')
-                ->from('kuma_translation', 'b');
+                ->select('DISTINCT b.translation_id AS id, b.keyword, b.domain, b.status')
+                ->from('kuma_translation', 'b')
+                ->andWhere('b.status != :statusstring')
+                ->setParameter('statusstring', Translation::STATUS_DISABLED);
 
             // Apply filters
             $filters = $this->getFilterBuilder()->getCurrentFilters();

--- a/src/Kunstmaan/TranslatorBundle/Entity/Translation.php
+++ b/src/Kunstmaan/TranslatorBundle/Entity/Translation.php
@@ -2,7 +2,9 @@
 
 namespace Kunstmaan\TranslatorBundle\Entity;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\TranslatorBundle\Model\Translation as TranslationModel;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -21,6 +23,9 @@ class Translation
 {
     const FLAG_NEW = 'new';
     const FLAG_UPDATED = 'updated';
+    const STATUS_DEPRECATED = 'deprecated';
+    const STATUS_DISABLED = 'disabled';
+    const STATUS_ENABLED =  'enabled';
 
     /**
      * @ORM\Id
@@ -50,6 +55,14 @@ class Translation
      * @Assert\NotBlank()
      */
     protected $locale;
+
+    /**
+     * @var string $status
+     * The translations deprecation date
+     *
+     * @ORM\column(type="string", length=10, options={"default" : "enabled"})
+     */
+    protected $status = self::STATUS_ENABLED;
 
     /**
      * Location where the translation comes from
@@ -101,8 +114,8 @@ class Translation
      */
     public function prePersist()
     {
-        $this->createdAt = new \DateTime();
-        $this->updatedAt = new \DateTime();
+        $this->createdAt = new DateTime();
+        $this->updatedAt = new DateTime();
         $this->flag = self::FLAG_NEW;
 
         return $this->id;
@@ -113,11 +126,12 @@ class Translation
      */
     public function preUpdate()
     {
-        $this->updatedAt = new \DateTime();
+        $this->updatedAt = new DateTime();
 
         if ($this->flag === null) {
             $this->flag = self::FLAG_UPDATED;
         }
+
     }
 
     /**
@@ -246,7 +260,7 @@ class Translation
      * @param \DateTime $createdAt
      * @return Translation
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
 
@@ -262,10 +276,10 @@ class Translation
     }
 
     /**
-     * @param \DateTime $updatedAt
+     * @param DateTime $updatedAt
      * @return Translation
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
 
@@ -308,5 +322,53 @@ class Translation
     public function getTranslationId()
     {
         return $this->translationId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     * @return Translation
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDisabled()
+    {
+        return $this->getStatus() === self::STATUS_DISABLED;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDeprecated()
+    {
+        return $this->getStatus() === self::STATUS_DEPRECATED;
+    }
+
+    /**
+     * @param integer $id
+     *
+     * @return TranslationModel
+     */
+    public function getTranslationModel($id = null)
+    {
+        $translationModel = new TranslationModel();
+        $translationModel->setKeyword($this->getKeyword());
+        $translationModel->setDomain($this->getDomain());
+        $translationModel->addText($this->getLocale(), $this->getText(), $id);
+        return $translationModel;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
+++ b/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
@@ -38,7 +38,8 @@ class TranslationRepository extends AbstractTranslatorRepository
     {
 
         $qb = $this->createQueryBuilder('t');
-        $result = $qb->select('t')
+        $qb
+            ->select('t')
             ->where('t.locale = :locale')
             ->andWhere('t.status != :statusstring')
             ->setParameter('statusstring', Translation::STATUS_DISABLED)

--- a/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
+++ b/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
@@ -2,7 +2,10 @@
 
 namespace Kunstmaan\TranslatorBundle\Repository;
 
+use DateTime;
+use Exception;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
+use Kunstmaan\TranslatorBundle\Model\Translation as TranslationModel;
 use Kunstmaan\TranslatorBundle\Model\TextWithLocale;
 
 /**
@@ -25,6 +28,32 @@ class TranslationRepository extends AbstractTranslatorRepository
             ->getArrayResult();
     }
 
+    /**
+     * Get an array of all non disabled translations
+     * @param string $locale
+     * @param string $domain
+     * @return array
+     */
+    public function findAllNotDisabled($locale, $domain = null)
+    {
+
+        $qb = $this->createQueryBuilder('t');
+        $result = $qb->select('t')
+            ->where('t.locale = :locale')
+            ->andWhere('t.status != :statusstring')
+            ->setParameter('statusstring', Translation::STATUS_DISABLED)
+            ->setParameter('locale', $locale);
+        if (!\is_null($domain) && !empty($domain)) {
+            $qb->andWhere('t.domain = :tdomain')
+                ->setParameter('tdomain', $domain);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return DateTime|null
+     */
     public function getLastChangedTranslationDate()
     {
         $em = $this->getEntityManager();
@@ -59,6 +88,9 @@ EOQ;
         return null;
     }
 
+    /**
+     * @return mixed
+     */
     public function resetAllFlags()
     {
         return $this->createQueryBuilder('t')
@@ -69,6 +101,11 @@ EOQ;
 
     }
 
+    /**
+     * @param $locales
+     * @param $domains
+     * @return mixed
+     */
     public function getTranslationsByLocalesAndDomains($locales, $domains)
     {
         $em = $this->getEntityManager();
@@ -76,6 +113,8 @@ EOQ;
         $qb
             ->select('t')
             ->from('KunstmaanTranslatorBundle:Translation', 't')
+            ->andWhere('t.status != :statusstring')
+            ->setParameter('statusstring', Translation::STATUS_DISABLED)
             ->orderBy('t.domain', 'ASC')
             ->addOrderBy('t.keyword', 'ASC');
 
@@ -94,6 +133,10 @@ EOQ;
         return $result;
     }
 
+    /**
+     * @param null $entity
+     * @return mixed
+     */
     public function flush($entity = null)
     {
         if ($entity !== null) {
@@ -103,12 +146,20 @@ EOQ;
         return $this->getEntityManager()->flush();
     }
 
+    /**
+     * @param $entity
+     * @return mixed
+     */
     public function persist($entity)
     {
         return $this->getEntityManager()->persist($entity);
     }
 
-    public function isUnique(\Kunstmaan\TranslatorBundle\Model\Translation $translationModel)
+    /**
+     * @param TranslationModel $translationModel
+     * @return bool
+     */
+    public function isUnique(TranslationModel $translationModel)
     {
         $qb = $this->createQueryBuilder('t');
         $count = $qb->select('COUNT(t.id)')
@@ -122,7 +173,10 @@ EOQ;
         return $count == 0;
     }
 
-    public function createTranslations(\Kunstmaan\TranslatorBundle\Model\Translation $translationModel)
+    /**
+     * @param TranslationModel $translationModel
+     */
+    public function createTranslations(TranslationModel $translationModel)
     {
         $this->getEntityManager()->beginTransaction();
         try {
@@ -147,12 +201,16 @@ EOQ;
                 $this->getEntityManager()->persist($translation);
             }
             $this->getEntityManager()->commit();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->getEntityManager()->rollback();
         }
     }
 
-    public function updateTranslations(\Kunstmaan\TranslatorBundle\Model\Translation $translationModel, $translationId)
+    /**
+     * @param TranslationModel $translationModel
+     * @param                  $translationId
+     */
+    public function updateTranslations(TranslationModel $translationModel, $translationId)
     {
         $this->getEntityManager()->beginTransaction();
         try {
@@ -182,7 +240,7 @@ EOQ;
                 }
             }
             $this->getEntityManager()->commit();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->getEntityManager()->rollback();
         }
     }
@@ -204,6 +262,9 @@ EOQ;
             ->execute();
     }
 
+    /**
+     * @return int
+     */
     public function getUniqueTranslationId()
     {
         $qb = $this->createQueryBuilder('t');
@@ -215,5 +276,26 @@ EOQ;
         }
 
         return $newId;
+    }
+
+    /**
+     * @param DateTime $date
+     * @param string $domain
+     * @return mixed
+     */
+    public function findDeprecatedTranslationsBeforeDate(DateTime $date, $domain)
+    {
+        $qb = $this->createQueryBuilder('t');
+        $result = $qb->select('t')
+            ->where('t.status = :status')
+            ->andWhere('t.domain = :domain')
+            ->andWhere('t.updatedAt < :date')
+            ->setParameter('status', Translation::STATUS_DEPRECATED)
+            ->setParameter('domain', $domain)
+            ->setParameter('date', $date)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
@@ -52,12 +52,13 @@ kuma_translator:
         header:
             domain:     Domain
             keyword:    Keyword
+            status:     Status
         filter:
             domain:     Domain
             keyword:    Keyword
             text:       Text
             locale:     Locale
-
+            status:     Status
 # Toolbar
 toolbar:
     translations:

--- a/src/Kunstmaan/TranslatorBundle/Tests/Repository/TranslationRepositoryTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Repository/TranslationRepositoryTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Kunstmaan\TranslatorBundle\Tests\Service\Importer;
 
+use Kunstmaan\TranslatorBundle\Repository\TranslationRepository;
 use Kunstmaan\TranslatorBundle\Tests\BaseTestCase;
 
 class TranslationRepositoryTest extends BaseTestCase
 {
-
+    /** @var TranslationRepository */
     private $translationRepository;
 
     public function setUp()
@@ -40,6 +41,26 @@ class TranslationRepositoryTest extends BaseTestCase
     public function testGetTranslationsByLocalesAndDomains()
     {
         $result = $this->translationRepository->getTranslationsByLocalesAndDomains(array('nl'), array('messages'));
+        $this->assertInstanceOf('Kunstmaan\TranslatorBundle\Entity\Translation', $result[0]);
+        $this->assertGreaterThan(0, count($result));
+    }
+
+    /**
+     * @group translation-repository
+     */
+    public function testFindAllNotDisabled()
+    {
+        $result = $this->translationRepository->findAllNotDisabled('nl');
+        $this->assertInstanceOf('Kunstmaan\TranslatorBundle\Entity\Translation', $result[0]);
+        $this->assertGreaterThan(0, count($result));
+    }
+
+    /**
+     * @group translation-repository
+     */
+    public function testFindAllDeprecated()
+    {
+        $result = $this->translationRepository->findDeprecatedTranslationsBeforeDate(new \DateTime(), 'messages');
         $this->assertInstanceOf('Kunstmaan\TranslatorBundle\Entity\Translation', $result[0]);
         $this->assertGreaterThan(0, count($result));
     }

--- a/src/Kunstmaan/TranslatorBundle/Tests/files/fixtures.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/files/fixtures.yml
@@ -3,6 +3,7 @@ Kunstmaan\TranslatorBundle\Entity\Translation:
         keyword: errors.<word()>.<word()>_<current()>
         locale: nl
         domain: messages
+        status: 'enabled'
         text: <text()>
         createdAt: <dateTime()>
         updatedAt: <dateTime()>
@@ -13,6 +14,7 @@ Kunstmaan\TranslatorBundle\Entity\Translation:
         createdAt: <dateTime()>
         updatedAt: <dateTime()>
         domain: validation
+        status: 'enabled'
     headers_updated:
         keyword: headers.frontpage
         text: 'a not yet updated frontpage header'
@@ -20,6 +22,7 @@ Kunstmaan\TranslatorBundle\Entity\Translation:
         updatedAt: <dateTime()>
         locale: en
         domain: messages
+        status: 'enabled'
     validation_messages:
         keyword: validation.ok
         text: 'Everything ok'
@@ -27,6 +30,7 @@ Kunstmaan\TranslatorBundle\Entity\Translation:
         updatedAt: <dateTime()>
         locale: en
         domain: validation
+        status: 'enabled'
     future_messages:
         keyword: validation.in_the_future
         text: 'This should be the last updated translation'
@@ -35,3 +39,12 @@ Kunstmaan\TranslatorBundle\Entity\Translation:
         updatedAt: <dateTimeBetween('+ 1 days', '+ 200 days')>
         locale: en
         domain: validation
+        status: 'enabled'
+    deprecated_messages:
+        keyword: these_are_deprecated
+        text: 'these are deprecated'
+        createdAt: <dateTime()>
+        updatedAt: <dateTimeBetween('- 200 days', '- 1 days')>
+        locale: en
+        domain: messages
+        status: 'deprecated'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Allows translations to be "deprecated" and "disabled". 
This feature will be invisible for classic websites as the feature does not add much in their use case.

