### PR TITLE
[AdminBundle] Don't depend on monolog implementation of the logger

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/LoginListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/LoginListener.php
@@ -4,7 +4,7 @@ namespace Kunstmaan\AdminBundle\EventListener;
 
 use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 class LoginListener
 {
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 
@@ -26,10 +26,10 @@ class LoginListener
     /**
      * Constructor
      *
-     * @param Logger         $logger         The logger
-     * @param VersionChecker $versionChecker The version checker
+     * @param LoggerInterface $logger         The logger
+     * @param VersionChecker  $versionChecker The version checker
      */
-    public function __construct(Logger $logger, VersionChecker $versionChecker)
+    public function __construct(LoggerInterface $logger, VersionChecker $versionChecker)
     {
         $this->logger         = $logger;
         $this->versionChecker = $versionChecker;
@@ -46,7 +46,7 @@ class LoginListener
         $user = $event->getAuthenticationToken()->getUser();
 
         if ($user instanceof UserInterface) {
-            $this->logger->addInfo($user . ' successfully logged in to the cms');
+            $this->logger->info($user . ' successfully logged in to the cms');
             $this->versionChecker->periodicallyCheck();
         }
     }

--- a/src/Kunstmaan/AdminBundle/Tests/EventListener/LoginListenerTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/EventListener/LoginListenerTest.php
@@ -5,8 +5,8 @@ namespace Kunstmaan\AdminBundle\Tests\EventListener;
 use Kunstmaan\AdminBundle\Entity\User;
 use Kunstmaan\AdminBundle\EventListener\LoginListener;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
-use Monolog\Logger;
 use PHPUnit_Framework_TestCase;
+use Psr\Log\AbstractLogger;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
@@ -14,13 +14,13 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
 {
     public function testListener()
     {
-        $logger = $this->createMock(Logger::class);
+        $logger = $this->createMock(AbstractLogger::class);
         $version = $this->createMock(VersionChecker::class);
         $token = $this->createMock(TokenInterface::class);
         $user = $this->createMock(User::class);
         $event = $this->createMock(InteractiveLoginEvent::class);
 
-        $logger->expects($this->once())->method('addInfo')->willReturn(true);
+        $logger->expects($this->once())->method('info')->willReturn(true);
         $version->expects($this->once())->method('periodicallyCheck')->willReturn(true);
         $event->expects($this->once())->method('getAuthenticationToken')->willReturn($token);
         $token->expects($this->once())->method('getUser')->willReturn($user);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Don't depend on an implementation of the logger but use the abstraction instead. Discovered while splitting the `symfony/symfony` package.
