### PR TITLE
[MediaBundle] Fix issues with CreatePdfPreviewCommand

### DIFF
--- a/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MediaBundle\Command;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use \ImagickException;
+use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Helper\Transformer\PdfTransformer;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,7 +30,7 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
     /**
      * @var string
      */
-    private $rootDir;
+    private $webRoot;
 
     /**
      * @var bool
@@ -40,7 +41,7 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
      * @param EntityManagerInterface|null $em
      * @param PdfTransformer|null         $mediaManager
      */
-    public function __construct(/* EntityManagerInterface */ $em = null, /* PdfTransformer */ $pdfTransformer = null, $rootDir = null, $enablePdfPreview = null)
+    public function __construct(/* EntityManagerInterface */ $em = null, /* PdfTransformer */ $pdfTransformer = null, $webRoot = null, $enablePdfPreview = null)
     {
         parent::__construct();
 
@@ -54,7 +55,7 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
 
         $this->em = $em;
         $this->pdfTransformer = $pdfTransformer;
-        $this->rootDir = $rootDir;
+        $this->webRoot = $webRoot;
         $this->enablePdfPreview = $enablePdfPreview;
     }
 
@@ -75,12 +76,11 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
         if (null ===  $this->em) {
             $this->em = $this->getContainer()->get('doctrine.orm.entity_manager');
             $this->pdfTransformer = $this->getContainer()->get('kunstmaan_media.pdf_transformer');
-            $this->rootDir = $this->getContainer()->get('kernel')->getRootDir();
+            $this->webRoot = $this->getContainer()->getParameter('kunstmaan_media.web_root');
             $this->enablePdfPreview = $this->getContainer()->getParameter('kunstmaan_media.enable_pdf_preview');
         }
 
         $output->writeln('Creating PDF preview images...');
-        $webPath = realpath($this->rootDir . '/../web') . DIRECTORY_SEPARATOR;
 
         /**
          * @var EntityManager
@@ -92,7 +92,7 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
         foreach ($medias as $media) {
             try
             {
-                $this->pdfTransformer->apply($webPath . $media->getUrl());
+                $this->pdfTransformer->apply($this->webRoot . $media->getUrl());
             }
             catch(ImagickException $e)
             {

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -40,6 +40,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $container->setParameter('kunstmaan_media.remote_video', $config['remote_video']);
         $container->setParameter('kunstmaan_media.enable_pdf_preview', $config['enable_pdf_preview']);
         $container->setParameter('kunstmaan_media.blacklisted_extensions', $config['blacklisted_extensions']);
+        $container->setParameter('kunstmaan_media.web_root', $config['web_root']);
         $container->setParameter('kunstmaan_media.full_media_path', $config['web_root'] . '%kunstmaan_media.media_path%');
 
         $loader->load('services.yml');

--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -10,11 +10,6 @@ services:
         class: '%kunstmaan_media.pdf_transformer.class%'
         arguments: ['@kunstmaan_media.imagick']
 
-    kunstmaan_media.command.createpdfpreview:
-        class: Kunstmaan\MediaBundle\Command\CreatePdfPreviewCommand
-        calls:
-            - [setContainer, ['@service_container'] ]
-
     kunstmaan_media.media_handlers.pdf:
         class: '%kunstmaan_media.media_handler.pdf.class%'
         parent: kunstmaan_media.media_handlers.file
@@ -30,7 +25,7 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@kunstmaan_media.pdf_transformer'
-            - '%kernel.root_dir%'
+            - '%kunstmaan_media.web_root%'
             - '%kunstmaan_media.enable_pdf_preview%'
         tags:
             - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In #1974 a duplicate yaml key was introduced so the command couldn't be loaded. And in #2058 I've introduced the dynamic web/public parameter, but it was not used in this command making it not usable for sf4. Changing the parameter befor the 5.1 release allows us to change it without breaking BC!
