### PR TITLE
[NodeSearchBundle] check if params exist while building container

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -54,7 +54,12 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
      */
     public function prepend(ContainerBuilder $container)
     {
-        $this->useElasticSearchVersion6 = ElasticSearchUtil::useVersion6(array($container->getParameter('kunstmaan_search.hostname').':'.$container->getParameter('searchport')));
+        $hosts = [];
+        if ($container->hasParameter('kunstmaan_search.hostname') && $container->hasParameter('kunstmaan_search.port')) {
+            $hosts[] = $container->getParameter('kunstmaan_search.hostname').':'.$container->getParameter('kunstmaan_search.port');
+        }
+
+        $this->useElasticSearchVersion6 = ElasticSearchUtil::useVersion6($hosts);
 
         if ($this->useElasticSearchVersion6) {
             $mapping = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This is a fix upon the implementation of #2075. Param `kunstmaan_search.hostnam`does not exist at the beginning state of any project so it will crash... hard.
