### PR TITLE
[AdminBundle] Add compatibility with the new symfony Role class

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
@@ -159,7 +159,7 @@ class PermissionAdmin
      */
     public function getPermission($role)
     {
-        if ($role instanceof RoleInterface) {
+        if ($role instanceof RoleInterface || $role instanceof \Symfony\Component\Security\Core\Role\Role) {
             $role = $role->getRole();
         }
         if (isset($this->permissions[$role])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I've fixed the `RoleInterface` deprecation in #1981, this PR fixes an incompatibilty issue in the `PermissionAdmin` where the `Role` object is checked.