### PR TITLE
[AdminBundle] Fixed issue with locale in kuma:user:create command

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
@@ -122,7 +122,7 @@ EOT
         $inactive = $input->getOption('inactive');
         $groupOption = $input->getOption('group');
 
-        if (null !== $locale) {
+        if (null === $locale) {
             $locale = $this->defaultLocale;
         }
         $command = $this->getApplication()->find('fos:user:create');


### PR DESCRIPTION
When the locale is passed to the kuma:user:create command, it is being overwritten by the default local due to an incorrect if statement.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 