### PR TITLE
[TranslatorBundle] Fix random failing test because of race condition

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Tests/Repository/TranslationRepositoryTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Repository/TranslationRepositoryTest.php
@@ -60,7 +60,7 @@ class TranslationRepositoryTest extends BaseTestCase
      */
     public function testFindAllDeprecated()
     {
-        $result = $this->translationRepository->findDeprecatedTranslationsBeforeDate(new \DateTime(), 'messages');
+        $result = $this->translationRepository->findDeprecatedTranslationsBeforeDate(new \DateTime('+5 minutes'), 'messages');
         $this->assertInstanceOf('Kunstmaan\TranslatorBundle\Entity\Translation', $result[0]);
         $this->assertGreaterThan(0, count($result));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In some cases a race condition occurs and this test fails randomly. See https://travis-ci.org/Kunstmaan/KunstmaanBundlesCMS/jobs/428044551#L2005

This is caused by the loading of the fixtures. We provide a specific updated date but the `prePersist` on the `Translation` entity is changing it to `new \DateTime()`, so in some cases this can cause a race condition. 

In the future we should rethink the entity/db related tests by just mocking the entity and have control over what this repository returns.