### PR TITLE
[MediaBundle] Liip imagine bundle version 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "gedmo/doctrine-extensions": "^2.4.34",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "stof/doctrine-extensions-bundle": "~1.1",
-        "liip/imagine-bundle": "~1.7",
+        "liip/imagine-bundle": "^2.0",
         "imagine/imagine": "~0.6",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "symfony-cmf/routing-bundle": "~2.0",

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
@@ -33,5 +33,14 @@ class MediaHandlerCompilerPass implements CompilerPassInterface
                 $definition->addMethodCall('addLoader', array(new Reference($id), $id));
             }
         }
+
+        // Inject the tagged resolvers into our cache manager override
+        if ($container->hasDefinition('kunstmaan_media.imagine.cache.manager')) {
+            $manager = $container->getDefinition('kunstmaan_media.imagine.cache.manager');
+
+            foreach ($container->findTaggedServiceIds('liip_imagine.cache.resolver') as $id => $tag) {
+                $manager->addMethodCall('addResolver', [$tag[0]['resolver'], new Reference($id)]);
+            }
+        }
     }
 }

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -51,12 +51,15 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         }
 
         $container->setParameter('liip_imagine.filter.loader.background.class', 'Kunstmaan\MediaBundle\Helper\Imagine\BackgroundFilterLoader');
-        $container->setParameter('liip_imagine.cache.manager.class', 'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager');
-        $container->setParameter('liip_imagine.cache.resolver.web_path.class', 'Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver');
-        $container->setParameter('liip_imagine.controller.class', 'Kunstmaan\MediaBundle\Helper\Imagine\ImagineController');
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('imagine.xml');
+
+        $container->setAlias('liip_imagine.controller', 'Kunstmaan\MediaBundle\Helper\Imagine\ImagineController')->setPublic(true);
+        $container->setAlias('Liip\ImagineBundle\Controller\ImagineController', 'Kunstmaan\MediaBundle\Helper\Imagine\ImagineController')->setPublic(true);
+        $container->setAlias('liip_imagine.cache.resolver.prototype.web_path', 'Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver');
+        $container->setAlias('liip_imagine.cache.manager', 'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager')->setPublic(true);
+        $container->setAlias('liip_imagine.filter.loader.background', 'kunstmaan_media.imagine.filter.loader.background')->setPublic(true);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Kunstmaan/MediaBundle/Helper/Transformer/PreviewTransformerInterface.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Transformer/PreviewTransformerInterface.php
@@ -2,9 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Helper\Transformer;
 
-use Liip\ImagineBundle\Imagine\Data\Transformer\TransformerInterface;
-
-interface PreviewTransformerInterface extends TransformerInterface
+interface PreviewTransformerInterface
 {
     /**
      * Return the path of the preview file.
@@ -14,4 +12,13 @@ interface PreviewTransformerInterface extends TransformerInterface
      * @return string
      */
     public function getPreviewFilename($absolutePath);
+
+    /**
+     * Apply the transformer on the absolute path and return an altered version of it.
+     *
+     * @param string $absolutePath
+     *
+     * @return string
+     */
+    public function apply($absolutePath);
 }

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -125,3 +125,37 @@ services:
         calls:
             - [setMimeTypeGuesser, ['@kunstmaan_media.mimetype_guesser.factory']]
             - [setExtensionGuesser, ['@kunstmaan_media.extension_guesser.factory']]
+
+    kunstmaan_media.imagine.filter.loader.background:
+        class: '%liip_imagine.filter.loader.background.class%'
+        arguments:
+            - '@liip_imagine'
+        tags:
+            - { name: 'liip_imagine.filter.loader', loader: 'background' }
+
+    Kunstmaan\MediaBundle\Helper\Imagine\ImagineController:
+        arguments:
+            - '@liip_imagine.service.filter'
+            - '@liip_imagine.data.manager'
+            - '@liip_imagine.cache.signer'
+        tags:
+            - { name: 'controller.service_arguments' }
+        public: true
+
+    Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver:
+        arguments:
+            - '@filesystem'
+            - '@router.request_context'
+            - ~ # will be injected by WebPathResolverFactory
+            - ~ # will be injected by WebPathResolverFactory
+            - '@liip_imagine.filter.configuration'
+        public: true
+        abstract: true
+
+    Kunstmaan\MediaBundle\Helper\Imagine\CacheManager:
+        arguments:
+            - '@liip_imagine.filter.configuration'
+            - '@router'
+            - '@liip_imagine.cache.signer'
+            - '@event_dispatcher'
+            - '%liip_imagine.cache.resolver.default%'

--- a/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/KunstmaanMediaExtensionTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/KunstmaanMediaExtensionTest.php
@@ -49,8 +49,5 @@ class KunstmaanMediaExtensionTest extends AbstractPrependableExtensionTestCase
         $this->assertContainerBuilderHasParameter('aviary_api_key', null);
         $this->assertContainerBuilderHasParameter('kunstmaan_media.media_path', '/uploads/media/');
         $this->assertContainerBuilderHasParameter('liip_imagine.filter.loader.background.class', 'Kunstmaan\MediaBundle\Helper\Imagine\BackgroundFilterLoader');
-        $this->assertContainerBuilderHasParameter('liip_imagine.cache.manager.class', 'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager');
-        $this->assertContainerBuilderHasParameter('liip_imagine.cache.resolver.web_path.class', 'Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver');
-        $this->assertContainerBuilderHasParameter('liip_imagine.controller.class', 'Kunstmaan\MediaBundle\Helper\Imagine\ImagineController');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

~~_**Only merge after #2090. Ping me after merge to rebase this PR**_~~

~~Diff best viewed against the prepare-5.2 branch [prepare-5.2-php-changes...liip-imagine-bundle-2-support](https://github.com/acrobat/KunstmaanBundlesCMS/compare/prepare-5.2-php-changes...acrobat:liip-imagine-bundle-2-support).~~

#2090 is merged, rebase done.

This PR upgrades the liip/imagine-bundle to version 2, as this is the first version that supports sf4. All custom overrides made in the kunstmaan/media-bundle are ported to the new version.