### PR TITLE
[AllBundles] Added support for both symfony 3 and 4 for our overrides on the container access methods

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
@@ -3,30 +3,16 @@
 namespace Kunstmaan\AdminBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Kernel;
 
-class BaseSettingsController extends Controller
-{
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function get($id)
+if (Kernel::VERSION_ID < 40000) {
+    class_alias('Kunstmaan\AdminBundle\Controller\Symfony3BaseSettingsController', 'Kunstmaan\AdminBundle\Controller\BaseSettingsController');
+} else {
+    class_alias('Kunstmaan\AdminBundle\Controller\Symfony4BaseSettingsController', 'Kunstmaan\AdminBundle\Controller\BaseSettingsController');
+}
+
+if (false) {
+    class BaseSettingsController extends Controller
     {
-        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
-
-        return parent::get($id);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function getParameter($name)
-    {
-        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
-
-        return parent::getParameter($name);
     }
 }

--- a/src/Kunstmaan/AdminBundle/Controller/Symfony3BaseSettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/Symfony3BaseSettingsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class Symfony3BaseSettingsController extends Controller
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get($id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
+
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter($name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Controller/Symfony4BaseSettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/Symfony4BaseSettingsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class Symfony4BaseSettingsController extends Controller
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get(string $id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
+
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter(string $name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -26,33 +26,8 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 /**
  * AdminListController
  */
-abstract class AdminListController extends Controller
+abstract class AdminListController extends ContainerDeprecationController
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function get($id)
-    {
-        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
-
-        return parent::get($id);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function getParameter($name)
-    {
-        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
-
-        return parent::getParameter($name);
-    }
-
-
     /**
      * You can override this method to return the correct entity manager when using multiple databases ...
      *

--- a/src/Kunstmaan/AdminListBundle/Controller/ContainerDeprecationController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/ContainerDeprecationController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\Kernel;
+
+if (Kernel::VERSION_ID < 40000) {
+    class_alias('Kunstmaan\AdminListBundle\Controller\Symfony3ContainerDeprecationController', 'Kunstmaan\AdminListBundle\Controller\ContainerDeprecationController');
+} else {
+    class_alias('Kunstmaan\AdminListBundle\Controller\Symfony4ContainerDeprecationController', 'Kunstmaan\AdminListBundle\Controller\ContainerDeprecationController');
+}
+if (false) {
+    class ContainerDeprecationController extends Controller
+    {
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Controller/Symfony3ContainerDeprecationController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/Symfony3ContainerDeprecationController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class Symfony3ContainerDeprecationController extends Controller
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get($id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
+
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter($name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Controller/Symfony4ContainerDeprecationController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/Symfony4ContainerDeprecationController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class Symfony4ContainerDeprecationController extends Controller
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function get(string $id)
+    {
+        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
+
+        return parent::get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     */
+    protected function getParameter(string $name)
+    {
+        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
+
+        return parent::getParameter($name);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

We need to override the `get` and `getParameters` methods to throw deprecations on container access in controllers. But both methods are tagged internal so symfony can change them any time. And so they did in sf4, typehints for the method parameters were added. 

In the old setup it was not possible to support both the version with and without the typehints as php doesn't support parameter widening in version bellow php 7.2 or type narrowing at all. So this fixes that technical issue and allows us to continue the effort to support sf4 in our 5.x series.
