### PR TITLE
[MediaBundle] Skip test if ghostscript is not installed

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Helper/Transformer/PdfTransformerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Helper/Transformer/PdfTransformerTest.php
@@ -53,6 +53,11 @@ class PdfTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testApplyWritesJpg()
     {
+        system('which gs > /dev/null', $returnCode);
+        if ($returnCode !== 0) {
+            $this->markTestSkipped('Ghostscript is not installed.');
+        }
+
         $pdfFilename = $this->tempDir . '/sample.pdf';
         $jpgFilename = $pdfFilename.'.jpg';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When running tests on your local machine ghostscript might not be installed. So this tests fails everytime. Skip the test when ghostscript is not installed, on travis ghostscript will be available.