### PR TITLE
[NodeBundle] Improved error shown when a page does not have a view path

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -105,7 +105,7 @@ class SlugController extends Controller
 
         $view = $renderContext->getView();
         if (empty($view)) {
-            throw $this->createNotFoundException('No page found for slug ' . $url);
+            throw $this->createNotFoundException(sprintf('Missing view path for page "%s"', get_class($entity)));
         }
 
         $template = new Template(array());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Better error message when view (path) is empty