### PR TITLE
[MediaBundle] Folder types as constants

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -183,7 +183,7 @@
 
                 {# Items #}
                 {% for obj in form %}
-                    <div id="{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}-pp-container" class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
+                    <div class="js-nested-form__item nested-form__item{% if sortable %} js-sortable-item sortable-item{% endif %}"
                             {% if attr['nested_deletable'] is not defined or attr['nested_deletable'] != false %}
                                 data-delete-key="{{ form.vars.id|replace({'form_': 'delete_'}) }}_{% if obj.vars.value.id is defined %}{{ obj.vars.value.id }}{% else %}{{ obj.vars.value }}{% endif %}"
                             {% endif %}

--- a/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
+++ b/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
@@ -6,6 +6,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Kunstmaan\MediaBundle\Entity\Folder;
+use Kunstmaan\MediaBundle\Folders\FolderTypes;
 
 /**
  * Fixtures that make a general media-folder for a project
@@ -22,7 +23,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager)
     {
         $gal = new Folder();
-        $gal->setRel('media');
+        $gal->setRel(FolderTypes::MEDIA);
         $gal->setName('Media');
         $gal->setTranslatableLocale('en');
         $manager->persist($gal);
@@ -43,7 +44,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
 
         $subgal = new Folder();
         $subgal->setParent($gal);
-        $subgal->setRel('image');
+        $subgal->setRel(FolderTypes::IMAGE);
         $subgal->setName('Images');
         $subgal->setTranslatableLocale('en');
         $manager->persist($subgal);
@@ -64,7 +65,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
 
         $subgal = new Folder();
         $subgal->setParent($gal);
-        $subgal->setRel('files');
+        $subgal->setRel(FolderTypes::FILES);
         $subgal->setName('Files');
         $subgal->setTranslatableLocale('en');
         $manager->persist($subgal);
@@ -85,7 +86,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
 
         $subgal = new Folder();
         $subgal->setParent($gal);
-        $subgal->setRel('slideshow');
+        $subgal->setRel(FolderTypes::SLIDESHOW);
         $subgal->setName('Slides');
         $subgal->setTranslatableLocale('en');
         $manager->persist($subgal);
@@ -106,7 +107,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
 
         $subgal = new Folder();
         $subgal->setParent($gal);
-        $subgal->setRel('video');
+        $subgal->setRel(FolderTypes::VIDEO);
         $subgal->setName('Videos');
         $subgal->setTranslatableLocale('en');
         $manager->persist($subgal);

--- a/src/Kunstmaan/MediaBundle/Folders/FolderTypes.php
+++ b/src/Kunstmaan/MediaBundle/Folders/FolderTypes.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Folders;
+
+/**
+ * Class FolderTypes
+ *
+ * Enabled folder types.
+ *
+ * @package Kunstmaan\MediaBundle\Folders
+ */
+class FolderTypes
+{
+    const FILES = 'files';
+    const IMAGE = 'image';
+    const MEDIA = 'media';
+    const SLIDESHOW = 'slideshow';
+    const VIDEO = 'video';
+
+    public static function allTypes()
+    {
+        return [
+            self::MEDIA => self::MEDIA,
+            self::IMAGE => self::IMAGE,
+            self::FILES => self::FILES,
+            self::SLIDESHOW => self::SLIDESHOW,
+            self::VIDEO => self::VIDEO,
+        ];
+    }
+}

--- a/src/Kunstmaan/MediaBundle/Form/FolderType.php
+++ b/src/Kunstmaan/MediaBundle/Form/FolderType.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Form;
 
+use Kunstmaan\MediaBundle\Folders\FolderTypes;
 use Kunstmaan\MediaBundle\Repository\FolderRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -40,12 +41,7 @@ class FolderType extends AbstractType
                 'rel',
                 ChoiceType::class,
                 array(
-                    'choices' => array(
-                        'media' => 'media',
-                        'image' => 'image',
-                        'slideshow' => 'slideshow',
-                        'video' => 'video'
-                    ),
+                    'choices' => FolderTypes::allTypes(),
                     'label' => 'media.folder.addsub.form.rel'
                 )
             )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I noticed a difference between the FolderType rel-field and the ones added in the fixtures. Extracted all used values into a class with constants.

ps. I'm not sure why, but it's showing a change in fields.html.twig (src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig) again, while that's a change already merged into 5.0 ?