### PR TITLE
[AdminBundle] Fixed issue with locale in kuma:user:create command

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
@@ -83,7 +83,7 @@ EOT
         $inactive = $input->getOption('inactive');
         $groupOption = $input->getOption('group');
 
-        if (null !== $locale) {
+        if (null === $locale) {
             $locale = $this->getContainer()->getParameter('kunstmaan_admin.default_admin_locale');
         }
         $command = $this->getApplication()->find('fos:user:create');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When the locale is passed to the kuma:user:create command, it is being overwritten by the default local due to an incorrect if statement.