### PR TITLE
[AllBundles] Explicitly set the template path for user bundle templates

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
@@ -44,7 +44,7 @@ class DefaultController extends Controller
      * The admin of the index page
      *
      * @Route("/adminindex", name="KunstmaanAdminBundle_homepage_admin")
-     * @Template()
+     * @Template("@KunstmaanAdmin/Default/editIndex.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -29,7 +29,7 @@ class FolderController extends Controller
      * @param int     $folderId The folder id
      *
      * @Route("/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_show")
-     * @Template()
+     * @Template("@KunstmaanMedia/Folder/show.html.twig")
      *
      * @return array
      */

--- a/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
@@ -53,7 +53,7 @@ class GroupsController extends BaseSettingsController
      *
      * @Route("/add", name="KunstmaanUserManagementBundle_settings_groups_add")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Groups/add.html.twig")
      *
      * @throws AccessDeniedException
      * @return array
@@ -96,7 +96,7 @@ class GroupsController extends BaseSettingsController
      *
      * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_edit")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Groups/edit.html.twig")
      *
      * @throws AccessDeniedException
      * @return array
@@ -141,7 +141,6 @@ class GroupsController extends BaseSettingsController
      *
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_delete")
      * @Method({"GET", "POST"})
-     * @Template()
      *
      * @throws AccessDeniedException
      * @return RedirectResponse

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -50,7 +50,7 @@ class RolesController extends BaseSettingsController
      *
      * @Route("/add", name="KunstmaanUserManagementBundle_settings_roles_add")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Roles/add.html.twig")
      *
      * @throws AccessDeniedException
      * @return array|RedirectResponse
@@ -93,7 +93,7 @@ class RolesController extends BaseSettingsController
      *
      * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_roles_edit")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Roles/edit.html.twig")
      *
      * @throws AccessDeniedException
      * @return array|RedirectResponse

--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -76,7 +76,7 @@ class UsersController extends BaseSettingsController
      *
      * @Route("/add", name="KunstmaanUserManagementBundle_settings_users_add")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Users/add.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
@@ -134,7 +134,7 @@ class UsersController extends BaseSettingsController
      *
      * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_users_edit")
      * @Method({"GET", "POST"})
-     * @Template()
+     * @Template("@KunstmaanUserManagement/Users/edit.html.twig")
      *
      * @throws AccessDeniedException
      * @return array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Follow up PR for #2045. Some user templates could not be loaded as the directory name is with a capital letter but the guesser will look for the lowercase version. Error caught by the behat tests of the standard editition.
