### PR TITLE
[MediaBundle] Fixed BackgroundFilterLoader issue

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
@@ -17,22 +17,6 @@ class BackgroundFilterLoader extends \Liip\ImagineBundle\Imagine\Filter\Loader\B
      */
     public function load(ImageInterface $image, array $options = array())
     {
-        $background = new Color(
-            isset($options['color']) ? $options['color'] : '#fff',
-            isset($options['transparency']) ? $options['transparency'] : 0
-        );
-        $topLeft = new Point(0, 0);
-        $size = $image->getSize();
-
-        if (isset($options['size'])) {
-            list($width, $height) = $options['size'];
-
-            $size = new Box($width, $height);
-            $topLeft = new Point(($width - $image->getSize()->getWidth()) / 2, ($height - $image->getSize()->getHeight()) / 2);
-        }
-
-        $canvas = $this->imagine->create($size, $background);
-
-        return $canvas->paste($image, $topLeft);
+        parent::load($image, $options);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The BackgroundFilterLoader class as it was throws an error because the Color class no longer exists. Besides, overriding the BackgroundFilterLoader from liip is no longer necessary as the original issue is fixed in the imagine & liip versions the current bundle version uses. 
