### PR TITLE
[AdminBundle][AdminListBundle] Revert code changes for container access deprecation to make symfony 4 upgrade easier

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/BaseSettingsController.php
@@ -6,27 +6,4 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class BaseSettingsController extends Controller
 {
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function get($id)
-    {
-        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
-
-        return parent::get($id);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function getParameter($name)
-    {
-        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
-
-        return parent::getParameter($name);
-    }
 }

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -29,31 +29,6 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 abstract class AdminListController extends Controller
 {
     /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function get($id)
-    {
-        @trigger_error('Getting services directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary dependencies.', E_USER_DEPRECATED);
-
-        return parent::get($id);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    protected function getParameter($name)
-    {
-        @trigger_error('Getting parameters directly from the container is deprecated in KunstmaanAdminListBundle 5.1 and will be removed in KunstmaanAdminListBundle 6.0. Register your controllers as services and inject the necessary parameters.', E_USER_DEPRECATED);
-
-        return parent::getParameter($name);
-    }
-
-
-    /**
      * You can override this method to return the correct entity manager when using multiple databases ...
      *
      * @return \Doctrine\Common\Persistence\ObjectManager|object


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The method we override here is an internal method so it has changes from 3.4 -> 4.0. This makes it currently hard to support both versions without BC breaks. So I suggest to revert this deprecation warning for now (until we can come up with a better fix). We currently have a notice about removing container access in these controller in our upgrade guide so this will do for now.