### PR TITLE
[AllBundles] Changes for upcoming travis-ci infra migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache/files


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Travis is deprecating the sudo keyword and moves everything to the same infrastructure (sudo really selects between two infrastructures).
