### PR TITLE
[KunstmaanAdminBundle] check if command is not null on console error

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
@@ -2,10 +2,10 @@
 
 namespace Kunstmaan\AdminBundle\EventListener;
 
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class ConsoleExceptionSubscriber.
@@ -17,6 +17,7 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
 
     /**
      * ConsoleExceptionListener constructor.
+     *
      * @param LoggerInterface $logger
      */
     public function __construct(LoggerInterface $logger)
@@ -30,7 +31,7 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ConsoleEvents::ERROR => 'onConsoleError'
+            ConsoleEvents::ERROR => 'onConsoleError',
         ];
     }
 
@@ -42,7 +43,9 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
         $command = $event->getCommand();
         $error = $event->getError();
 
-        $this->logCommandError($command, $error);
+        if (null !== $command) {
+            $this->logCommandError($command, $error);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2020 

(bugfix on a new feature part of master branch)

Ticket #2020 introduces the new ConsoleExeceptionSubscriber. When entering the following for example in the terminal: "bin/console kuma:", you would normally get the available commands. Now the new subscriber throws an error because the command is NULL here. We should only log an error when the command is found.
