### PR TITLE
[NodeBundle] Revert "Fix bug in NodeChoiceType (#2115)"

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
@@ -42,20 +42,18 @@ class NodeChoiceType extends AbstractType
                 $queryBuilder = call_user_func($queryBuilder, $options['em']->getRepository($options['class']));
             }
 
-            $queryBuilder
-                ->select('n, nt')
-                ->innerJoin('n.nodeTranslations', 'nt')
-                ->innerJoin('nt.publicNodeVersion', 'nv')
-                ->andWhere('nt.online = :online')
-                ->andWhere('nt.lang = :lang')
-                ->andWhere('n.deleted != 1')
-                ->setParameter('lang', $options['locale'] ? $options['locale'] : $this->getCurrentLocale())
-                ->setParameter('online', $options['online']);
-
             if (!empty($options['page_class'])) {
                 $queryBuilder
+                    ->select('n, nt')
+                    ->innerJoin('n.nodeTranslations', 'nt')
+                    ->innerJoin('nt.publicNodeVersion', 'nv')
+                    ->andWhere('nt.online = :online')
+                    ->andWhere('nt.lang = :lang')
+                    ->andWhere('n.deleted != 1')
                     ->andWhere('n.refEntityName IN(:refEntityName)')
-                    ->setParameter('refEntityName', $options['page_class']);
+                    ->setParameter('lang', $options['locale'] ? $options['locale'] : $this->getCurrentLocale())
+                    ->setParameter('refEntityName', $options['page_class'])
+                    ->setParameter('online', $options['online']);
             }
 
             return $queryBuilder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This reverts commit 31d0cbb67dddb448656a01670017b1b625be615a.

This reverts pull request #2115 because it's current implementation is BC breaking. In the NodeChoiceType, it's possible to overwrite the querybuilder with a custom querybuilder, for example:
```
        $builder
            ->add('node', NodeChoiceType::class, [
                'required' => true,
                'multiple' => false,
                'attr' => [
                    'class' => 'js-advanced-select',
                ],
                'label' => 'Some label',
                'query_builder' => function (NodeRepository $repo) use ($options) {
                    return $repo->createQueryBuilder('n')
                        ->innerJoin('n.nodeTranslations', 'nt')
                        ->innerJoin('nt.publicNodeVersion', 'nv')
                        ->andWhere(.....
                        ;
                },
            ]) 
```
With the the version of the NodeChoiceType as in PR #2115 , the page is broken because:

> [Semantical Error] line 0, col 259 near 'nt INNER JOIN': Error: 'nt' is already defined.

@wesleylancel Could you have another look at this issue, trying to find a non BC breaking solution?