### PR TITLE
[KunstmaanTranslatorBundle] export all translations, use correct locales

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
@@ -75,12 +75,11 @@ class TranslatorCommandController extends Controller
      */
     public function exportAction()
     {
-        $locales = explode('|', $this->getParameter('requiredlocales'));
+        $locales = $this->getParameter('kuma_translator.managed_locales');
         $exportCommand = new ExportCommand();
         $exportCommand
             ->setLocales($locales)
-            ->setFormat('csv')
-            ->setDomains('messages');
+            ->setFormat('csv');
 
         $response = $this->get('kunstmaan_translator.service.exporter.command_handler')->executeExportCSVCommand($exportCommand);
 

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -32,6 +32,9 @@ class KunstmaanTranslatorExtension extends Extension
         $container->setParameter('kuma_translator.default_bundle', $config['default_bundle']);
         $container->setParameter('kuma_translator.bundles', $config['bundles']);
         $container->setParameter('kuma_translator.cache_dir', $config['cache_dir']);
+        if (empty($config['managed_locales']) && $container->hasParameter('requiredlocales')) {
+            $config['managed_locales'] = explode('|', $container->getParameter('requiredlocales'));
+        }
         $container->setParameter('kuma_translator.managed_locales', $config['managed_locales']);
         $container->setParameter('kuma_translator.file_formats', $config['file_formats']);
         $container->setParameter('kuma_translator.storage_engine.type', $config['storage_engine']['type']);
@@ -54,12 +57,12 @@ class KunstmaanTranslatorExtension extends Extension
         $this->registerTranslatorConfiguration($config, $container);
 
         // overwrites everything
-        $translator->addMethodCall('addDatabaseResources', array());
+        $translator->addMethodCall('addDatabaseResources', []);
 
-        $translator->addMethodCall('setFallbackLocales', array(array('en')));
+        $translator->addMethodCall('setFallbackLocales', [['en']]);
 
-        if($container->hasParameter('defaultlocale')) {
-            $translator->addMethodCall('setFallbackLocales', array(array($container->getParameter('defaultlocale'))));
+        if ($container->hasParameter('defaultlocale')) {
+            $translator->addMethodCall('setFallbackLocales', [[$container->getParameter('defaultlocale')]]);
         }
     }
 
@@ -72,7 +75,7 @@ class KunstmaanTranslatorExtension extends Extension
     {
         $translator = $container->getDefinition('kunstmaan_translator.service.translator.translator');
 
-        $dirs = array();
+        $dirs = [];
         if (class_exists('Symfony\Component\Validator\Validation')) {
             $r = new \ReflectionClass('Symfony\Component\Validator\Validation');
 
@@ -106,16 +109,18 @@ class KunstmaanTranslatorExtension extends Extension
             $finder = Finder::create();
             $finder->files();
 
-                $finder->filter(function (\SplFileInfo $file) {
+            $finder->filter(
+                function (\SplFileInfo $file) {
                     return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());
-                });
+                }
+            );
 
             $finder->in($dirs);
 
             foreach ($finder as $file) {
                 // filename is domain.locale.format
                 list($domain, $locale, $format) = explode('.', $file->getBasename());
-                $translator->addMethodCall('addResource', array($format, (string) $file, $locale, $domain));
+                $translator->addMethodCall('addResource', [$format, (string) $file, $locale, $domain]);
             }
         }
     }

--- a/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
+++ b/src/Kunstmaan/TranslatorBundle/Repository/TranslationRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Kunstmaan\TranslatorBundle\Repository;
 
 use Kunstmaan\TranslatorBundle\Entity\Translation;
@@ -11,16 +12,17 @@ class TranslationRepository extends AbstractTranslatorRepository
 {
     /**
      * Get an array of all domains group by locales
+     *
      * @return array array[0] = ["name" => "messages", "locale" => "nl"]
      */
     public function getAllDomainsByLocale()
     {
         return $this->createQueryBuilder('t')
-          ->select('t.locale, t.domain name')
-          ->addGroupBy('t.locale')
-          ->addGroupBy('t.domain')
-          ->getQuery()
-          ->getArrayResult();
+            ->select('t.locale, t.domain name')
+            ->addGroupBy('t.locale')
+            ->addGroupBy('t.domain')
+            ->getQuery()
+            ->getArrayResult();
     }
 
     public function getLastChangedTranslationDate()
@@ -60,10 +62,10 @@ EOQ;
     public function resetAllFlags()
     {
         return $this->createQueryBuilder('t')
-          ->update('KunstmaanTranslatorBundle:Translation', 't')
-          ->set('t.flag', "NULL")
-          ->getQuery()
-          ->execute();
+            ->update('KunstmaanTranslatorBundle:Translation', 't')
+            ->set('t.flag', "NULL")
+            ->getQuery()
+            ->execute();
 
     }
 
@@ -72,8 +74,10 @@ EOQ;
         $em = $this->getEntityManager();
         $qb = $em->createQueryBuilder();
         $qb
-          ->select('t')
-          ->from('KunstmaanTranslatorBundle:Translation', 't');
+            ->select('t')
+            ->from('KunstmaanTranslatorBundle:Translation', 't')
+            ->orderBy('t.domain', 'ASC')
+            ->addOrderBy('t.keyword', 'ASC');
 
         if (count($locales) > 0) {
             $qb->andWhere($qb->expr()->in('t.locale', $locales));
@@ -84,8 +88,8 @@ EOQ;
         }
 
         $result = $qb
-          ->getQuery()
-          ->getResult();
+            ->getQuery()
+            ->getResult();
 
         return $result;
     }
@@ -108,12 +112,12 @@ EOQ;
     {
         $qb = $this->createQueryBuilder('t');
         $count = $qb->select('COUNT(t.id)')
-          ->where('t.domain = :domain')
-          ->andWhere('t.keyword = :keyword')
-          ->setParameter('domain', $translationModel->getDomain())
-          ->setParameter('keyword', $translationModel->getKeyword())
-          ->getQuery()
-          ->getSingleScalarResult();
+            ->where('t.domain = :domain')
+            ->andWhere('t.keyword = :keyword')
+            ->setParameter('domain', $translationModel->getDomain())
+            ->setParameter('keyword', $translationModel->getKeyword())
+            ->getQuery()
+            ->getSingleScalarResult();
 
         return $count == 0;
     }
@@ -135,11 +139,11 @@ EOQ;
 
                 $translation = new Translation();
                 $translation
-                  ->setDomain($translationModel->getDomain())
-                  ->setKeyword($translationModel->getKeyword())
-                  ->setTranslationId($translationId)
-                  ->setLocale($textWithLocale->getLocale())
-                  ->setText($textWithLocale->getText());
+                    ->setDomain($translationModel->getDomain())
+                    ->setKeyword($translationModel->getKeyword())
+                    ->setTranslationId($translationId)
+                    ->setLocale($textWithLocale->getLocale())
+                    ->setText($textWithLocale->getText());
                 $this->getEntityManager()->persist($translation);
             }
             $this->getEntityManager()->commit();
@@ -187,24 +191,25 @@ EOQ;
      * Removes all translations with the given translation id
      *
      * @param string $translationId
+     *
      * @return mixed
      */
     public function removeTranslations($translationId)
     {
         return $this->createQueryBuilder('t')
-          ->delete()
-          ->where('t.translationId = :translationId')
-          ->setParameter('translationId', $translationId)
-          ->getQuery()
-          ->execute();
+            ->delete()
+            ->where('t.translationId = :translationId')
+            ->setParameter('translationId', $translationId)
+            ->getQuery()
+            ->execute();
     }
 
     public function getUniqueTranslationId()
     {
         $qb = $this->createQueryBuilder('t');
         $newId = $qb->select('MAX(t.translationId)+1')
-          ->getQuery()
-          ->getSingleScalarResult();
+            ->getQuery()
+            ->getSingleScalarResult();
         if (is_null($newId)) {
             $newId = 1;
         }

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/parameters.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/parameters.yml
@@ -1,3 +1,4 @@
 parameters:
     debug_toolbar: false
     secret: secret
+    requiredlocales: nl|fr|en


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

- When exporting translations to a csv file, only the messages domain is exported. For now we removed the messages limit. If people want to have the possibility to specify the domains to export, a PR can be created for this.

- When exporting translations, the requiredlocales parameter is being used but this should be the managed locales. In the dependency injection, i've also added the requiredlocales as default for the managed_locales parameter.

- Formatting