### PR TITLE
[PagePartBundle] Allow bundless config for pagepart and page yaml files paths

### DIFF
--- a/src/Kunstmaan/PagePartBundle/PagePartConfigurationReader/PagePartConfigurationParser.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartConfigurationReader/PagePartConfigurationParser.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\PagePartBundle\PagePartConfigurationReader;
 
 use Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminConfigurator;
 use Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdminConfiguratorInterface;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -108,8 +109,14 @@ class PagePartConfigurationParser implements PagePartConfigurationParserInterfac
 
         $nameParts = explode(':', $name);
         if (2 !== count($nameParts)) {
-            throw new \Exception(sprintf('Malformed namespaced configuration name "%s" (expecting "namespace:pagename").',
-                $name));
+            $filePaths = [
+                $this->kernel->getProjectDir().'/config/kunstmaancms/pageparts',
+                $this->kernel->getProjectDir().'/src/Resources/config/pageparts',
+            ];
+            $fileLocator = new FileLocator($filePaths);
+            $filePath = $fileLocator->locate(sprintf('%s.yml', $name));
+
+            return Yaml::parse(file_get_contents($filePath));
         }
 
         list ($namespace, $name) = $nameParts;

--- a/src/Kunstmaan/PagePartBundle/PageTemplate/PageTemplateConfigurationParser.php
+++ b/src/Kunstmaan/PagePartBundle/PageTemplate/PageTemplateConfigurationParser.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\PagePartBundle\PageTemplate;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -115,7 +116,14 @@ class PageTemplateConfigurationParser implements PageTemplateConfigurationParser
         }
 
         if (false === strpos($name, ':')) {
-            throw new \Exception(sprintf('Malformed namespaced configuration name "%s" (expecting "namespace:pagename").', $name));
+            $filePaths = [
+                $this->kernel->getProjectDir().'/config/kunstmaancms/pagetemplates',
+                $this->kernel->getProjectDir().'/src/Resources/config/pagetemplates',
+            ];
+            $fileLocator = new FileLocator($filePaths);
+            $path = $fileLocator->locate(sprintf('%s.yml', $name));
+
+            return Yaml::parse(file_get_contents($path));
         }
 
         list ($namespace, $name) = explode(':', $name, 2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

With the current code it's required to have a bundle namespace in the yaml path config (eg. `WebsiteBundle:homepage`). With this pr we allow "bundless" paths, this also to have compatibilty with sf4 where the concept of bundles in the `src/` dir is not recommended anymore. 

So the locator will look in 2 possible paths and will return the first hit it finds.
For a bundless setup in sf 3.4 it will look into `src/Resources/config/(pageparts|pagetemplates)`. And for the sf 4 direcoty structure it will look into `config/kunstmaancms/(pageparts|pagetemplates)`.