### PR TITLE
[GeneratorBundle, FormBundle] add generator for form pageparts

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionField.php
@@ -3,7 +3,6 @@
 namespace Kunstmaan\FormBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -55,6 +54,13 @@ abstract class FormSubmissionField
      * @ORM\Column(type="integer", nullable=true)
      */
     protected $sequence;
+
+    /**
+     * The internal name of the form pagepart attached to this.
+     *
+     * @ORM\Column(name="internal_name", type="string", nullable=true)
+     */
+    protected $internalName;
 
     /**
      * Get id
@@ -174,6 +180,38 @@ abstract class FormSubmissionField
         $this->sequence = $sequence;
 
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFormSubmission()
+    {
+        return $this->formSubmission;
+    }
+
+    /**
+     * @param mixed $formSubmission
+     */
+    public function setFormSubmission($formSubmission)
+    {
+        $this->formSubmission = $formSubmission;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * @param mixed $internalName
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/StringFormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/StringFormSubmissionField.php
@@ -14,7 +14,6 @@ use Kunstmaan\FormBundle\Form\StringFormSubmissionType;
  */
 class StringFormSubmissionField extends FormSubmissionField
 {
-
     /**
      * @ORM\Column(name="sfsf_value", type="string")
      */

--- a/src/Kunstmaan/FormBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/FormBundle/Resources/translations/messages.en.yml
@@ -71,6 +71,8 @@ kuma_form:
                 label: Regex
             errormessage_regex:
                 label: Error message regex
+        form_page_part:
+            internal_name: Internal name
         submit_button_page_part:
             label:
                 label: Label

--- a/src/Kunstmaan/FormBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/FormBundle/Resources/translations/messages.nl.yml
@@ -72,6 +72,8 @@ kuma_form:
         label: Regex
       errormessage_regex:
         label: Foutmelding regex
+    form_page_part:
+      internal_name: Interne naam
     submit_button_page_part:
       label:
         label: Label

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Kunstmaan\GeneratorBundle\Command;
+
+use Kunstmaan\GeneratorBundle\Generator\DefaultPagePartGenerator;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Generates the default form pageparts
+ */
+class GenerateFormPagePartsCommand extends KunstmaanGenerateCommand
+{
+    /**
+     * @var BundleInterface
+     */
+    private $bundle;
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this->setDescription('Generates default form pageparts')
+            ->setHelp(
+                <<<EOT
+The <info>kuma:generate:form-pageparts</info> command generates the default form pageparts and adds the pageparts configuration.
+
+<info>php bin/console kuma:generate:form-pageparts</info>
+EOT
+            )
+            ->addOption('namespace', '', InputOption::VALUE_OPTIONAL, 'The namespace to generate the default form pageparts in')
+            ->addOption('prefix', '', InputOption::VALUE_OPTIONAL, 'The prefix to be used in the table name of the generated entity')
+            ->setName('kuma:generate:form-pageparts');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getWelcomeText()
+    {
+        return 'Welcome to the Kunstmaan default form pageparts generator';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doExecute()
+    {
+        $this->assistant->writeSection('Default Form PageParts generation');
+
+        $pagepartNames = [
+            'AbstractFormPagePart',
+            'CheckboxPagePart',
+            'ChoicePagePart',
+            'EmailPagePart',
+            'FileUploadPagePart',
+            'MultiLineTextPagePart',
+            'SingleLineTextPagePart',
+            'SubmitButtonPagePart',
+        ];
+
+        foreach ($pagepartNames as $pagepartName) {
+            $this->createGenerator()->generate($this->bundle, $pagepartName, $this->prefix, [], false);
+        }
+
+        $this->assistant->writeSection('PageParts successfully created', 'bg=green;fg=black');
+        $this->assistant->writeLine(
+            [
+                'Make sure you update your database first before you test the pagepart:',
+                '    Directly update your database:          <comment>bin/console doctrine:schema:update --force</comment>',
+                '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doInteract()
+    {
+        if (!$this->isBundleAvailable('KunstmaanPagePartBundle')) {
+            $this->assistant->writeError('KunstmaanPagePartBundle not found', true);
+        }
+
+        $this->assistant->writeLine(["This command helps you to generate the form pageparts.\n"]);
+
+        /**
+         * Ask for which bundle we need to create the pagepart
+         */
+        $bundleNamespace = $this->assistant->getOptionOrDefault('namespace', null);
+        $this->bundle = $this->askForBundleName('pagepart', $bundleNamespace);
+
+        /**
+         * Ask the database table prefix
+         */
+        $this->prefix = $this->askForPrefix(null, $this->bundle->getNamespace());
+    }
+
+    /**
+     * Get the generator.
+     *
+     * @return DefaultPagePartGenerator
+     */
+    protected function createGenerator()
+    {
+        $filesystem = $this->getContainer()->get('filesystem');
+        $registry = $this->getContainer()->get('doctrine');
+
+        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer());
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultPagePartGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultPagePartGenerator.php
@@ -129,6 +129,14 @@ class DefaultPagePartGenerator extends KunstmaanGenerator
             true
         );
 
+        $this->renderSingleFile(
+            $this->skeletonDir . '/Resources/views/PageParts/' . $this->entity . '/',
+            $this->bundle->getPath() . '/Resources/views/PageParts/' . $this->entity . '/',
+            'admin-view.html.twig',
+            $params,
+            true
+        );
+
         $this->assistant->writeLine('Generating ' . $this->entity . ' template:     <info>OK</info>');
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Generator/FormPageGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/FormPageGenerator.php
@@ -3,7 +3,6 @@
 namespace Kunstmaan\GeneratorBundle\Generator;
 
 use Kunstmaan\GeneratorBundle\Helper\GeneratorUtils;
-
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
@@ -47,6 +46,11 @@ class FormPageGenerator extends KunstmaanGenerator
     private $parentPages;
 
     /**
+     * @var boolean
+     */
+    private $generateFormPageParts;
+
+    /**
      * @var string
      */
     protected $skeletonDir;
@@ -55,13 +59,14 @@ class FormPageGenerator extends KunstmaanGenerator
     /**
      * Generate the formpage.
      *
-     * @param BundleInterface $bundle      The bundle
-     * @param string          $entity      The entity name
-     * @param string          $prefix      The database prefix
-     * @param array           $fields      The fields
-     * @param string          $template    The page template
-     * @param array           $sections    The page sections
-     * @param array           $parentPages The parent pages
+     * @param BundleInterface $bundle                The bundle
+     * @param string          $entity                The entity name
+     * @param string          $prefix                The database prefix
+     * @param array           $fields                The fields
+     * @param string          $template              The page template
+     * @param array           $sections              The page sections
+     * @param array           $parentPages           The parent pages
+     * @param boolean         $generateFormPageParts Boolean to check if form pageparts need to be generated
      *
      * @throws \RuntimeException
      */
@@ -72,16 +77,18 @@ class FormPageGenerator extends KunstmaanGenerator
         array $fields,
         $template,
         array $sections,
-        array $parentPages
+        array $parentPages,
+        $generateFormPageParts
     ) {
-        $this->bundle      = $bundle;
-        $this->entity      = $entity;
-        $this->prefix      = $prefix;
-        $this->fields      = $fields;
-        $this->template    = $template;
-        $this->sections    = $sections;
+        $this->bundle = $bundle;
+        $this->entity = $entity;
+        $this->prefix = $prefix;
+        $this->fields = $fields;
+        $this->template = $template;
+        $this->sections = $sections;
         $this->parentPages = $parentPages;
         $this->skeletonDir = __DIR__.'/../Resources/SensioGeneratorBundle/skeleton/formpage';
+        $this->generateFormPageParts = $generateFormPageParts;
 
         $this->generatePageEntity();
         $this->generatePageFormType();
@@ -189,12 +196,14 @@ class FormPageGenerator extends KunstmaanGenerator
     private function copyTemplateConfig()
     {
         $dirPath = $this->bundle->getPath();
-        $pagepartFile = $dirPath . '/Resources/config/pageparts/'.$this->template.'.yml';
-        $this->filesystem->copy($this->skeletonDir .'/Resources/config/pageparts/formpage.yml', $pagepartFile, false);
+        $pagepartFile = $dirPath.'/Resources/config/pageparts/'.$this->template.'.yml';
+        $namespace = $this->generateFormPageParts ? $this->bundle->getNamespace() : 'Kunstmaan\FormBundle';
+        $this->filesystem->copy($this->skeletonDir.'/Resources/config/pageparts/formpage.yml', $pagepartFile, false);
         GeneratorUtils::replace("~~~ENTITY~~~", $this->entity, $pagepartFile);
+        GeneratorUtils::replace("~~~FORM_BUNDLE~~~", $namespace, $pagepartFile);
 
-        $pagetemplateFile = $dirPath . '/Resources/config/pagetemplates/'.$this->template.'.yml';
-        $this->filesystem->copy($this->skeletonDir .'/Resources/config/pagetemplates/formpage.yml', $pagetemplateFile, false);
+        $pagetemplateFile = $dirPath.'/Resources/config/pagetemplates/'.$this->template.'.yml';
+        $this->filesystem->copy($this->skeletonDir.'/Resources/config/pagetemplates/formpage.yml', $pagetemplateFile, false);
         GeneratorUtils::replace("~~~BUNDLE~~~", $this->bundle->getName(), $pagetemplateFile);
         GeneratorUtils::replace("~~~ENTITY~~~", $this->entity, $pagetemplateFile);
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/formpage/Resources/config/pageparts/formpage.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/formpage/Resources/config/pageparts/formpage.yml
@@ -1,19 +1,20 @@
-name: "~~~ENTITY~~~"
-context: "main"
+name: '~~~ENTITY~~~'
+context: 'main'
 types:
-    - { name: "Single Line text input", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\SingleLineTextPagePart" }
-    - { name: "Multi Line text input", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\MultiLineTextPagePart" }
-    - { name: "Email input", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\EmailPagePart" }
-    - { name: "File upload", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\FileUploadPagePart" }
-    - { name: "Choice input", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\ChoicePagePart" }
-    - { name: "Submit button", class: "Kunstmaan\\FormBundle\\Entity\\PageParts\\SubmitButtonPagePart" }
-    - { name: "Header", class: "Kunstmaan\\PagePartBundle\\Entity\\HeaderPagePart" }
-    - { name: "Text", class: "Kunstmaan\\PagePartBundle\\Entity\\TextPagePart" }
-    - { name: "Line", class: "Kunstmaan\\PagePartBundle\\Entity\\LinePagePart" }
-    - { name: "TOC", class: "Kunstmaan\\PagePartBundle\\Entity\\TocPagePart" }
-    - { name: "Link", class: "Kunstmaan\\PagePartBundle\\Entity\\LinkPagePart" }
-    - { name: "To Top", class: "Kunstmaan\\PagePartBundle\\Entity\\ToTopPagePart" }
-    - { name: "Image", class: "Kunstmaan\\MediaPagePartBundle\\Entity\\ImagePagePart" }
-    - { name: "Download", class: "Kunstmaan\\MediaPagePartBundle\\Entity\\DownloadPagePart" }
-    - { name: "Video", class: "Kunstmaan\\MediaPagePartBundle\\Entity\\VideoPagePart" }
-    - { name: "Audio", class: "Kunstmaan\\MediaPagePartBundle\\Entity\\AudioPagePart" }
+    - { name: 'Single Line text input', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\SingleLineTextPagePart' }
+    - { name: 'Multi Line text input', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\MultiLineTextPagePart' }
+    - { name: 'Email input', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\EmailPagePart' }
+    - { name: 'File upload', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\FileUploadPagePart' }
+    - { name: 'Checkbox input', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\CheckboxPagePart' }
+    - { name: 'Choice input', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\ChoicePagePart' }
+    - { name: 'Submit button', class: '~~~FORM_BUNDLE~~~\Entity\PageParts\SubmitButtonPagePart' }
+    - { name: 'Header', class: 'Kunstmaan\PagePartBundle\Entity\HeaderPagePart' }
+    - { name: 'Text', class: 'Kunstmaan\PagePartBundle\Entity\TextPagePart' }
+    - { name: 'Line', class: 'Kunstmaan\PagePartBundle\Entity\LinePagePart' }
+    - { name: 'TOC', class: 'Kunstmaan\PagePartBundle\Entity\TocPagePart' }
+    - { name: 'Link', class: 'Kunstmaan\PagePartBundle\Entity\LinkPagePart' }
+    - { name: 'To Top', class: 'Kunstmaan\PagePartBundle\Entity\ToTopPagePart' }
+    - { name: 'Image', class: 'Kunstmaan\MediaPagePartBundle\Entity\ImagePagePart' }
+    - { name: 'Download', class: 'Kunstmaan\MediaPagePartBundle\Entity\DownloadPagePart' }
+    - { name: 'Video', class: 'Kunstmaan\MediaPagePartBundle\Entity\VideoPagePart' }
+    - { name: 'Audio', class: 'Kunstmaan\MediaPagePartBundle\Entity\AudioPagePart' }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractFormPagePart/AbstractFormPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractFormPagePart/AbstractFormPagePart.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormAdaptorInterface;
+use Kunstmaan\PagePartBundle\Entity\AbstractPagePart;
+use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Abstract version of a form page part
+ */
+abstract class {{ pagepart }} extends AbstractPagePart implements FormAdaptorInterface
+{
+    /**
+     * The label
+     *
+     * @ORM\Column(type="string")
+     * @Assert\NotBlank()
+     */
+    protected $label;
+
+    /**
+     * Returns a unique id for the current page part
+     *
+     * @return string
+     */
+    public function getUniqueId()
+    {
+        return  str_replace('\\', '', ClassLookup::getClass($this)) . $this->id; //TODO
+    }
+
+    /**
+     * Set the label used for this page part
+     *
+     * @param int $label
+     *
+     * @return AbstractFormPagePart
+     */
+    public function setLabel($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get the label used for this page part
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * Returns the view used in the backend
+     *
+     * @return string
+     */
+    public function getAdminView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/admin-view.html.twig';
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\BooleanFormSubmissionField;
+use Kunstmaan\FormBundle\Form\BooleanFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Sets the required valud of this page part
+     *
+     * @param bool $required
+     *
+     * @return CheckboxPagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return CheckboxPagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * Returns the frontend view
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $bfsf = new BooleanFormSubmissionField();
+        $bfsf->setFieldName('field_' . $this->getUniqueId());
+        $bfsf->setLabel($this->getLabel());
+        $bfsf->setInternalName($this->getInternalName());
+        $bfsf->setSequence($sequence);
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $bfsf;
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+            BooleanFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'constraints' => $constraints,
+                'required'    => $this->getRequired()
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($bfsf);
+    }
+
+    /**
+     * Returns the default backend form type for this page part
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\ChoiceFormSubmissionField;
+use Kunstmaan\FormBundle\Form\ChoiceFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, radio buttons or checkboxes will be rendered (depending on the multiple value). If false,
+     * a select element will be rendered.
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $expanded = false;
+
+    /**
+     * If true, the user will be able to select multiple options (as opposed to choosing just one option).
+     * Depending on the value of the expanded option, this will render either a select tag or checkboxes
+     * if true and a select tag or radio buttons if false. The returned value will be an array.
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $multiple = false;
+
+    /**
+     * The choices that should be used by this field. The choices can be entered separated by a new line.
+     *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    protected $choices;
+
+    /**
+     * This option determines whether or not a special "empty" option (e.g. "Choose an option")
+     * will appear at the top of a select widget. This option only applies if both the expanded and
+     * multiple options are set to false.
+     *
+     * @ORM\Column(type="string", name="empty_value", nullable=true)
+     */
+    protected $emptyValue;
+
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Returns the view used in the frontend
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $choices = explode("\n", $this->getChoices());
+        $choices = array_map('trim', $choices);
+
+        $cfsf = new ChoiceFormSubmissionField();
+        $cfsf->setFieldName("field_" . $this->getUniqueId());
+        $cfsf->setLabel($this->getLabel());
+        $cfsf->setChoices($choices);
+        $cfsf->setRequired($this->required);
+        $cfsf->setSequence($sequence);
+        $cfsf->setInternalName($this->getInternalName());
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $cfsf;
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+
+        $formBuilder->add(
+            'formwidget_' . $this->getUniqueId(),
+            ChoiceFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'required'    => $this->getRequired(),
+                'expanded'    => $this->getExpanded(),
+                'multiple'    => $this->getMultiple(),
+                'choices'     => $choices,
+                'placeholder' => $this->getEmptyValue(),
+                'constraints' => $constraints,
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($cfsf);
+    }
+
+    /**
+     * Returns the default backend form type for this FormSubmissionField
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+
+    /**
+     * Set the expanded value, default this is false
+     *
+     * @param bool $expanded
+     *
+     * @return ChoicePagePart
+     */
+    public function setExpanded($expanded)
+    {
+        $this->expanded = $expanded;
+
+        return $this;
+    }
+
+    /**
+     * Get the expanded value
+     *
+     * @return bool
+     */
+    public function getExpanded()
+    {
+        return $this->expanded;
+    }
+
+    /**
+     * Set the multple value, default this is false
+     *
+     * @param bool $multiple
+     *
+     * @return ChoicePagePart
+     */
+    public function setMultiple($multiple)
+    {
+        $this->multiple = $multiple;
+
+        return $this;
+    }
+
+    /**
+     * Get the current multiple value
+     *
+     * @return boolean
+     */
+    public function getMultiple()
+    {
+        return $this->multiple;
+    }
+
+    /**
+     * Set the choices for this pagepart
+     *
+     * @param string $choices Seperated by '\n'
+     *
+     * @return ChoicePagePart
+     */
+    public function setChoices($choices)
+    {
+        $this->choices = $choices;
+
+        return $this;
+    }
+
+    /**
+     * Get the current choices
+     *
+     * @return string Seperated by '\n'
+     */
+    public function getChoices()
+    {
+        return $this->choices;
+    }
+
+    /**
+     * Set emptyValue
+     *
+     * @param string $emptyValue
+     *
+     * @return ChoicePagePart
+     */
+    public function setEmptyValue($emptyValue)
+    {
+        $this->emptyValue = $emptyValue;
+
+        return $this;
+    }
+
+    /**
+     * Get emptyValue
+     *
+     * @return string
+     */
+    public function getEmptyValue()
+    {
+        return $this->emptyValue;
+    }
+
+    /**
+     * Sets the required valud of this page part
+     *
+     * @param bool $required
+     *
+     * @return ChoicePagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return ChoicePagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\EmailFormSubmissionField;
+use Kunstmaan\FormBundle\Form\EmailFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * Error message shows when the value is invalid
+     *
+     * @ORM\Column(type="string", name="error_message_invalid", nullable=true)
+     */
+    protected $errorMessageInvalid;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Sets the required value of this page part
+     *
+     * @param bool $required
+     *
+     * @return EmailPagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return EmailPagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * Sets the message shown when the value is invalid
+     *
+     * @param string $errorMessageInvalid
+     *
+     * @return EmailPagePart
+     */
+    public function setErrorMessageInvalid($errorMessageInvalid)
+    {
+        $this->errorMessageInvalid = $errorMessageInvalid;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the value is invalid
+     *
+     * @return string
+     */
+    public function getErrorMessageInvalid()
+    {
+        return $this->errorMessageInvalid;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * Returns the frontend view
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $efsf = new EmailFormSubmissionField();
+        $efsf->setFieldName("field_" . $this->getUniqueId());
+        $efsf->setLabel($this->getLabel());
+        $efsf->setSequence($sequence);
+        $efsf->setInternalName($this->getInternalName());
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $efsf;
+
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+        $options = array();
+        if (!empty($this->errorMessageInvalid)) {
+            $options['message'] = $this->getErrorMessageInvalid();
+        }
+        $constraints[] = new Email($options);
+
+        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+            EmailFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'constraints' => $constraints,
+                'required'    => $this->getRequired()
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($efsf);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\FileFormSubmissionField;
+use Kunstmaan\FormBundle\Form\FileFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $ffsf = new FileFormSubmissionField();
+        $ffsf->setFieldName('field_' . $this->getUniqueId());
+        $ffsf->setLabel($this->getLabel());
+        $ffsf->setSequence($sequence);
+        $ffsf->setInternalName($this->getInternalName());
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $ffsf;
+
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+
+        $formBuilder->add(
+            'formwidget_' . $this->getUniqueId(),
+            FileFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'constraints' => $constraints,
+                'required'    => $this->getRequired()
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($ffsf);
+    }
+
+    /**
+     * Sets the required valud of this page part
+     *
+     * @param bool $required
+     *
+     * @return FileUploadPagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return FileUploadPagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * Returns the view used in the frontend
+     *
+     * @return mixed
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Returns the default backend form type for this page part
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\TextFormSubmissionField;
+use Kunstmaan\FormBundle\Form\TextFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * If set the entered value will be matched with this regular expression
+     *
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $regex;
+
+    /**
+     * If a regular expression is set and it doesn't match with the given value, this error message will be shown
+     *
+     * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+     */
+    protected $errorMessageRegex;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Set the regular expression to match the entered value against
+     *
+     * @param string $regex
+     *
+     * @return MultiLineTextPagePart
+     */
+    public function setRegex($regex)
+    {
+        $this->regex = $regex;
+
+        return $this;
+    }
+
+    /**
+     * Get the current regular expression
+     *
+     * @return string
+     */
+    public function getRegex()
+    {
+        return $this->regex;
+    }
+
+    /**
+     * Set the error message which will be shown when the entered value doesn't match the regular expression
+     *
+     * @param string $errorMessageRegex
+     *
+     * @return MultiLineTextPagePart
+     */
+    public function setErrorMessageRegex($errorMessageRegex)
+    {
+        $this->errorMessageRegex = $errorMessageRegex;
+
+        return $this;
+    }
+
+    /**
+     * Get the current error message which will be shown when the entered value doesn't match the regular expression
+     *
+     * @return string
+     */
+    public function getErrorMessageRegex()
+    {
+        return $this->errorMessageRegex;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * Returns the frontend view
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Sets the required valud of this page part
+     *
+     * @param bool $required
+     *
+     * @return MultiLineTextPagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return MultiLineTextPagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $mfsf = new TextFormSubmissionField();
+        $mfsf->setFieldName('field_' . $this->getUniqueId());
+        $mfsf->setLabel($this->getLabel());
+        $mfsf->setSequence($sequence);
+        $mfsf->setInternalName($this->getInternalName());
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $mfsf;
+
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+        if ($this->getRegex()) {
+            $options = array('pattern' => $this->getRegex());
+            if (!empty($this->errorMessageRegex)) {
+                $options['message'] = $this->errorMessageRegex;
+            }
+            $constraints[] = new Regex($options);
+        }
+
+        $formBuilder->add(
+            'formwidget_' . $this->getUniqueId(),
+            TextFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'constraints' => $constraints,
+                'required'    => $this->getRequired()
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($mfsf);
+    }
+
+    /**
+     * Returns the default backend form type for this page part
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\StringFormSubmissionField;
+use Kunstmaan\FormBundle\Form\StringFormSubmissionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractFormPagePart
+{
+    /**
+     * If set to true, you are obligated to fill in this page part
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    protected $required = false;
+
+    /**
+     * Error message shows when the page part is required and nothing is filled in
+     *
+     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     */
+    protected $errorMessageRequired;
+
+    /**
+     * If set the entered value will be matched with this regular expression
+     *
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $regex;
+
+    /**
+     * If a regular expression is set and it doesn't match with the given value, this error message will be shown
+     *
+     * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+     */
+    protected $errorMessageRegex;
+
+    /**
+     * Internal name that can be used with form submission subscribers.
+     *
+     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     */
+    protected $internalName;
+
+    /**
+     * Sets the required valud of this page part
+     *
+     * @param bool $required
+     *
+     * @return SingleLineTextPagePart
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Check if the page part is required
+     *
+     * @return bool
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
+     * Sets the message shown when the page part is required and no value was entered
+     *
+     * @param string $errorMessageRequired
+     *
+     * @return SingleLineTextPagePart
+     */
+    public function setErrorMessageRequired($errorMessageRequired)
+    {
+        $this->errorMessageRequired = $errorMessageRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get the error message that will be shown when the page part is required and no value was entered
+     *
+     * @return string
+     */
+    public function getErrorMessageRequired()
+    {
+        return $this->errorMessageRequired;
+    }
+
+    /**
+     * Set the regular expression to match the entered value against
+     *
+     * @param string $regex
+     *
+     * @return SingleLineTextPagePart
+     */
+    public function setRegex($regex)
+    {
+        $this->regex = $regex;
+
+        return $this;
+    }
+
+    /**
+     * Get the current regular expression
+     *
+     * @return string
+     */
+    public function getRegex()
+    {
+        return $this->regex;
+    }
+
+    /**
+     * Set the error message which will be shown when the entered value doesn't match the regular expression
+     *
+     * @param string $errorMessageRegex
+     *
+     * @return SingleLineTextPagePart
+     */
+    public function setErrorMessageRegex($errorMessageRegex)
+    {
+        $this->errorMessageRegex = $errorMessageRegex;
+
+        return $this;
+    }
+
+    /**
+     * Get the current error message which will be shown when the entered value doesn't match the regular expression
+     *
+     * @return string
+     */
+    public function getErrorMessageRegex()
+    {
+        return $this->errorMessageRegex;
+    }
+
+    /**
+     * @param string $internalName
+     *
+     * @return self
+     */
+    public function setInternalName($internalName)
+    {
+        $this->internalName = $internalName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return $this->internalName;
+    }
+
+    /**
+     * Returns the frontend view
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Modify the form with the fields of the current page part
+     *
+     * @param FormBuilderInterface $formBuilder The form builder
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
+     */
+    public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
+    {
+        $sfsf = new StringFormSubmissionField();
+        $sfsf->setFieldName('field_' . $this->getUniqueId());
+        $sfsf->setLabel($this->getLabel());
+        $sfsf->setInternalName($this->getInternalName());
+        $sfsf->setSequence($sequence);
+
+        $data = $formBuilder->getData();
+        $data['formwidget_' . $this->getUniqueId()] = $sfsf;
+
+        $constraints = array();
+        if ($this->getRequired()) {
+            $options = array();
+            if (!empty($this->errorMessageRequired)) {
+                $options['message'] = $this->errorMessageRequired;
+            }
+            $constraints[] = new NotBlank($options);
+        }
+        if ($this->getRegex()) {
+            $options = array('pattern' => $this->getRegex());
+            if (!empty($this->errorMessageRegex)) {
+                $options['message'] = $this->errorMessageRegex;
+            }
+            $constraints[] = new Regex($options);
+        }
+
+        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+            StringFormSubmissionType::class,
+            array(
+                'label'       => $this->getLabel(),
+                'constraints' => $constraints,
+                'required'    => $this->getRequired()
+            )
+        );
+        $formBuilder->setData($data);
+
+        $fields->append($sfsf);
+    }
+
+    /**
+     * Returns the default backend form type for this page part
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SubmitButtonPagePart/SubmitButtonPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SubmitButtonPagePart/SubmitButtonPagePart.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace {{ namespace }}\Entity\PageParts;
+
+use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\PagePartBundle\Entity\AbstractPagePart;
+
+/**
+ * {{ pagepart }}
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
+ */
+class {{ pagepart }} extends AbstractPagePart
+{
+
+    /**
+     * The label on the submit button
+     *
+     * @ORM\Column(type="string", nullable=true)
+     */
+    protected $label;
+
+    /**
+     * Set the label
+     *
+     * @param int $label
+     *
+     * @return SubmitButtonPagePart
+     */
+    public function setLabel($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get the label
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * Return a string representation of this page part
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return "SubmitButtonPagePart";
+    }
+
+    /**
+     * Return the frontend view
+     *
+     * @return string
+     */
+    public function getDefaultView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/view.html.twig';
+    }
+
+    /**
+     * Return the backend view
+     *
+     * @return string
+     */
+    public function getAdminView()
+    {
+        return '{{ bundle }}:PageParts:{{ pagepart }}/admin-view.html.twig';
+    }
+
+    /**
+     * Returns the default form type for this FormSubmissionField
+     *
+     * @return string
+     */
+    public function getDefaultAdminType()
+    {
+        return {{ adminType }}::class;
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/CheckboxPagePart/CheckboxPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/CheckboxPagePart/CheckboxPagePartAdminType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\FormBundle\Form;
+namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -9,9 +9,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This class represents the type for the SubleLineTextPagePart
+ * {{ pagepart }}AdminType
  */
-class SingleLineTextPagePartAdminType extends AbstractType
+class {{ pagepart }}AdminType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
@@ -24,40 +24,32 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 'label',
                 TextType::class,
                 [
+                    'label' => 'kuma_form.form.checkbox_page_part.label.label',
                     'required' => true,
-                    'label' => 'kuma_form.form.single_line_text_page_part.label.label',
                 ]
             )
             ->add(
                 'required',
                 CheckboxType::class,
                 [
+                    'label' => 'kuma_form.form.checkbox_page_part.required.label',
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.required.label',
                 ]
             )
             ->add(
                 'errormessage_required',
                 TextType::class,
                 [
+                    'label' => 'kuma_form.form.checkbox_page_part.errormessage_required.label',
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_required.label',
                 ]
             )
             ->add(
-                'regex',
+                'internalName',
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.regex.label',
-                ]
-            )
-            ->add(
-                'errormessage_regex',
-                TextType::class,
-                [
-                    'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_regex.label',
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
                 ]
             );
     }
@@ -67,7 +59,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'kunstmaan_formbundle_singlelinetextpageparttype';
+        return '{{ pagepart|lower }}type';
     }
 
     /**
@@ -75,6 +67,10 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => 'Kunstmaan\FormBundle\Entity\PageParts\SingleLineTextPagePart']);
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ChoicePagePart/ChoicePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ChoicePagePart/ChoicePagePartAdminType.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace {{ namespace }}\Form\PageParts;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * {{ pagepart }}AdminType
+ */
+class {{ pagepart }}AdminType extends AbstractType
+{
+
+    /**
+     * @param FormBuilderInterface $builder The form builder
+     * @param array                $options The options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'label',
+                TextType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.label.label',
+                    'required' => true,
+                ]
+            )
+            ->add(
+                'required',
+                CheckboxType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.required.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'errormessage_required',
+                TextType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.errormessage_required.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'expanded',
+                CheckboxType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.expanded.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'multiple',
+                CheckboxType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.multiple.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'choices',
+                TextareaType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.choices.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'empty_value',
+                TextType::class,
+                [
+                    'label' => 'kuma_form.form.choice_page_part.empty_value.label',
+                    'required' => false,
+                ]
+            )
+            ->add(
+                'internalName',
+                TextType::class,
+                [
+                    'required' => false,
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
+                ]
+            );
+    }
+
+    /**
+     * @return string
+     */
+    public function getBlockPrefix()
+    {
+        return '{{ pagepart|lower }}type';
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EmailPagePart/EmailPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EmailPagePart/EmailPagePartAdminType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\FormBundle\Form;
+namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -9,9 +9,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This class represents the type for the SubleLineTextPagePart
+ * {{ pagepart }}AdminType
  */
-class SingleLineTextPagePartAdminType extends AbstractType
+class {{ pagepart }}AdminType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
@@ -25,7 +25,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => true,
-                    'label' => 'kuma_form.form.single_line_text_page_part.label.label',
+                    'label' => 'kuma_form.form.email_page_part.label.label',
                 ]
             )
             ->add(
@@ -33,31 +33,31 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 CheckboxType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.required.label',
+                    'label' => 'kuma_form.form.email_page_part.required.label',
                 ]
             )
             ->add(
-                'errormessage_required',
+                'errorMessageRequired',
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_required.label',
+                    'label' => 'kuma_form.form.email_page_part.errorMessageRequired.label',
                 ]
             )
             ->add(
-                'regex',
+                'errorMessageInvalid',
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.regex.label',
+                    'label' => 'kuma_form.form.email_page_part.errorMessageInvalid.label',
                 ]
             )
             ->add(
-                'errormessage_regex',
+                'internalName',
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_regex.label',
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
                 ]
             );
     }
@@ -67,7 +67,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'kunstmaan_formbundle_singlelinetextpageparttype';
+        return '{{ pagepart|lower }}type';
     }
 
     /**
@@ -75,6 +75,10 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => 'Kunstmaan\FormBundle\Entity\PageParts\SingleLineTextPagePart']);
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/FileUploadPagePart/FileUploadPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/FileUploadPagePart/FileUploadPagePartAdminType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\FormBundle\Form;
+namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -9,10 +9,11 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This class represents the type for the SubleLineTextPagePart
+ * {{ pagepart }}AdminType
  */
-class SingleLineTextPagePartAdminType extends AbstractType
+class {{ pagepart }}AdminType extends AbstractType
 {
+
     /**
      * @param FormBuilderInterface $builder The form builder
      * @param array                $options The options
@@ -25,7 +26,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => true,
-                    'label' => 'kuma_form.form.single_line_text_page_part.label.label',
+                    'label' => 'kuma_form.form.file_upload_page_part.label.label',
                 ]
             )
             ->add(
@@ -33,7 +34,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 CheckboxType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.required.label',
+                    'label' => 'kuma_form.form.file_upload_page_part.required.label',
                 ]
             )
             ->add(
@@ -41,23 +42,15 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_required.label',
+                    'label' => 'kuma_form.form.file_upload_page_part.errormessage_required.label',
                 ]
             )
             ->add(
-                'regex',
+                'internalName',
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.regex.label',
-                ]
-            )
-            ->add(
-                'errormessage_regex',
-                TextType::class,
-                [
-                    'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_regex.label',
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
                 ]
             );
     }
@@ -67,7 +60,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'kunstmaan_formbundle_singlelinetextpageparttype';
+        return '{{ pagepart|lower }}type';
     }
 
     /**
@@ -75,6 +68,10 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => 'Kunstmaan\FormBundle\Entity\PageParts\SingleLineTextPagePart']);
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/MultiLineTextPagePart/MultiLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/MultiLineTextPagePart/MultiLineTextPagePartAdminType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\FormBundle\Form;
+namespace {{ namespace }}\Form\PageParts;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -9,9 +9,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This class represents the type for the SubleLineTextPagePart
+ * {{ pagepart }}AdminType
  */
-class SingleLineTextPagePartAdminType extends AbstractType
+class {{ pagepart }}AdminType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
@@ -25,7 +25,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => true,
-                    'label' => 'kuma_form.form.single_line_text_page_part.label.label',
+                    'label' => 'kuma_form.form.multi_line_text_page_part.label.label',
                 ]
             )
             ->add(
@@ -33,7 +33,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 CheckboxType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.required.label',
+                    'label' => 'kuma_form.form.multi_line_text_page_part.required.label',
                 ]
             )
             ->add(
@@ -41,7 +41,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_required.label',
+                    'label' => 'kuma_form.form.multi_line_text_page_part.errormessage_required.label',
                 ]
             )
             ->add(
@@ -49,7 +49,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.regex.label',
+                    'label' => 'kuma_form.form.multi_line_text_page_part.regex.label',
                 ]
             )
             ->add(
@@ -57,7 +57,15 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 TextType::class,
                 [
                     'required' => false,
-                    'label' => 'kuma_form.form.single_line_text_page_part.errormessage_regex.label',
+                    'label' => 'kuma_form.form.multi_line_text_page_part.errormessage_regex.label',
+                ]
+            )
+            ->add(
+                'internalName',
+                TextType::class,
+                [
+                    'required' => false,
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
                 ]
             );
     }
@@ -67,7 +75,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'kunstmaan_formbundle_singlelinetextpageparttype';
+        return '{{ pagepart|lower }}type';
     }
 
     /**
@@ -75,6 +83,10 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => 'Kunstmaan\FormBundle\Entity\PageParts\SingleLineTextPagePart']);
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SingleLineTextPagePart/SingleLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SingleLineTextPagePart/SingleLineTextPagePartAdminType.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Kunstmaan\FormBundle\Form;
+namespace {{ namespace }}\Form\PageParts;
 
-use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\AbstractType;
 
 /**
- * This class represents the type for the SubleLineTextPagePart
+ * {{ pagepart }}AdminType
  */
-class SingleLineTextPagePartAdminType extends AbstractType
+class {{ pagepart }}AdminType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
@@ -59,6 +59,14 @@ class SingleLineTextPagePartAdminType extends AbstractType
                     'required' => false,
                     'label' => 'kuma_form.form.single_line_text_page_part.errormessage_regex.label',
                 ]
+            )
+            ->add(
+                'internalName',
+                TextType::class,
+                [
+                    'required' => false,
+                    'label' => 'kuma_form.form.form_page_part.internal_name',
+                ]
             );
     }
 
@@ -67,7 +75,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'kunstmaan_formbundle_singlelinetextpageparttype';
+        return '{{ pagepart|lower }}type';
     }
 
     /**
@@ -75,6 +83,10 @@ class SingleLineTextPagePartAdminType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => 'Kunstmaan\FormBundle\Entity\PageParts\SingleLineTextPagePart']);
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SubmitButtonPagePart/SubmitButtonPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SubmitButtonPagePart/SubmitButtonPagePartAdminType.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace {{ namespace }}\Form\PageParts;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * {{ pagepart }}AdminType
+ */
+class {{ pagepart }}AdminType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'label',
+                TextType::class,
+                [
+                    'required' => true,
+                    'label' => 'kuma_form.form.submit_button_page_part.label.label',
+                ]
+            );
+    }
+
+    /**
+     * @return string
+     */
+    public function getBlockPrefix()
+    {
+        return '{{ pagepart|lower }}type';
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => '{{ namespace }}\Entity\PageParts\{{ pagepart }}',
+            ]
+        );
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/AbstractFormPagePart/admin-view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/AbstractFormPagePart/admin-view.html.twig
@@ -1,0 +1,5 @@
+{% set label = resource.label %}
+{% if resource.required %}
+    {% set label = label ~ ' *' %}
+{% endif %}
+<strong>{{ label }}</strong>

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/CheckboxPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/CheckboxPagePart/view.html.twig
@@ -1,0 +1,3 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/ChoicePagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/ChoicePagePart/view.html.twig
@@ -1,0 +1,4 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+    {{ form_errors(frontendform['formwidget_'~resource.uniqueId]) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/EmailPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/EmailPagePart/view.html.twig
@@ -1,0 +1,3 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/FileUploadPagePart/submission.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/FileUploadPagePart/submission.html.twig
@@ -1,0 +1,11 @@
+{% if resource is defined and resource is not null %}
+    {% if not resource.isNull() %}
+        {% if resource.url is defined and resource.url is not null %}
+            {% set href = host ~ resource.url %}
+        {% else %}
+            {% set href = host ~ form_submission_webdir ~ resource.fileName %}
+        {% endif %}
+        <a target="_blank"
+           href="{{ href }}">{{ resource.fileName }}</a>
+    {% endif %}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/FileUploadPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/FileUploadPagePart/view.html.twig
@@ -1,0 +1,3 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/MultiLineTextPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/MultiLineTextPagePart/view.html.twig
@@ -1,0 +1,3 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SingleLineTextPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SingleLineTextPagePart/view.html.twig
@@ -1,0 +1,3 @@
+{% if frontendform is defined %}
+    {{ form_widget(frontendform['formwidget_'~resource.uniqueId], { 'attr' : {'bound' : frontendformobject.submitted } }) }}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SubmitButtonPagePart/admin-view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SubmitButtonPagePart/admin-view.html.twig
@@ -1,0 +1,1 @@
+<button class="btn" disabled="disabled">{{ resource.label }}</button>

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SubmitButtonPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/SubmitButtonPagePart/view.html.twig
@@ -1,0 +1,1 @@
+<input type="submit" value="{{resource.label}}" class="btn btn-primary">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2096

When generating a form page, you will get the option to generate all the form pageparts to your own custom bundle. I've also added a "internal name" field to all form pageparts. By filling in the internal name of a form pagepart, you will get the option to do something with it when using the events coming from the form submission.