### PR TITLE
[AdminBundle] added missing translations to main language

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/translations/messages.en.yml
@@ -139,6 +139,12 @@ kuma_js:
         more_button_label: More
 
 toolbar:
+    bundle_version:
+        unknown: Unknown
+        uptodate: Up-to-date
+        toupdate: Outdated
+        version: Bundle version
+        status: Bundle status
     exception:
         title: Exceptions
         message: "<strong>%X%</strong> exception triggered by <strong>%Y%</strong> events"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Because translation was not added to the EN but to NL instead, crowdin wants to delete these translations.
