### PR TITLE
[AdminBundle] Fixed issue when running kuma:user:create with --no-interaction flag

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
@@ -62,6 +62,12 @@ EOT
             );
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->groups = $this->getGroups();
+    }
+
+
     /**
      * Executes the current command.
      *
@@ -217,16 +223,6 @@ EOT
             $input->setArgument('locale', $locale);
         }
 
-        $this->groups = $this->getContainer()->get('fos_user.group_manager')->findGroups();
-
-        // reindexing the array, using the db id as the key
-        $newGroups = [];
-        foreach($this->groups as $group) {
-            $newGroups[$group->getId()] = $group;
-        }
-
-        $this->groups = $newGroups;
-
         if (!$input->getOption('group')) {
             $question = new ChoiceQuestion(
                 'Please enter the group(s) the user should be a member of (multiple possible, separated by comma):',
@@ -259,5 +255,18 @@ EOT
 
             $input->setOption('group', $groups);
         }
+    }
+
+    private function getGroups()
+    {
+        $groups = $this->getContainer()->get('fos_user.group_manager')->findGroups();
+
+        // reindexing the array, using the db id as the key
+        $newGroups = [];
+        foreach($groups as $group) {
+            $newGroups[$group->getId()] = $group;
+        }
+
+        return $newGroups;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This fixes an issue when the `kuma:user:create` command is being run with `-n`|`--no-interaction`. The problem with this is that [Symfony detects if interaction mode is possible](https://github.com/symfony/symfony/blob/b959d8594cfe7ab6dada23b2b615efa566f472ff/src/Symfony/Component/Console/Application.php#L840), when it isn't - interaction mode is disabled.

Edit: To clarify, the `$this->groups` var was set in the interact method, which isn't called when `--no-interaction` flag is given to the command. The correct way is to set this var in the `initialize` method, that's what it's for.