### PR TITLE
[PagePartBundle] Translate pagepart type name in delete modal

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/pagepart.html.twig
@@ -92,14 +92,14 @@
                         <i class="fa fa-times"></i>
                     </button>
                     <h3>
-                        {{ 'kuma_pagepart.modal.delete.title.%type%'|trans({'%type%': pagepartadmin.getType(pagepart)}) }}
+                        {{ 'kuma_pagepart.modal.delete.title.%type%'|trans({'%type%': (pagepartadmin.getType(pagepart)) | trans }) }}
                     </h3>
                 </div>
 
                 <!-- Body -->
                 <div class="modal-body">
                     <p>
-                        {{ 'kuma_pagepart.modal.delete.text.%type%'|trans({'%type%': pagepartadmin.getType(pagepart)}) }}
+                        {{ 'kuma_pagepart.modal.delete.text.%type%'|trans({'%type%': (pagepartadmin.getType(pagepart)) | trans }) }}
                     </p>
                 </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | []

We use a translation message as pagepart name. The pagepart name/message string isn't translated in the delete modal.

`Verwijderen van pagepart 'Titel' ` 
vs. 
`Verwijderen van pagepart 'website.admin.pageparts.header'`
