### PR TITLE
[GeneratorBundle] fix gulp dependency

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/package.json
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-import": "^2.2.0",
     "exports-loader": "^0.6.4",
     "gsap": "^1.19.1",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-cached": "^1.1.1",
     "gulp-chug": "^0.5.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Gulp recently deleted their 4.0 branch and switched to the 4.0 tag. This removal of the branch breaks the frontend setup since it still references this branch.