### PR TITLE
[AllBundles] Bump minimum php version to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
 
 matrix:
   fast_finish: true
@@ -18,7 +17,7 @@ matrix:
 before_install:
   - cp /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ~/xdebug.ini
   - phpenv config-rm xdebug.ini || true
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
   - composer selfupdate
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   - wget https://scrutinizer-ci.com/ocular.phar
@@ -29,9 +28,6 @@ before_install:
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 before_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MAJOR_VERSION;") -le 5 ]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - phpenv config-add ~/xdebug.ini || true
 
 script: ./vendor/codeception/codeception/codecept run --coverage --coverage-xml

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.1",
         "symfony/symfony": "~3.4",
         "doctrine/orm": "^2.5",
         "doctrine/dbal": "^2.5",

--- a/docs/installation/system-requirements.md
+++ b/docs/installation/system-requirements.md
@@ -1,7 +1,7 @@
 # System Requirements
 
 * PHP
-    * minimum version is PHP 5.6, but also working great with PHP 7.0 or PHP 7.1.
+    * minimum version is PHP 7.1
     * JSON needs to be enabled
     * ctype needs to be enabled
     * curl needs to be enabled

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -30,7 +30,7 @@ Starting fresh has a lot of advantages and going further we defined the basic pr
 2. Added on top of the framework we included a lot of **community components** that provide our extended framework with functionality like Image resizing, pagination, user management, an advanced router, etc.
 3. And we wrap all this into a **user friendly admin interface with content management** functionalities.
 
-We are able to support PHP 5.4 and up, and all Symfony versions since 2.3. We constantly test and adapt to be able to run the latest and greatest from Symfony and the community.
+We support PHP 7.1 and up, and Symfony 3.4. We constantly test and adapt to be able to run the latest and greatest from Symfony and the community.
 
 # Open Source
 

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "doctrine/orm": "~2.2,>=2.2.3",
         "friendsofsymfony/user-bundle": "2.0.*",

--- a/src/Kunstmaan/AdminListBundle/composer.json
+++ b/src/Kunstmaan/AdminListBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "sensio/framework-extra-bundle": ">=2.3.4,<4.0.0",
         "white-october/pagerfanta-bundle": "1.0.*",

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "white-october/pagerfanta-bundle": "1.0.*",
         "kunstmaan/admin-bundle": "~3.2",

--- a/src/Kunstmaan/BehatBundle/composer.json
+++ b/src/Kunstmaan/BehatBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.3",
         "behat/behat": "~2.5.0",
         "behat/mink": "*",

--- a/src/Kunstmaan/DashboardBundle/composer.json
+++ b/src/Kunstmaan/DashboardBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.6",
         "doctrine/orm": "^2.2.3",
         "alchemy/google-plus-api-client": "~0.6.5"

--- a/src/Kunstmaan/FixturesBundle/composer.json
+++ b/src/Kunstmaan/FixturesBundle/composer.json
@@ -18,7 +18,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.4.0",
+    "php": "^7.1",
     "symfony/symfony": "~2.3",
     "doctrine/orm": "^2.2.3",
     "doctrine/doctrine-bundle": "~1.2",

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "ddeboer/data-import-bundle": "0.1.*",
         "gedmo/doctrine-extensions": "2.3.*",

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "doctrine/orm": "^2.2.3",
         "sensio/generator-bundle": "~2.5|~3.0",

--- a/src/Kunstmaan/LeadGenerationBundle/composer.json
+++ b/src/Kunstmaan/LeadGenerationBundle/composer.json
@@ -20,7 +20,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.5.0",
+    "php": "^7.1",
     "symfony/symfony": "~2.8",
     "kunstmaan/adminlist-bundle": "~3.2"
   },

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "^2.8",
         "gedmo/doctrine-extensions": "2.3.*",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0",

--- a/src/Kunstmaan/MediaPagePartBundle/composer.json
+++ b/src/Kunstmaan/MediaPagePartBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "kunstmaan/pagepart-bundle": "~3.2",
         "kunstmaan/media-bundle": "~3.2",

--- a/src/Kunstmaan/MenuBundle/composer.json
+++ b/src/Kunstmaan/MenuBundle/composer.json
@@ -18,7 +18,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.5.0",
+    "php": "^7.1",
     "symfony/symfony": "~2.8",
     "kunstmaan/adminlist-bundle": "~3.2",
     "kunstmaan/node-bundle": "~3.2"

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "gedmo/doctrine-extensions": "2.3.*",
         "symfony-cmf/routing-bundle": "dev-master",

--- a/src/Kunstmaan/NodeSearchBundle/composer.json
+++ b/src/Kunstmaan/NodeSearchBundle/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "white-october/pagerfanta-bundle": "1.0.*",
         "ruflin/elastica": "~3.2",

--- a/src/Kunstmaan/PagePartBundle/composer.json
+++ b/src/Kunstmaan/PagePartBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "kunstmaan/admin-bundle": "~3.2",
         "kunstmaan/utilities-bundle": "~3.2",

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "symfony-cmf/routing-bundle": "dev-master",
         "symfony-cmf/routing": "~1.4",

--- a/src/Kunstmaan/SearchBundle/composer.json
+++ b/src/Kunstmaan/SearchBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "ruflin/elastica": "~3.2"
     },

--- a/src/Kunstmaan/SeoBundle/composer.json
+++ b/src/Kunstmaan/SeoBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "gedmo/doctrine-extensions": "2.3.*",
         "kunstmaan/admin-bundle": "~3.2",

--- a/src/Kunstmaan/SitemapBundle/composer.json
+++ b/src/Kunstmaan/SitemapBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "kunstmaan/admin-bundle": "~3.2",
         "kunstmaan/node-bundle": "~3.2",

--- a/src/Kunstmaan/TaggingBundle/composer.json
+++ b/src/Kunstmaan/TaggingBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "fpn/doctrine-extensions-taggable": "0.9.0",
         "kunstmaan/admin-bundle": "~3.2",

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "doctrine/orm": "^2.2.3",
         "doctrine/doctrine-bundle": "~1.2",

--- a/src/Kunstmaan/UserManagementBundle/composer.json
+++ b/src/Kunstmaan/UserManagementBundle/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "kunstmaan/adminlist-bundle": "~3.2",
         "kunstmaan/admin-bundle": "~3.2",

--- a/src/Kunstmaan/UtilitiesBundle/composer.json
+++ b/src/Kunstmaan/UtilitiesBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.8",
         "doctrine/orm": "~2.2,>=2.2.3",
         "behat/transliterator": "~1.2"

--- a/src/Kunstmaan/VotingBundle/composer.json
+++ b/src/Kunstmaan/VotingBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.1",
         "symfony/symfony": "~2.3",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-fixtures-bundle": "~2.2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

***SHOULD ONLY BE MERGED WHEN 5.1 IS TAGGED AND THE MAINTANCE BRANCH IS CREATED***

As discussed we are bumping the minimum php version to 7.1, as this will be the minimum support version by the end of the year (http://php.net/supported-versions.php). This is also required for the symfony 4 support (dependencies that support sf4 require php 7.1)
