### PR TITLE
[NodeBundle] Remove unused vardumper use

### DIFF
--- a/src/Kunstmaan/ArticleBundle/Router/TagCategoryRouter.php
+++ b/src/Kunstmaan/ArticleBundle/Router/TagCategoryRouter.php
@@ -6,7 +6,6 @@ use Kunstmaan\NodeBundle\Router\SlugRouter;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\VarDumper\VarDumper;
 
 class TagCategoryRouter extends SlugRouter
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Discovered an unused use during the split of the `symfony/symfony` package. Vardumper is no dependency of the bundles package and this use is unused. 