### PR TITLE
[DashboardBundle] Fixed duplicate service id and missing command in command services config

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigFlushCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigFlushCommand.php
@@ -13,14 +13,13 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class GoogleAnalyticsConfigFlushCommand extends ContainerAwareCommand
 {
-
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @param EntityManagerInterface|null                   $em
+     * @param EntityManagerInterface|null $em
      */
     public function __construct(/* EntityManagerInterface */ $em = null)
     {

--- a/src/Kunstmaan/DashboardBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/commands.yml
@@ -9,13 +9,13 @@ services:
         tags:
             - { name: console.command }
 
-    Kunstmaan\DashboardBundle\Command\GoogleAnalyticsSegmentsListCommand:
-        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_dashboard.helper.google.analytics.service']
+    Kunstmaan\DashboardBundle\Command\GoogleAnalyticsConfigsListCommand:
+        arguments: ['@doctrine.orm.entity_manager']
         tags:
             - { name: console.command }
 
-    Kunstmaan\DashboardBundle\Command\GoogleAnalyticsConfigsListCommand:
-        arguments: ['@doctrine.orm.entity_manager']
+    Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand:
+        arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_dashboard.helper.google.analytics.service']
         tags:
             - { name: console.command }
 
@@ -25,6 +25,11 @@ services:
             - { name: console.command }
 
     Kunstmaan\DashboardBundle\Command\GoogleAnalyticsOverviewsGenerateCommand:
+        arguments: ['@doctrine.orm.entity_manager']
+        tags:
+            - { name: console.command }
+
+    Kunstmaan\DashboardBundle\Command\GoogleAnalyticsOverviewsListCommand:
         arguments: ['@doctrine.orm.entity_manager']
         tags:
             - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | related to #2022

PR #2022 generated incorrect yaml for the commands as services. Duplicated service id and 1 command service definition was missing. 
