### PR TITLE
[AdminBundle] Fix broken console exception tests

### DIFF
--- a/src/Kunstmaan/AdminBundle/Tests/EventListener/ConsoleExceptionListenerTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/EventListener/ConsoleExceptionListenerTest.php
@@ -7,6 +7,7 @@ use Kunstmaan\AdminBundle\Command\ApplyAclCommand;
 use Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 
 class ConsoleExceptionListenerTest extends PHPUnit_Framework_TestCase
@@ -14,16 +15,21 @@ class ConsoleExceptionListenerTest extends PHPUnit_Framework_TestCase
     public function testListener()
     {
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->willReturn(true);
         $listener = new ConsoleExceptionListener($logger);
 
-        $command = new ApplyAclCommand();
-        $exception = new Exception();
-
         $event = $this->createMock(ConsoleExceptionEvent::class);
-        $event->expects($this->once())->method('getCommand')->willReturn($command);
-        $event->expects($this->once())->method('getException')->willReturn($exception);
+        if (class_exists(ConsoleErrorEvent::class)){
+            $this->assertNull($listener->onConsoleException($event));
+        } else {
+            $command = new ApplyAclCommand();
+            $exception = new Exception();
 
-        $listener->onConsoleException($event);
+            $logger->expects($this->once())->method('error')->willReturn(true);
+
+            $event->expects($this->once())->method('getCommand')->willReturn($command);
+            $event->expects($this->once())->method('getException')->willReturn($exception);
+
+            $listener->onConsoleException($event);
+        }
     }
 }

--- a/src/Kunstmaan/AdminBundle/Tests/EventListener/ConsoleExceptionSubscriberTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/EventListener/ConsoleExceptionSubscriberTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\EventListener;
+
+use Exception;
+use Codeception\Test\Unit;
+use Kunstmaan\AdminBundle\Command\ApplyAclCommand;
+use Kunstmaan\AdminBundle\EventListener\ConsoleExceptionSubscriber;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsoleExceptionSubscriberTest extends Unit
+{
+    public function testListener()
+    {
+        if (!class_exists(ConsoleErrorEvent::class)) {
+            // Nothing to test
+            return;
+        }
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->willReturn(true);
+        $subscriber = new ConsoleExceptionSubscriber($logger);
+
+        $command = new ApplyAclCommand();
+        $exception = new Exception();
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $event = new ConsoleErrorEvent($input, $output, $exception, $command);
+
+        $subscriber->onConsoleError($event);
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Tests/KunstmaanAdminBundleTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/KunstmaanAdminBundleTest.php
@@ -18,7 +18,7 @@ class KunstmaanAdminBundleTest extends PHPUnit_Framework_TestCase
         $resources = $containerBuilder->getResources();
         $extensions = $containerBuilder->getExtensions();
 
-        $this->assertCount(6, $resources);
+        $this->assertCount(7, $resources);
         $this->assertCount(1, $extensions);
         $this->assertArrayHasKey('kunstmaan_admin', $extensions);
         $this->assertInstanceOf(KunstmaanAdminExtension::class, $extensions['kunstmaan_admin']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This fixes the tests that were broken by PR #2020 
