### PR TITLE
[AllBundles] rollback sensio framework extra bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
         "sensio/distribution-bundle": "^5.0",
-        "sensio/framework-extra-bundle": "^5.0",
+        "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
 
         "friendsofsymfony/user-bundle": "2.0.*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

We have to downgrade the sensio framework-extra-bundle because in v4.0 there's a BC break that causes issues with our templates. We'll have to rethink this further down the line for the sf4 compatibility.

> [BC BREAK] changed template name generation from camelCase to under_score for both files and directories