### PR TITLE
[NodeSearchBundle] Backport elasticsearch 6.2 compatibility fix from 5.0

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/ElasticSearchUtil.php
@@ -18,7 +18,7 @@ final class ElasticSearchUtil
      */
     public static function useVersion6()
     {
-        if (PHP_MAJOR_VERSION < 7 || !class_exists('\Elastica\Tool\CrossIndex')) {
+        if (PHP_MAJOR_VERSION < 7) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Backport of the ES 6.2 bugfix from bundles 5.0. See #2009 
