### PR TITLE
[AdminListBundle] Feature/sortable adminlist

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -14,6 +14,8 @@ use Kunstmaan\AdminListBundle\AdminList\SortableInterface;
 use Kunstmaan\AdminListBundle\Entity\LockableEntityInterface;
 use Kunstmaan\AdminListBundle\Event\AdminListEvent;
 use Kunstmaan\AdminListBundle\Event\AdminListEvents;
+use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Kunstmaan\AdminListBundle\Service\EntityVersionLockService;
@@ -405,7 +407,10 @@ abstract class AdminListController extends Controller
     {
         $em = $this->getEntityManager();
         $sortableField = $configurator->getSortableField();
-        $repo = $em->getRepository($configurator->getRepositoryName());
+
+        $repositoryName = $this->getAdminListRepositoryName($configurator);
+
+        $repo = $em->getRepository($repositoryName);
         $item = $repo->find($entityId);
 
         $setter = "set".ucfirst($sortableField);
@@ -438,7 +443,10 @@ abstract class AdminListController extends Controller
     {
         $em = $this->getEntityManager();
         $sortableField = $configurator->getSortableField();
-        $repo = $em->getRepository($configurator->getRepositoryName());
+
+        $repositoryName = $this->getAdminListRepositoryName($configurator);
+
+        $repo = $em->getRepository($repositoryName);
         $item = $repo->find($entityId);
 
         $setter = "set".ucfirst($sortableField);
@@ -536,5 +544,20 @@ abstract class AdminListController extends Controller
             $action = new SimpleItemAction($route, 'arrow-down', 'kuma_admin_list.action.move_down');
             $configurator->addItemAction($action);
         }
+    }
+
+    /**
+     * @param AbstractAdminListConfigurator $configurator
+     * @return string
+     */
+    protected function getAdminListRepositoryName(AbstractAdminListConfigurator $configurator) {
+        $em = $this->getEntityManager();
+        $className = $em->getClassMetadata($configurator->getRepositoryName())->getName();
+
+        if(class_implements($className,HasNodeInterface::class)) {
+            return NodeTranslation::class;
+        }
+
+        return $configurator->getRepositoryName();
     }
 }

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -554,7 +554,8 @@ abstract class AdminListController extends Controller
         $em = $this->getEntityManager();
         $className = $em->getClassMetadata($configurator->getRepositoryName())->getName();
 
-        if(class_implements($className,HasNodeInterface::class)) {
+        $implements = class_implements($className);
+        if (isset($implements[HasNodeInterface::class])) {
             return NodeTranslation::class;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When using an adminlist for pages, sorting does not work. The $entityId is the id of the NodeTranslation, not the entity. Which means that the page is never found, because $repo = $em->getRepository($configurator->getRepositoryName()); returns the repository of the page.
This fix checks if the adminlist is for a page, if it is then it should always use the NodeTranslationRepository, if not then it uses the repository of the entity.
