### PR TITLE
[AllBundles] Fix BC break after upgrading to sensio/framework-extra-bundle 5.0

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
@@ -16,7 +16,6 @@ class DashboardController extends Controller
      * The index action will render the main screen the users see when they log in in to the admin
      *
      * @Route("/", name="kunstmaan_dashboard")
-     * @Template()
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return array

--- a/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
+++ b/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
@@ -57,7 +57,7 @@ class FormSubmissionsController extends Controller
      * @Route("/list/{nodeTranslationId}", requirements={"nodeTranslationId" = "\d+"},
      *                                     name="KunstmaanFormBundle_formsubmissions_list")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanForm/FormSubmissions/list.html.twig")
      *
      * @return array
      */
@@ -85,7 +85,7 @@ class FormSubmissionsController extends Controller
      * @Route("/list/{nodeTranslationId}/{submissionId}", requirements={"nodeTranslationId" = "\d+", "submissionId" =
      *                                                    "\d+"}, name="KunstmaanFormBundle_formsubmissions_list_edit")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanForm/FormSubmissions/edit.html.twig")
      *
      * @return array
      */
@@ -142,7 +142,6 @@ class FormSubmissionsController extends Controller
      *      requirements={"id" = "\d+"},
      *      name="KunstmaanFormBundle_formsubmissions_delete"
      * )
-     * @Template()
      * @Method("POST")
      *
      * @param Request $request

--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -70,7 +70,7 @@ class ChooserController extends Controller
      * @param int     $folderId The folder id
      *
      * @Route("/chooser/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_chooser_show_folder")
-     * @Template()
+     * @Template("@KunstmaanMedia/Chooser/chooserShowFolder.html.twig")
      *
      * @return array
      */

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -155,7 +155,6 @@ class FolderController extends Controller
      *
      * @Route("/subcreate/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_sub_create")
      * @Method({"GET", "POST"})
-     * @Template()
      *
      * @return Response
      */
@@ -215,7 +214,6 @@ class FolderController extends Controller
      *
      * @Route("/empty/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_empty")
      * @Method({"GET", "POST"})
-     * @Template()
      *
      * @return Response
      */

--- a/src/Kunstmaan/MediaBundle/Controller/IconFontController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/IconFontController.php
@@ -16,7 +16,7 @@ class IconFontController extends Controller
      * @param Request $request
      *
      * @Route("/chooser", name="KunstmaanMediaBundle_icon_font_chooser")
-     * @Template()
+     * @Template("@KunstmaanMedia/IconFont/iconFontChooser.html.twig")
      *
      * @return array
      */

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -122,7 +122,7 @@ class MediaController extends Controller
      * @param int $folderId
      *
      * @Route("bulkupload/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_media_bulk_upload")
-     * @Template()
+     * @Template("@KunstmaanMedia/Media/bulkUpload.html.twig")
      *
      * @return array|RedirectResponse
      */
@@ -141,7 +141,6 @@ class MediaController extends Controller
      * @param int     $folderId
      *
      * @Route("bulkuploadsubmit/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_media_bulk_upload_submit")
-     * @Template()
      *
      * @return JsonResponse
      */
@@ -352,7 +351,7 @@ class MediaController extends Controller
      *
      * @Route("create/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_create")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanMedia/Media/create.html.twig")
      *
      * @return array|RedirectResponse
      */
@@ -437,8 +436,7 @@ class MediaController extends Controller
      * @param string  $type     The type
      *
      * @Route("create/modal/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_modal_create")
-     * @Method({"GET", "POST"})
-     * @Template()
+     * @Method({"POST"})
      *
      * @return array|RedirectResponse
      */

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -160,7 +160,6 @@ class NodeAdminController extends Controller
      *      name="KunstmaanNodeBundle_nodes_copyfromotherlanguage"
      * )
      * @Method("GET")
-     * @Template()
      *
      * @param Request $request
      * @param int $id The node id
@@ -212,7 +211,6 @@ class NodeAdminController extends Controller
      *      name="KunstmaanNodeBundle_nodes_recopyfromotherlanguage"
      * )
      * @Method("POST")
-     * @Template()
      *
      * @param Request $request
      * @param int $id The node id
@@ -263,7 +261,6 @@ class NodeAdminController extends Controller
      *      name="KunstmaanNodeBundle_nodes_createemptypage"
      * )
      * @Method("GET")
-     * @Template()
      *
      * @param Request $request
      * @param int $id
@@ -389,7 +386,6 @@ class NodeAdminController extends Controller
      *      requirements={"id" = "\d+"},
      *      name="KunstmaanNodeBundle_nodes_delete"
      * )
-     * @Template()
      * @Method("POST")
      *
      * @param Request $request
@@ -454,7 +450,6 @@ class NodeAdminController extends Controller
      *      requirements={"id" = "\d+"},
      *      name="KunstmaanNodeBundle_nodes_duplicate"
      * )
-     * @Template()
      * @Method("POST")
      *
      * @param Request $request
@@ -528,7 +523,6 @@ class NodeAdminController extends Controller
      *      defaults={"subaction" = "public"},
      *      name="KunstmaanNodeBundle_nodes_revert"
      * )
-     * @Template()
      * @Method("GET")
      *
      * @param Request $request
@@ -613,7 +607,6 @@ class NodeAdminController extends Controller
      *      requirements={"id" = "\d+"},
      *      name="KunstmaanNodeBundle_nodes_add"
      * )
-     * @Template()
      * @Method("POST")
      *
      * @param Request $request
@@ -679,7 +672,6 @@ class NodeAdminController extends Controller
 
     /**
      * @Route("/add-homepage", name="KunstmaanNodeBundle_nodes_add_homepage")
-     * @Template()
      * @Method("POST")
      *
      * @return RedirectResponse
@@ -802,7 +794,7 @@ class NodeAdminController extends Controller
      *      defaults={"subaction" = "public"},
      *      name="KunstmaanNodeBundle_nodes_edit"
      * )
-     * @Template()
+     * @Template("@KunstmaanNode/NodeAdmin/edit.html.twig")
      * @Method({"GET", "POST"})
      *
      * @param Request $request


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | closes #2039 (can be closed as the downgrade is not required anymore with this fix)

Upgrading to sensio/framework-extra-bundle 5.0 caused a bc break for camelcase template paths which were not explicitly configured (Symfony would guess the template path for the empty `@Template()` annotations. This is fixed by explicitly settings the template path for these cases. 

I've also remove some unused `@Template` annotations as these actions returned a redirect so the annotation was unused.
