### PR TITLE
[AdminListBundle] fixed form options source in admin list controller

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -123,7 +123,7 @@ abstract class AdminListController extends Controller
         $event = $this->container->get('event_dispatcher')->dispatch(Events::ADAPT_SIMPLE_FORM, $event);
         $tabPane = $event->getTabPane();
 
-        $form = $this->createForm($formType, $helper, $configurator->getAdminTypeOptions());
+        $form = $this->createForm($formType, $helper, $event->getOptions());
 
         if ($request->isMethod('POST')) {
             if ($tabPane) {
@@ -241,7 +241,7 @@ abstract class AdminListController extends Controller
         $event = $this->container->get('event_dispatcher')->dispatch(Events::ADAPT_SIMPLE_FORM, $event);
         $tabPane = $event->getTabPane();
 
-        $form = $this->createForm($formType, $helper, $configurator->getAdminTypeOptions());
+        $form = $this->createForm($formType, $helper, $event->getOptions());
 
         if ($request->isMethod('POST')) {
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

In AdminListController type options come from the configuration. They are passed to the AdaptSimpleFormEvent but then form factory use the same array. 

Due to the array isn't passed to the event by reference it's impossible to modify form options in the AdaptSimpleFormEvent listener. 

I have passed to the form factory options from the event rather than configuration. 