### PR TITLE
[AllBundles] Replace deprecated Route/Method annotations

### DIFF
--- a/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Entity\DashboardConfiguration;
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\DashboardConfigurationType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Kunstmaan/AdminBundle/Controller/ExceptionController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/ExceptionController.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\AdminList\ExceptionAdminListConfigurator;
 use Kunstmaan\AdminBundle\Entity\Exception;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Kunstmaan/AdminBundle/Controller/ModulesController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/ModulesController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 

--- a/src/Kunstmaan/AdminBundle/Controller/SettingsController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/SettingsController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 

--- a/src/Kunstmaan/CacheBundle/Controller/VarnishController.php
+++ b/src/Kunstmaan/CacheBundle/Controller/VarnishController.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\CacheBundle\Controller;
 use Kunstmaan\CacheBundle\Form\Varnish\BanType;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Kunstmaan/ConfigBundle/Controller/ConfigController.php
+++ b/src/Kunstmaan/ConfigBundle/Controller/ConfigController.php
@@ -4,7 +4,7 @@ namespace Kunstmaan\ConfigBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\ConfigBundle\Entity\AbstractConfig;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormFactoryInterface;

--- a/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
@@ -4,7 +4,7 @@ namespace Kunstmaan\DashboardBundle\Controller;
 
 use Kunstmaan\DashboardBundle\Manager\WidgetManager;
 use Kunstmaan\DashboardBundle\Widget\DashboardWidget;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
@@ -7,7 +7,7 @@ use Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsGoal;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Kunstmaan\DashboardBundle\Repository\AnalyticsOverviewRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\DashboardBundle\Controller;
 
 use Kunstmaan\DashboardBundle\Repository\AnalyticsConfigRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/DashboardBundle/Widget/DashboardWidget.php
+++ b/src/Kunstmaan/DashboardBundle/Widget/DashboardWidget.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\DashboardBundle\Widget;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
+++ b/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
@@ -10,8 +10,7 @@ use Kunstmaan\FormBundle\AdminList\FormPageAdminListConfigurator;
 use Kunstmaan\FormBundle\AdminList\FormSubmissionAdminListConfigurator;
 use Kunstmaan\FormBundle\AdminList\FormSubmissionExportListConfigurator;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -54,8 +53,7 @@ class FormSubmissionsController extends Controller
      * @param int $nodeTranslationId
      *
      * @Route("/list/{nodeTranslationId}", requirements={"nodeTranslationId" = "\d+"},
-     *                                     name="KunstmaanFormBundle_formsubmissions_list")
-     * @Method({"GET", "POST"})
+     *                                     name="KunstmaanFormBundle_formsubmissions_list", methods={"GET", "POST"})
      * @Template("@KunstmaanForm/FormSubmissions/list.html.twig")
      *
      * @return array
@@ -82,8 +80,7 @@ class FormSubmissionsController extends Controller
      * @param int $submissionId      The submission id
      *
      * @Route("/list/{nodeTranslationId}/{submissionId}", requirements={"nodeTranslationId" = "\d+", "submissionId" =
-     *                                                    "\d+"}, name="KunstmaanFormBundle_formsubmissions_list_edit")
-     * @Method({"GET", "POST"})
+     *                                                    "\d+"}, name="KunstmaanFormBundle_formsubmissions_list_edit", methods={"GET", "POST"})
      * @Template("@KunstmaanForm/FormSubmissions/edit.html.twig")
      *
      * @return array
@@ -116,8 +113,7 @@ class FormSubmissionsController extends Controller
      * @param int $nodeTranslationId
      *
      * @Route("/export/{nodeTranslationId}.{_format}", requirements={"nodeTranslationId" = "\d+","_format" =
-     *                                                 "csv|xlsx|ods"}, name="KunstmaanFormBundle_formsubmissions_export")
-     * @Method({"GET"})
+     *                                                 "csv|xlsx|ods"}, name="KunstmaanFormBundle_formsubmissions_export", methods={"GET"})
      *
      * @return Response
      */
@@ -139,9 +135,9 @@ class FormSubmissionsController extends Controller
      * @Route(
      *      "/{id}/delete",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanFormBundle_formsubmissions_delete"
+     *      name="KunstmaanFormBundle_formsubmissions_delete",
+     *      methods={"POST"}
      * )
-     * @Method("POST")
      *
      * @param Request $request
      * @param int     $id

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/Controller/EntityAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/Controller/EntityAdminListController.php
@@ -4,8 +4,7 @@ namespace {{ namespace }}\Controller;
 
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}AdminListConfigurator;
@@ -45,8 +44,7 @@ class {{ entity_class }}AdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -59,8 +57,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -74,8 +71,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/view", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_view")
-     * @Method({"GET"})
+     * @Route("/{id}/view", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_view", methods={"GET"})
      *
      * @return array
      */
@@ -89,8 +85,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -104,8 +99,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param string $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "{{ export_extensions }}"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "{{ export_extensions }}"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_export", methods={"GET", "POST"})
      * @return array
      */
     public function exportAction(Request $request, $_format)
@@ -119,8 +113,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_up")
-     * @Method({"GET"})
+     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_up", methods={"GET"})
      *
      * @return array
      */
@@ -134,8 +127,7 @@ class {{ entity_class }}AdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_down")
-     * @Method({"GET"})
+     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_down", methods={"GET"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
@@ -6,7 +6,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleAuthorAdminListController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}AuthorAdminListConfigurator;
@@ -37,8 +37,7 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -51,8 +50,7 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -66,8 +64,7 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -81,8 +78,7 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
      *
      * @param $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_export", methods={"GET", "POST"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
@@ -4,7 +4,7 @@ namespace {{ namespace }}\Controller;
 
 use {{ namespace }}\AdminList\{{ entity_class }}CategoryAdminListConfigurator;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleCategoryAdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +29,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -43,8 +42,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_edit", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -58,8 +56,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_view")
-     * @Method({"GET"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_view", methods={"GET"})
      *
      * @return Response
      */
@@ -73,8 +70,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_delete", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -88,8 +84,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param string $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_export", methods={"GET", "POST"})
      * @return array
      */
     public function exportAction(Request $request, $_format)
@@ -102,8 +97,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param int $id
      *
-     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_up")
-     * @Method({"GET"})
+     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_up", methods={"GET"})
      *
      * @return Response
      */
@@ -117,8 +111,7 @@ class {{ entity_class }}CategoryAdminListController extends AbstractArticleCateg
      *
      * @param int $id
      *
-     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_down")
-     * @Method({"GET"})
+     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_down", methods={"GET"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
@@ -6,7 +6,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticlePageAdminListController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}PageAdminListConfigurator;
@@ -37,8 +37,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -51,8 +50,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -66,8 +64,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -81,8 +78,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
      *
      * @param $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_export", methods={"GET", "POST"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
@@ -4,7 +4,7 @@ namespace {{ namespace }}\Controller;
 
 use {{ namespace }}\AdminList\{{ entity_class }}TagAdminListConfigurator;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleTagAdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +29,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -43,8 +42,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_edit", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -58,8 +56,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_view")
-     * @Method({"GET"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_view", methods={"GET"})
      *
      * @return Response
      */
@@ -73,8 +70,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_delete", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -88,8 +84,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param string $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_export", methods={"GET", "POST"})
      * @return array
      */
     public function exportAction(Request $request, $_format)
@@ -102,8 +97,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param int $id
      *
-     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_up")
-     * @Method({"GET"})
+     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_up", methods={"GET"})
      *
      * @return Response
      */
@@ -117,8 +111,7 @@ class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminLi
      *
      * @param int $id
      *
-     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_down")
-     * @Method({"GET"})
+     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_down", methods={"GET"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/bundle/DefaultController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/bundle/DefaultController.php
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }}\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template,
     Symfony\Bundle\FrameworkBundle\Controller\Controller;

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/BikeAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/BikeAdminListController.php
@@ -5,7 +5,7 @@ namespace {{ namespace }}\Controller;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\BikeAdminListConfigurator;
@@ -42,8 +42,7 @@ class BikeAdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/add", name="{{ bundle_name|lower }}_admin_bike_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="{{ bundle_name|lower }}_admin_bike_add", methods={"GET", "POST"})
      * @return array
      */
     public function addAction(Request $request)
@@ -56,8 +55,7 @@ class BikeAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -71,8 +69,7 @@ class BikeAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -82,8 +79,7 @@ class BikeAdminListController extends AdminListController
     }
 
     /**
-     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle_name|lower }}_admin_bike_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle_name|lower }}_admin_bike_export", methods={"GET", "POST"})
      * @return array
      */
     public function exportAction(Request $request, $_format)
@@ -96,8 +92,7 @@ class BikeAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_up")
-     * @Method({"GET"})
+     * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_up", methods={"GET"})
      *
      * @return array
      */
@@ -111,8 +106,7 @@ class BikeAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_down")
-     * @Method({"GET"})
+     * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_down", methods={"GET"})
      *
      * @return array
      */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
@@ -3,7 +3,7 @@
 namespace {{ namespace }}\Controller;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\LeadGenerationBundle\Controller;
 use Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup;
 use Kunstmaan\LeadGenerationBundle\Form\NewsletterSubscriptionType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -29,8 +29,7 @@ abstract class AbstractNewsletterController extends Controller
     }
 
     /**
-     * @Route("/{popup}/subscribe", name="popup_newsletter_subscribe", requirements={"popup": "\d+"})
-     * @Method("POST")
+     * @Route("/{popup}/subscribe", name="popup_newsletter_subscribe", requirements={"popup": "\d+"}, methods={"POST"})
      * @Template()
      */
     public function subscribeAction(Request $request, $popup)

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\LeadGenerationBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 abstract class AbstractRedirectController extends Controller

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/PopupsAdminListController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/PopupsAdminListController.php
@@ -7,8 +7,7 @@ use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterf
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\LeadGenerationBundle\AdminList\PopupAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 class PopupsAdminListController extends AdminListController
@@ -55,8 +54,7 @@ class PopupsAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -70,8 +68,7 @@ class PopupsAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -83,8 +80,7 @@ class PopupsAdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/add",  name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add",  name="kunstmaanleadgenerationbundle_admin_popup_abstractpopup_add", methods={"GET", "POST"})
      *
      * @return array
      */

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/RulesAdminListController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/RulesAdminListController.php
@@ -5,8 +5,7 @@ namespace Kunstmaan\LeadGenerationBundle\Controller;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\LeadGenerationBundle\AdminList\RulesAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 class RulesAdminListController extends AdminListController
@@ -41,8 +40,7 @@ class RulesAdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/{popup}/add", requirements={"popup" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_add")
-     * @Method({"GET", "POST"})
+     * @Route("/{popup}/add", requirements={"popup" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_add", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -58,8 +56,7 @@ class RulesAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{popup}/rules/{id}/edit", requirements={"popup" = "\d+", "rule" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{popup}/rules/{id}/edit", requirements={"popup" = "\d+", "rule" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -73,8 +70,7 @@ class RulesAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{popup}/rules/{id}/delete", requirements={"popup" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{popup}/rules/{id}/delete", requirements={"popup" = "\d+"}, name="kunstmaanleadgenerationbundle_admin_rule_abstractrule_delete", methods={"GET", "POST"})
      *
      * @return array
      */

--- a/src/Kunstmaan/MediaBundle/Controller/AviaryController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/AviaryController.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\MediaBundle\Controller;
 use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -9,7 +9,7 @@ use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Form\FolderType;
 use Kunstmaan\MediaBundle\Helper\Media\AbstractMediaHandler;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -8,8 +8,7 @@ use Kunstmaan\MediaBundle\AdminList\MediaAdminListConfigurator;
 use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Form\FolderType;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -154,8 +153,7 @@ class FolderController extends Controller
      * @param Request $request
      * @param int     $folderId
      *
-     * @Route("/subcreate/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_sub_create")
-     * @Method({"GET", "POST"})
+     * @Route("/subcreate/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_sub_create", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -215,8 +213,7 @@ class FolderController extends Controller
      * @param Request $request
      * @param int     $folderId
      *
-     * @Route("/empty/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_empty")
-     * @Method({"GET", "POST"})
+     * @Route("/empty/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_folder_empty", methods={"GET", "POST"})
      *
      * @return Response
      */

--- a/src/Kunstmaan/MediaBundle/Controller/IconFontController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/IconFontController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\MediaBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -8,8 +8,7 @@ use Kunstmaan\MediaBundle\Entity\Folder;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Form\BulkMoveMediaType;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\File\File;
@@ -293,8 +292,7 @@ class MediaController extends Controller
      * @param Request $request
      * @param int     $folderId
      *
-     * @Route("drop/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_media_drop_upload")
-     * @Method({"GET", "POST"})
+     * @Route("drop/{folderId}", requirements={"folderId" = "\d+"}, name="KunstmaanMediaBundle_media_drop_upload", methods={"GET", "POST"})
      *
      * @return JsonResponse
      */
@@ -337,8 +335,7 @@ class MediaController extends Controller
      * @param int     $folderId The folder id
      * @param string  $type     The type
      *
-     * @Route("create/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_create")
-     * @Method({"GET", "POST"})
+     * @Route("create/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_create", methods={"GET", "POST"})
      * @Template("@KunstmaanMedia/Media/create.html.twig")
      *
      * @return array|RedirectResponse
@@ -423,8 +420,7 @@ class MediaController extends Controller
      * @param int     $folderId The folder id
      * @param string  $type     The type
      *
-     * @Route("create/modal/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_modal_create")
-     * @Method({"POST"})
+     * @Route("create/modal/{folderId}/{type}", requirements={"folderId" = "\d+", "type" = ".+"}, name="KunstmaanMediaBundle_media_modal_create", methods={"POST"})
      *
      * @return array|RedirectResponse
      */
@@ -454,8 +450,7 @@ class MediaController extends Controller
     /**
      * @param Request $request
      *
-     * @Route("move/", name="KunstmaanMediaBundle_media_move")
-     * @Method({"POST"})
+     * @Route("move/", name="KunstmaanMediaBundle_media_move", methods={"POST"})
      *
      * @return string
      */

--- a/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuAdminListController.php
@@ -7,7 +7,7 @@ use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractAdminListConfigurat
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 class MenuAdminListController extends AdminListController

--- a/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
+++ b/src/Kunstmaan/MenuBundle/Controller/MenuItemAdminListController.php
@@ -8,8 +8,7 @@ use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterf
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\MenuBundle\Entity\BaseMenu;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -101,8 +100,7 @@ class MenuItemAdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/{menuid}/items/add", name="kunstmaanmenubundle_admin_menuitem_add")
-     * @Method({"GET", "POST"})
+     * @Route("/{menuid}/items/add", name="kunstmaanmenubundle_admin_menuitem_add", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -116,8 +114,7 @@ class MenuItemAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("{menuid}/items/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaanmenubundle_admin_menuitem_edit")
-     * @Method({"GET", "POST"})
+     * @Route("{menuid}/items/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaanmenubundle_admin_menuitem_edit", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -131,8 +128,7 @@ class MenuItemAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("{menuid}/items/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanmenubundle_admin_menuitem_delete")
-     * @Method({"GET", "POST"})
+     * @Route("{menuid}/items/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanmenubundle_admin_menuitem_delete", methods={"GET", "POST"})
      *
      * @return array
      */
@@ -144,8 +140,7 @@ class MenuItemAdminListController extends AdminListController
     /**
      * Move an item up in the list.
      *
-     * @Route("{menuid}/items/{item}/move-up", name="kunstmaanmenubundle_admin_menuitem_move_up")
-     * @Method({"GET"})
+     * @Route("{menuid}/items/{item}/move-up", name="kunstmaanmenubundle_admin_menuitem_move_up", methods={"GET"})
      *
      * @return RedirectResponse
      */
@@ -167,8 +162,7 @@ class MenuItemAdminListController extends AdminListController
     /**
      * Move an item down in the list.
      *
-     * @Route("{menuid}/items/{item}/move-down", name="kunstmaanmenubundle_admin_menuitem_move_down")
-     * @Method({"GET"})
+     * @Route("{menuid}/items/{item}/move-down", name="kunstmaanmenubundle_admin_menuitem_move_down", methods={"GET"})
      *
      * @return RedirectResponse
      */

--- a/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
+++ b/src/Kunstmaan/MultiDomainBundle/Controller/SiteSwitchController.php
@@ -3,8 +3,7 @@
 namespace Kunstmaan\MultiDomainBundle\Controller;
 
 use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,8 +14,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class SiteSwitchController extends Controller
 {
     /**
-     * @Route("/switch-site", name="KunstmaanMultiDomainBundle_switch_site")
-     * @Method({"GET"})
+     * @Route("/switch-site", name="KunstmaanMultiDomainBundle_switch_site", methods={"GET"})
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -34,8 +34,7 @@ use Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeAdminPublisher;
 use Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeVersionLockHelper;
 use Kunstmaan\NodeBundle\Repository\NodeVersionRepository;
 use Kunstmaan\UtilitiesBundle\Helper\ClassLookup;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -154,9 +153,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/copyfromotherlanguage",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_copyfromotherlanguage"
+     *      name="KunstmaanNodeBundle_nodes_copyfromotherlanguage",
+     *      methods={"GET"}
      * )
-     * @Method("GET")
      *
      * @param Request $request
      * @param int     $id      The node id
@@ -206,9 +205,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/recopyfromotherlanguage",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_recopyfromotherlanguage"
+     *      name="KunstmaanNodeBundle_nodes_recopyfromotherlanguage",
+     *      methods={"POST"}
      * )
-     * @Method("POST")
      *
      * @param Request $request
      * @param int     $id      The node id
@@ -257,9 +256,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/createemptypage",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_createemptypage"
+     *      name="KunstmaanNodeBundle_nodes_createemptypage",
+     *      methods={"GET"}
      * )
-     * @Method("GET")
      *
      * @param Request $request
      * @param int     $id
@@ -299,8 +298,7 @@ class NodeAdminController extends Controller
     /**
      * @Route("/{id}/publish", requirements={"id" =
      *                         "\d+"},
-     *                         name="KunstmaanNodeBundle_nodes_publish")
-     * @Method({"GET", "POST"})
+     *                         name="KunstmaanNodeBundle_nodes_publish", methods={"GET", "POST"})
      *
      * @param Request $request
      * @param int     $id
@@ -326,9 +324,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/unpublish",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_unpublish"
+     *      name="KunstmaanNodeBundle_nodes_unpublish",
+     *      methods={"GET", "POST"}
      * )
-     * @Method({"GET", "POST"})
      *
      * @param Request $request
      * @param int     $id
@@ -354,9 +352,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/unschedulepublish",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_unschedule_publish"
+     *      name="KunstmaanNodeBundle_nodes_unschedule_publish",
+     *      methods={"GET", "POST"}
      * )
-     * @Method({"GET", "POST"})
      *
      * @param Request $request
      * @param int     $id
@@ -387,9 +385,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/delete",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_delete"
+     *      name="KunstmaanNodeBundle_nodes_delete",
+     *      methods={"POST"}
      * )
-     * @Method("POST")
      *
      * @param Request $request
      * @param int     $id
@@ -452,9 +450,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/duplicate",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_duplicate"
+     *      name="KunstmaanNodeBundle_nodes_duplicate",
+     *      methods={"POST"}
      * )
-     * @Method("POST")
      *
      * @param Request $request
      * @param int     $id
@@ -526,9 +524,9 @@ class NodeAdminController extends Controller
      *      "/{id}/revert",
      *      requirements={"id" = "\d+"},
      *      defaults={"subaction" = "public"},
-     *      name="KunstmaanNodeBundle_nodes_revert"
+     *      name="KunstmaanNodeBundle_nodes_revert",
+     *      methods={"GET"}
      * )
-     * @Method("GET")
      *
      * @param Request $request
      * @param int     $id      The node id
@@ -611,9 +609,9 @@ class NodeAdminController extends Controller
      * @Route(
      *      "/{id}/add",
      *      requirements={"id" = "\d+"},
-     *      name="KunstmaanNodeBundle_nodes_add"
+     *      name="KunstmaanNodeBundle_nodes_add",
+     *      methods={"POST"}
      * )
-     * @Method("POST")
      *
      * @param Request $request
      * @param int     $id
@@ -678,8 +676,7 @@ class NodeAdminController extends Controller
     }
 
     /**
-     * @Route("/add-homepage", name="KunstmaanNodeBundle_nodes_add_homepage")
-     * @Method("POST")
+     * @Route("/add-homepage", name="KunstmaanNodeBundle_nodes_add_homepage", methods={"POST"})
      *
      * @return RedirectResponse
      *
@@ -728,8 +725,7 @@ class NodeAdminController extends Controller
     }
 
     /**
-     * @Route("/reorder", name="KunstmaanNodeBundle_nodes_reorder")
-     * @Method("POST")
+     * @Route("/reorder", name="KunstmaanNodeBundle_nodes_reorder", methods={"POST"})
      *
      * @param Request $request
      *
@@ -799,10 +795,10 @@ class NodeAdminController extends Controller
      *      "/{id}/{subaction}",
      *      requirements={"id" = "\d+"},
      *      defaults={"subaction" = "public"},
-     *      name="KunstmaanNodeBundle_nodes_edit"
+     *      name="KunstmaanNodeBundle_nodes_edit",
+     *      methods={"GET", "POST"}
      * )
      * @Template("@KunstmaanNode/NodeAdmin/edit.html.twig")
-     * @Method({"GET", "POST"})
      *
      * @param Request $request
      * @param int     $id        The node id

--- a/src/Kunstmaan/NodeBundle/Controller/UrlReplaceController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/UrlReplaceController.php
@@ -3,14 +3,12 @@
 namespace Kunstmaan\NodeBundle\Controller;
 
 use Kunstmaan\NodeBundle\Helper\URLHelper;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class UrlReplaceController
- *
- * @Route(service="kunstmaan_node.url_replace.controller")
  */
 class UrlReplaceController
 {

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -8,7 +8,7 @@ use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\StructureNode;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -188,6 +188,9 @@ services:
             - "@kunstmaan_node.helper.url"
         public: true
 
+    # Add service alias to use controller as a service with the symfony core route annotation
+    Kunstmaan\NodeBundle\Controller\UrlReplaceController: '@kunstmaan_node.url_replace.controller'
+
     kunstmaan_node.helper.node:
         class: Kunstmaan\NodeBundle\Helper\NodeHelper
         arguments:

--- a/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
+++ b/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\PagePartBundle\Controller;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Kunstmaan\PagePartBundle\PagePartAdmin\PagePartAdmin;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\FormType;

--- a/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
+++ b/src/Kunstmaan/RedirectBundle/Controller/RedirectAdminListController.php
@@ -5,8 +5,7 @@ namespace Kunstmaan\RedirectBundle\Controller;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\RedirectBundle\AdminList\RedirectAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -42,8 +41,7 @@ class RedirectAdminListController extends AdminListController
     /**
      * The add action
      *
-     * @Route("/add", name="kunstmaanredirectbundle_admin_redirect_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="kunstmaanredirectbundle_admin_redirect_add", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -57,8 +55,7 @@ class RedirectAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="kunstmaanredirectbundle_admin_redirect_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}", requirements={"id" = "\d+"}, name="kunstmaanredirectbundle_admin_redirect_edit", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -72,8 +69,7 @@ class RedirectAdminListController extends AdminListController
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanredirectbundle_admin_redirect_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaanredirectbundle_admin_redirect_delete", methods={"GET", "POST"})
      *
      * @return Response
      */
@@ -87,8 +83,7 @@ class RedirectAdminListController extends AdminListController
      *
      * @param string $_format
      *
-     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="kunstmaanredirectbundle_admin_redirect_export")
-     * @Method({"GET", "POST"})
+     * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="kunstmaanredirectbundle_admin_redirect_export", methods={"GET", "POST"})
      *
      * @return Response
      */

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -6,7 +6,7 @@ use Kunstmaan\AdminBundle\Controller\BaseSettingsController;
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\SeoBundle\Entity\Robots;
 use Kunstmaan\SeoBundle\Form\RobotsType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\SeoBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
+++ b/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\SitemapBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
@@ -5,8 +5,7 @@ namespace Kunstmaan\TaggingBundle\Controller;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\TaggingBundle\AdminList\TagAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -39,8 +38,7 @@ class TagAdminListController extends AdminListController
     }
 
     /**
-     * @Route("/add", name="kunstmaantaggingbundle_admin_tag_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="kunstmaantaggingbundle_admin_tag_add", methods={"GET", "POST"})
      * @Template("KunstmaanAdminListBundle:Default:add.html.twig")
      *
      * @return array
@@ -51,8 +49,7 @@ class TagAdminListController extends AdminListController
     }
 
     /**
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaantaggingbundle_admin_tag_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="kunstmaantaggingbundle_admin_tag_edit", methods={"GET", "POST"})
      * @Template("KunstmaanAdminListBundle:Default:edit.html.twig")
      */
     public function editAction(Request $request, $id)
@@ -61,8 +58,7 @@ class TagAdminListController extends AdminListController
     }
 
     /**
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaantaggingbundle_admin_tag_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="kunstmaantaggingbundle_admin_tag_delete", methods={"GET", "POST"})
      * @Template("KunstmaanAdminListBundle:Default:delete.html.twig")
      */
     public function deleteAction(Request $request, $id)

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
@@ -5,7 +5,7 @@ namespace Kunstmaan\TranslatorBundle\Controller;
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\TranslatorBundle\Model\Export\ExportCommand;
 use Kunstmaan\TranslatorBundle\Model\Import\ImportCommand;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -11,8 +11,7 @@ use Kunstmaan\TranslatorBundle\AdminList\TranslationAdminListConfigurator;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
 use Kunstmaan\TranslatorBundle\Form\TranslationAdminType;
 use Kunstmaan\TranslatorBundle\Form\TranslationsFileUploadType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -72,8 +71,7 @@ class TranslatorController extends AdminListController
      *
      * @throws \Doctrine\ORM\OptimisticLockException
      *
-     * @Route("/add", name="KunstmaanTranslatorBundle_settings_translations_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="KunstmaanTranslatorBundle_settings_translations_add", methods={"GET", "POST"})
      * @Template("KunstmaanTranslatorBundle:Translator:addTranslation.html.twig")
      */
     public function addAction(Request $request, $keyword = '', $domain = '', $locale = '')
@@ -129,8 +127,7 @@ class TranslatorController extends AdminListController
     /**
      * The edit action
      *
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanTranslatorBundle_settings_translations_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanTranslatorBundle_settings_translations_edit", methods={"GET", "POST"})
      * @Template("KunstmaanTranslatorBundle:Translator:editTranslation.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
@@ -199,8 +196,7 @@ class TranslatorController extends AdminListController
     }
 
     /**
-     * @Route("upload", name="KunstmaanTranslatorBundle_settings_translations_upload")
-     * @Method({"POST", "GET"})
+     * @Route("upload", name="KunstmaanTranslatorBundle_settings_translations_upload", methods={"GET", "POST"})
      * @Template("KunstmaanTranslatorBundle:Translator:addTranslation.html.twig")
      *
      * @param Request $request
@@ -237,8 +233,6 @@ class TranslatorController extends AdminListController
      * @param $keyword
      *
      * @return RedirectResponse
-     *
-     * @Method({"GET"})
      */
     public function editSearchAction($domain, $locale, $keyword)
     {
@@ -268,8 +262,7 @@ class TranslatorController extends AdminListController
      *
      * @throws NotFoundHttpException
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanTranslatorBundle_settings_translations_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanTranslatorBundle_settings_translations_delete", methods={"GET", "POST"})
      */
     public function deleteAction(Request $request, $id)
     {
@@ -311,8 +304,7 @@ class TranslatorController extends AdminListController
      *
      * @return JsonResponse|Response
      *
-     * @Route("/inline-edit", name="KunstmaanTranslatorBundle_settings_translations_inline_edit")
-     * @Method({"POST"})
+     * @Route("/inline-edit", name="KunstmaanTranslatorBundle_settings_translations_inline_edit", methods={"POST"})
      */
     public function inlineEditAction(Request $request)
     {

--- a/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
@@ -9,8 +9,7 @@ use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\GroupType;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\UserManagementBundle\AdminList\GroupAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,8 +48,7 @@ class GroupsController extends BaseSettingsController
     /**
      * Add a group
      *
-     * @Route("/add", name="KunstmaanUserManagementBundle_settings_groups_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="KunstmaanUserManagementBundle_settings_groups_add", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Groups/add.html.twig")
      *
      * @throws AccessDeniedException
@@ -93,8 +91,7 @@ class GroupsController extends BaseSettingsController
      *
      * @param int $id
      *
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_edit", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Groups/edit.html.twig")
      *
      * @throws AccessDeniedException
@@ -139,8 +136,7 @@ class GroupsController extends BaseSettingsController
      *
      * @param int $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_groups_delete", methods={"GET", "POST"})
      *
      * @throws AccessDeniedException
      *

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -9,8 +9,7 @@ use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\RoleType;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\UserManagementBundle\AdminList\RoleAdminListConfigurator;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,8 +47,7 @@ class RolesController extends BaseSettingsController
     /**
      * Add a role
      *
-     * @Route("/add", name="KunstmaanUserManagementBundle_settings_roles_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="KunstmaanUserManagementBundle_settings_roles_add", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Roles/add.html.twig")
      *
      * @throws AccessDeniedException
@@ -92,8 +90,7 @@ class RolesController extends BaseSettingsController
      *
      * @param int $id
      *
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_roles_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_roles_edit", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Roles/edit.html.twig")
      *
      * @throws AccessDeniedException
@@ -138,8 +135,7 @@ class RolesController extends BaseSettingsController
      *
      * @param int $id
      *
-     * @Route ("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_roles_delete")
-     * @Method({"GET", "POST"})
+     * @Route ("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_roles_delete", methods={"GET", "POST"})
      *
      * @throws AccessDeniedException
      *

--- a/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/UsersController.php
@@ -13,8 +13,7 @@ use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\AdminBundle\Form\RoleDependentUserFormInterface;
 use Kunstmaan\AdminListBundle\AdminList\AdminList;
 use Kunstmaan\UserManagementBundle\Event\UserEvents;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -74,8 +73,7 @@ class UsersController extends BaseSettingsController
     /**
      * Add a user
      *
-     * @Route("/add", name="KunstmaanUserManagementBundle_settings_users_add")
-     * @Method({"GET", "POST"})
+     * @Route("/add", name="KunstmaanUserManagementBundle_settings_users_add", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Users/add.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
@@ -132,8 +130,7 @@ class UsersController extends BaseSettingsController
      *
      * @param int $id
      *
-     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_users_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_users_edit", methods={"GET", "POST"})
      * @Template("@KunstmaanUserManagement/Users/edit.html.twig")
      *
      * @throws AccessDeniedException
@@ -224,8 +221,7 @@ class UsersController extends BaseSettingsController
      * @param Request $request
      * @param int     $id
      *
-     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_users_delete")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="KunstmaanUserManagementBundle_settings_users_delete", methods={"GET", "POST"})
      *
      * @throws AccessDeniedException
      *

--- a/src/Kunstmaan/VotingBundle/Controller/VotingController.php
+++ b/src/Kunstmaan/VotingBundle/Controller/VotingController.php
@@ -8,7 +8,7 @@ use Kunstmaan\VotingBundle\Event\Facebook\FacebookSendEvent;
 use Kunstmaan\VotingBundle\Event\LinkedIn\LinkedInShareEvent;
 use Kunstmaan\VotingBundle\Event\UpDown\DownVoteEvent;
 use Kunstmaan\VotingBundle\Event\UpDown\UpVoteEvent;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

This PR fixes the latest `@Route` and `@Method` annotation deprecations in SensioFrameworkExtraBundle 5.2. `@Method` is removed and the allowed http methods should be moved to the route requirements. The `@Route` of the SensioFrameworkExtraBundle is deprecated and the `@Route` annotation of the routing component should be used instead.
