### PR TITLE
[AllBundles] Support symfony/swiftmailerBundle 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^1.3",
-        "symfony/swiftmailer-bundle": "^2.3",
+        "symfony/swiftmailer-bundle": "^2.3|^3.0",
         "symfony/monolog-bundle": "~2.8|~3.0",
         "symfony/security-acl": "~2.8|~3.0",
         "sensio/framework-extra-bundle": "^5.0",

--- a/src/Kunstmaan/FormBundle/Helper/FormMailer.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormMailer.php
@@ -5,7 +5,6 @@ namespace Kunstmaan\FormBundle\Helper;
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Swift_Mailer;
 use Swift_Message;
-use Swift_Mime_Message;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -46,18 +45,21 @@ class FormMailer implements FormMailerInterface
         $request = $this->container->get('request_stack')->getCurrentRequest();
 
         $toArr = explode("\r\n", $to);
-        /* @var $message Swift_Mime_Message */
-        $message = Swift_Message::newInstance()->setSubject($subject)->setFrom($from)->setTo($toArr);
-        $message->setBody(
-            $this->templating->render(
-                'KunstmaanFormBundle:Mailer:mail.html.twig',
-                array(
-                    'submission' => $submission,
-                    'host'       => $request->getScheme() . '://' . $request->getHttpHost()
-                )
-            ),
-            'text/html'
-        );
+
+        $message = (new Swift_Message($subject))
+            ->setFrom($from)
+            ->setTo($toArr)
+            ->setBody(
+                $this->templating->render(
+                    'KunstmaanFormBundle:Mailer:mail.html.twig',
+                    array(
+                        'submission' => $submission,
+                        'host'       => $request->getScheme() . '://' . $request->getHttpHost()
+                    )
+                ),
+                'text/html'
+            );
+
         $this->mailer->send($message);
     }
 }

--- a/src/Kunstmaan/FormBundle/Tests/Helper/FormMailerTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Helper/FormMailerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kunstmaan\FormBundle\Tests\Helper;
+
+use Kunstmaan\FormBundle\Entity\FormSubmission;
+use Kunstmaan\FormBundle\Helper\FormMailer;
+use Symfony\Bundle\TwigBundle\TwigEngine;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class FormMailerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testSendContactMail()
+    {
+        $mailer = $this->createMock(\Swift_Mailer::class);
+        $twigEngine = $this->createMock(TwigEngine::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $request = $this->createMock(Request::class);
+        $requestStack = $this->createMock(RequestStack::class);
+
+        $mailer->expects($this->once())->method('send');
+        $request->expects($this->once())->method('getScheme')->will($this->returnValue('http'));
+        $request->expects($this->once())->method('getHttpHost')->will($this->returnValue('example.com'));
+        $requestStack->expects($this->once())->method('getCurrentRequest')->will($this->returnValue($request));
+        $container->expects($this->once())->method('get')->will($this->returnValue($requestStack));
+
+        $formMailer = new FormMailer($mailer, $twigEngine, $container);
+
+        $formSubmission = $this->createMock(FormSubmission::class);
+
+        $formMailer->sendContactMail($formSubmission, 'from@example.com', 'to@example.com', 'subject');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

To support sf4 we also need to allow `symfony/swiftmailer-bundle` 3.0. But swiftmailer 3 only supports swiftmailer 6. To make sure our code works with both swiftmailer 5 and 6 I've modified the code so we are using the forward compatibility layer.
