### PR TITLE
[AdminBundle] Remove id of nested form item containers

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -183,7 +183,7 @@
 
                 {# Items #}
                 {% for obj in form %}
-                    <div id="{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}-pp-container" class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
+                    <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
                             {% if attr['nested_deletable'] is not defined or attr['nested_deletable'] != false %}
                                 data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
                             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Nested item containers conflict with page parts, because they use the same id: #-pp-container
As far as I could tell, the id of this element is never used, but the id of page part container elements is.

I have a page part with a (one to many) collection field. When the page has multiple page parts, deleting the second one actually triggers the removal of the second item of the collection field, while also marks the page part for deletion. When saving, this results in a error: Call to a member function setContext() on null at vendor/kunstmaan/bundles-cms/src/Kunstmaan/PagePartBundle/Repository/PagePartRefRepository.php:195.
