### PR TITLE
[NodeSearchBundle] Fix search index of childpages of a structured node

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "behat/mink-goutte-driver": "dev-master",
         "behat/mink-sahi-driver": "dev-master",
         "symfony/phpunit-bridge": "~3.0",
-        "phpunit/phpunit": "~4.4",
+        "phpunit/phpunit": "^5.7",
         "fzaninotto/faker": "~1.6",
         "nelmio/alice": "^2.1.4"
     },

--- a/src/Kunstmaan/NodeSearchBundle/EventListener/NodeIndexUpdateEventListener.php
+++ b/src/Kunstmaan/NodeSearchBundle/EventListener/NodeIndexUpdateEventListener.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeSearchBundle\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Kunstmaan\NodeBundle\Event\NodeEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -117,7 +118,7 @@ class NodeIndexUpdateEventListener implements NodeIndexUpdateEventListenerInterf
         $lang = $nodeTranslation->getLang();
         foreach ($nodeTranslation->getNode()->getParents() as $node) {
             $nodeNT = $node->getNodeTranslation($lang, true);
-            if ($nodeNT && !$nodeNT->isOnline()) {
+            if ($nodeNT && !$nodeNT->isOnline() && !$nodeNT instanceof StructureNode) {
                 return true;
             }
         }

--- a/src/Kunstmaan/NodeSearchBundle/Tests/EventListener/NodeIndexUpdateEventListenerTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/EventListener/NodeIndexUpdateEventListenerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Tests\EventListener;
+
+use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\StructureNode;
+use Kunstmaan\NodeBundle\Event\NodeEvent;
+use Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration;
+use Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener;
+
+class NodeIndexUpdateEventListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUpdateOfChildPageWithStructuredNodeParent()
+    {
+        $parentNodeTranslation = $this->createMock(StructureNode::class);
+        $parentNodeTranslation->method('isOnline')->willReturn(false);
+
+        $parentNode = $this->createMock(Node::class);
+        $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
+
+        $node = $this->createMock(Node::class);
+        $node->method('getParents')->willReturn([
+            $parentNode
+        ]);
+
+        $nodeTranslation = $this->createMock(NodeTranslation::class);
+        $nodeTranslation->method('getId')->willReturn(1);
+        $nodeTranslation->method('getLang')->willReturn('nl');
+        $nodeTranslation->method('getNode')->willReturn($node);
+
+        $nodeEvent = $this->getMockBuilder(NodeEvent::class)->disableOriginalConstructor()->getMock();
+
+        $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
+
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(true)));
+        $listener->onPostPersist($nodeEvent);
+    }
+
+    public function testUpdateOfChildPageWithStructuredNodeParentAndOfflineParent()
+    {
+        $parentNodeTranslation = $this->createMock(StructureNode::class);
+        $parentNodeTranslation->method('isOnline')->willReturn(false);
+
+        $parentNodeTranslation2 = $this->createMock(NodeTranslation::class);
+        $parentNodeTranslation2->method('isOnline')->willReturn(false);
+
+        $parentNode1 = $this->createMock(Node::class);
+        $parentNode1->method('getNodeTranslation')->willReturn($parentNodeTranslation);
+        $parentNode2 = $this->createMock(Node::class);
+        $parentNode2->method('getNodeTranslation')->willReturn($parentNodeTranslation2);
+
+        $node = $this->createMock(Node::class);
+        $node->method('getParents')->willReturn([
+            $parentNode1,
+            $parentNode2,
+        ]);
+
+        $nodeTranslation = $this->createMock(NodeTranslation::class);
+        $nodeTranslation->method('getId')->willReturn(1);
+        $nodeTranslation->method('getLang')->willReturn('nl');
+        $nodeTranslation->method('getNode')->willReturn($node);
+
+        $nodeEvent = $this->getMockBuilder(NodeEvent::class)->disableOriginalConstructor()->getMock();
+
+        $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
+
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
+        $listener->onPostPersist($nodeEvent);
+    }
+
+    public function testUpdateOfChildPageWithOfflineParent()
+    {
+        $parentNodeTranslation = $this->createMock(NodeTranslation::class);
+        $parentNodeTranslation->method('isOnline')->willReturn(false);
+
+        $parentNode = $this->createMock(Node::class);
+        $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
+
+        $node = $this->createMock(Node::class);
+        $node->method('getParents')->willReturn([$parentNode]);
+
+        $nodeTranslation = $this->createMock(NodeTranslation::class);
+        $nodeTranslation->method('getId')->willReturn(1);
+        $nodeTranslation->method('getLang')->willReturn('nl');
+        $nodeTranslation->method('getNode')->willReturn($node);
+
+        $nodeEvent = $this->getMockBuilder(NodeEvent::class)->disableOriginalConstructor()->getMock();
+
+        $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
+
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
+        $listener->onPostPersist($nodeEvent);
+    }
+
+
+    public function testUpdateOfChildPageWithOnlineParent()
+    {
+        $parentNodeTranslation = $this->createMock(NodeTranslation::class);
+        $parentNodeTranslation->method('isOnline')->willReturn(true);
+
+        $parentNode = $this->createMock(Node::class);
+        $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
+
+        $node = $this->createMock(Node::class);
+        $node->method('getParents')->willReturn([$parentNode]);
+
+        $nodeTranslation = $this->createMock(NodeTranslation::class);
+        $nodeTranslation->method('getId')->willReturn(1);
+        $nodeTranslation->method('getLang')->willReturn('nl');
+        $nodeTranslation->method('getNode')->willReturn($node);
+
+        $nodeEvent = $this->getMockBuilder(NodeEvent::class)->disableOriginalConstructor()->getMock();
+
+        $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
+
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(true)));
+        $listener->onPostPersist($nodeEvent);
+    }
+
+    private function getContainer($searchConfigMock)
+    {
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $container
+            ->expects($this->any())
+            ->method('get')
+            ->with($this->equalTo('kunstmaan_node_search.search_configuration.node'))
+            ->willReturn($searchConfigMock)
+        ;
+
+        return $container;
+    }
+
+    private function getSearchConfiguration($expectCall)
+    {
+        $searchConfig = $this->createMock(NodePagesConfiguration::class);
+        $searchConfig
+            ->expects($expectCall ? $this->once() : $this->never())
+            ->method('indexNodeTranslation')
+            ->willReturn(null)
+        ;
+
+        return $searchConfig;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #2083 
| Tests pass? | Yes 🎉 

Indexing child pages of a structured node (or any of the parents is a structured node) was broken because structured nodes are always offline. Added a check to allow structured node parents to be offline. I've also added tests to check the expected behavior. 
