### PR TITLE
[NodeBundle] Deprecate unused TemplateEngine constructor argument

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -25,10 +25,19 @@ class RenderContextListener
      * @param EngineInterface        $templating
      * @param EntityManagerInterface $em
      */
-    public function __construct(EngineInterface $templating, EntityManagerInterface $em)
+    public function __construct(/* EngineInterface|EntityManagerInterface */ $em, EntityManagerInterface $emOld = null)
     {
-        $this->templating = $templating;
-        $this->em         = $em;
+        if ($em instanceof EngineInterface) {
+            // NEXT_MAJOR Also remove the symfony/templating dependency as it is unused after the removal of the templating parameter.
+            @trigger_error(sprintf('Passing a templating engine as the first argument of "%s" is deprecated since KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0. Remove the template engine service argument.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->templating = $em;
+            $this->em = $emOld;
+
+            return;
+        }
+
+        $this->em = $em;
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -159,7 +159,7 @@ services:
 
     kunstmaan_node.render.context.listener:
         class: Kunstmaan\NodeBundle\EventListener\RenderContextListener
-        arguments: ['@templating', '@doctrine.orm.entity_manager']
+        arguments: ['@doctrine.orm.entity_manager']
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

This was a left over of the clean up in PR #544. I've deprecated the unused `$templating` argument so it can be removed in the next major.

I wanted to add a test to check the deprecation behavior. But this is not possible because we run our tests with codeception. (see explanation below)

```php
<?php

namespace Kunstmaan\NodeBundle\Tests\EventListener;

use Doctrine\ORM\EntityManagerInterface;
use Kunstmaan\NodeBundle\EventListener\RenderContextListener;
use Symfony\Component\Templating\EngineInterface;

class RenderContextListenerTest extends \PHPUnit\Framework\TestCase
{
    /**
     * @group legacy
     * @expectedDeprecation Passing a templating engine as the first argument of "Kunstmaan\NodeBundle\EventListener\RenderContextListener::__construct" is deprecated since KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0. Remove the template engine service argument.
     */
    public function test__construct()
    {
        $templateEngine = $this->createMock(EngineInterface::class);
        $em = $this->createMock(EntityManagerInterface::class);

        new RenderContextListener($templateEngine, $em);
    }
}
```

The test checks the deprecation behavior by using the `@expectedDeprecation` annotation provided by `symfony/phpunit-bridge`. This annotation allows to test classes if they throw the correct deprecation warning. But in the current codeception setup it's not possible to use this listener as codeception doesn't use `the phpunit.xml` (where you should register the phpunit-bridge listener) or you have no option to manually set the listener in the codeception config.

Is it even necessary to run our testsuite with codeception? As we currently only have phpunit tests and integration tests can easily be done with behat (as it is already the case on the standard-edition). I would suggest to switch back to phpunit as we can cover all our cases with phpunit and have the extra test helpers from the `symfony/phpunit-bridge`