### PR TITLE
[MediaBundle] Add web_root configuration to support both web and public as the root dir for uploads

### DIFF
--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\DependencyInjection;
 
+use Kunstmaan\MediaBundle\Utils\SymfonyVersion;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -37,6 +38,10 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('blacklisted_extensions')
                     ->defaultValue(array('php', 'htaccess'))
                     ->prototype('scalar')->end()
+                ->end()
+                ->scalarNode('web_root')
+                    ->defaultValue(SymfonyVersion::getRootWebPath())
+                    ->cannotBeEmpty()
                 ->end()
             ->end();
 

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -40,6 +40,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_media.remote_video', $config['remote_video']);
         $container->setParameter('kunstmaan_media.enable_pdf_preview', $config['enable_pdf_preview']);
         $container->setParameter('kunstmaan_media.blacklisted_extensions', $config['blacklisted_extensions']);
+        $container->setParameter('kunstmaan_media.full_media_path', $config['web_root'] . '%kunstmaan_media.media_path%');
 
         $loader->load('services.yml');
         $loader->load('handlers.yml');

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -110,7 +110,7 @@ services:
     kunstmaan_media.filesystem_adapter:
         class: Gaufrette\Adapter\Local
         arguments:
-            - '%kernel.root_dir%/../web%kunstmaan_media.media_path%'
+            - '%kunstmaan_media.full_media_path%'
             - true
 
     kunstmaan_media.filesystem:

--- a/src/Kunstmaan/MediaBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MediaBundle\Tests\DependencyInjection;
 use Kunstmaan\MediaBundle\DependencyInjection\Configuration;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class ConfigurationTest
@@ -31,8 +32,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
                 'dailymotion' => false,
             ],
             'enable_pdf_preview' => true,
-            'blacklisted_extensions' => []
+            'blacklisted_extensions' => [],
+            'web_root' => '%kernel.project_dir%/web'
         ];
+
+        if (Kernel::VERSION_ID >= 40000) {
+            $array['web_root'] = '%kernel.project_dir%/public';
+        }
 
         $this->assertProcessedConfigurationEquals([$array], $array);
     }

--- a/src/Kunstmaan/MediaBundle/Tests/Utils/SymfonyVersionTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Utils/SymfonyVersionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Tests\Utils;
+
+use Kunstmaan\MediaBundle\Utils\SymfonyVersion;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @covers \Kunstmaan\MediaBundle\Utils\SymfonyVersion
+ */
+class SymfonyVersionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetRootWebPath()
+    {
+        $path = SymfonyVersion::getRootWebPath();
+        $this->assertStringStartsWith('%kernel.project_dir%/', $path);
+        $this->assertStringEndsWith(Kernel::VERSION_ID < 40000 ? 'web' : 'public', $path);
+    }
+
+    public function testIsKernelLessThan()
+    {
+        $this->assertTrue(SymfonyVersion::isKernelLessThan(100, 100, 100));
+        $this->assertFalse(SymfonyVersion::isKernelLessThan(1, 1, 1));
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Utils/SymfonyVersion.php
+++ b/src/Kunstmaan/MediaBundle/Utils/SymfonyVersion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Utils;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @internal
+ */
+class SymfonyVersion
+{
+    /**
+     * @return string
+     */
+    public static function getRootWebPath()
+    {
+        return sprintf('%%kernel.project_dir%%/%s', self::isKernelLessThan(4) ? 'web' : 'public');
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isKernelLessThan($major, $minor = null, $patch = null)
+    {
+        return static::kernelVersionCompare('<', $major, $minor, $patch);
+    }
+
+    /**
+     * @return bool
+     */
+    private static function kernelVersionCompare($operator, $major, $minor = null, $patch = null)
+    {
+        return version_compare(Kernel::VERSION_ID, sprintf("%d%'.02d%'.02d", $major, $minor ?: 0, $patch ?: 0), $operator);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In sf4 the web root was moved from `web` to `public` but the web directory was hardcoded for the full media upload path in our code. This change adds a configuration option to the mediabundle to override the web root path. Default it will use the symfony kernel version to set a sensible default value, `web` for <sf4 and `public` for >sf4.
