### PR TITLE
[MenuBundle] Fix menu item sorting issue with multiple menus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "white-october/pagerfanta-bundle": "~1.0",
         "kunstmaan/google-api-custom": "~1.0",
         "ddeboer/data-import-bundle": "~0.1",
-        "gedmo/doctrine-extensions": "~2.3",
+        "gedmo/doctrine-extensions": "^2.4.34",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "stof/doctrine-extensions-bundle": "~1.1",
         "liip/imagine-bundle": "~1.7",

--- a/src/Kunstmaan/MenuBundle/Entity/BaseMenuItem.php
+++ b/src/Kunstmaan/MenuBundle/Entity/BaseMenuItem.php
@@ -34,6 +34,7 @@ abstract class BaseMenuItem extends AbstractEntity
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MenuBundle\Entity\Menu", inversedBy="items")
      * @ORM\JoinColumn(name="menu_id", referencedColumnName="id")
      * @Assert\NotNull()
+     * @Gedmo\TreeRoot(identifierMethod="getMenu")
      */
     protected $menu;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

There are issues with sorting menu items when you have multiple menu's defined. This causes the sorting to happen over all menu items instead of only checking the items within the current menu.

A fix was proposed in PR #1812 but it was closed as it was implemented in Atlantic18/DoctrineExtensions#1877. The necessary fix on our end still needed to be done. So I bumped the minimum requirement for `gedmo/doctrine-extensions` to the version with the fix and added the required annotation on our `MenuItem` entity.
