### PR TITLE
[AdminBundle] Remove unused RoleInterface on the group entity

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -7,3 +7,11 @@ General
  * We don't depend on the `symfony/symfony` package anymore, instead the individual `symfony/*` packages are added as dependencies.
    If your code depends on other symfony packages than the ones we require, add them to your project `composer.json`.
  * The `symfony/monolog-bundle` package was removed as it was no dependency of the kunstmaan cms. If you use this in your project, add the `"symfony/monolog-bundle": "~2.8|~3.0"` constraint to your project `composer.json`.
+
+AdminBundle
+-------
+
+* We've removed the `RoleInterface` on the `Kunstmaan\AdminBundle\Entity\Group` entity if you run your code on symfony 4. 
+  The interface was deprecated and removed in symfony 4. If you used this interface to check the `Group` entity change it to
+  the `FOS\UserBundle\Model\GroupInterface`. The `Group` entity won't change if you run on symfony 3.4 but it's adviced to make 
+  this change already.

--- a/src/Kunstmaan/AdminBundle/Entity/Group.php
+++ b/src/Kunstmaan/AdminBundle/Entity/Group.php
@@ -2,243 +2,30 @@
 
 namespace Kunstmaan\AdminBundle\Entity;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\GroupInterface;
-use InvalidArgumentException;
-use Symfony\Component\Security\Core\Role\RoleInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-/**
- * Group
- *
- * @ORM\Entity
- * @ORM\Table(name="kuma_groups")
- */
-class Group implements RoleInterface, GroupInterface
-{
+// NEXT_MAJOR: BC layer for deprecated RoleInterface on sf 3.4. Remove this if (keep the else) and move the content of the trait back into this class. Trait is final/internal by default so can be removed
+if (interface_exists('\Symfony\Component\Security\Core\Role\RoleInterface')) {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
-
-    /**
-     * @Assert\NotBlank()
-     * @ORM\Column(type="string")
-     */
-    protected $name;
-
-    /**
-     * @ORM\ManyToMany(targetEntity="Role")
-     * @ORM\JoinTable(name="kuma_groups_roles",
-     *      joinColumns={@ORM\JoinColumn(name="group_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="role_id", referencedColumnName="id")}
-     * )
-     */
-    protected $roles;
-
-    /**
-     * Construct a new group
+     * Group
      *
-     * @param string $name Name of the group
+     * @ORM\Entity
+     * @ORM\Table(name="kuma_groups")
      */
-    public function __construct($name = '')
+    class Group implements \Symfony\Component\Security\Core\Role\RoleInterface, GroupInterface
     {
-        $this->name = $name;
-        $this->roles = new ArrayCollection();
+        use GroupPropertiesTrait;
     }
-
+} else {
     /**
-     * Get id
+     * Group
      *
-     * @return int
+     * @ORM\Entity
+     * @ORM\Table(name="kuma_groups")
      */
-    public function getId()
+    class Group implements GroupInterface
     {
-        return $this->id;
-    }
-
-    /**
-     * Get string representation of object
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->getName();
-    }
-
-    /**
-     * Returns an array of strings (needed because Symfony ACL doesn't support using RoleInterface yet)
-     *
-     * @return array
-     */
-    public function getRoles()
-    {
-        $result = array();
-        /* @var $role RoleInterface */
-        foreach ($this->roles as $role) {
-            $result[] = $role->getRole();
-        }
-
-        return $result;
-    }
-
-    /**
-     * Returns the true ArrayCollection of Roles.
-     *
-     * @return ArrayCollection
-     */
-    public function getRolesCollection()
-    {
-        return $this->roles;
-    }
-
-    /**
-     * Pass a string, get the desired Role object or null.
-     *
-     * @param string $role
-     *
-     * @return Role|null
-     */
-    public function getRole($role = null)
-    {
-        /* @var $roleItem RoleInterface */
-        foreach ($this->roles as $roleItem) {
-            if ($role == $roleItem->getRole()) {
-                return $roleItem;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Pass a string, checks if we have that Role. Same functionality as getRole() except it returns a boolean.
-     *
-     * @param string $role
-     *
-     * @return bool
-     */
-    public function hasRole($role)
-    {
-        if ($this->getRole($role)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Adds a Role object to the ArrayCollection. Can't type hint due to interface so throws Exception.
-     *
-     * @param Role $role
-     *
-     * @return GroupInterface
-     *
-     * @throws InvalidArgumentException
-     */
-    public function addRole($role)
-    {
-        if (!$role instanceof Role) {
-            throw new InvalidArgumentException('addRole takes a Role object as the parameter');
-        }
-
-        if (!$this->hasRole($role->getRole())) {
-            $this->roles->add($role);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Pass a string, remove the Role object from collection.
-     *
-     * @param string $role
-     *
-     * @return GroupInterface
-     */
-    public function removeRole($role)
-    {
-        $roleElement = $this->getRole($role);
-        if ($roleElement) {
-            $this->roles->removeElement($roleElement);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Pass an ARRAY of Role objects and will clear the collection and re-set it with new Roles.
-     *
-     * @param Role[] $roles array of Role objects
-     *
-     * @return GroupInterface
-     */
-    public function setRoles(array $roles)
-    {
-        $this->roles->clear();
-        foreach ($roles as $role) {
-            $this->addRole($role);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Directly set the ArrayCollection of Roles. Type hinted as Collection which is the parent of (Array|Persistent)Collection.
-     *
-     * @param Collection $collection
-     *
-     * @return GroupInterface
-     */
-    public function setRolesCollection(Collection $collection)
-    {
-        $this->roles = $collection;
-
-        return $this;
-    }
-
-    /**
-     * Return the name of the group
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * Set the name of the group
-     *
-     * @param string $name New name of the group
-     *
-     * @return GroupInterface
-     */
-    public function setName($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * @Assert\Callback
-     *
-     * @param ExecutionContextInterface $context
-     */
-    public function isGroupValid(ExecutionContextInterface $context)
-    {
-        if (!(count($this->getRoles()) > 0)) {
-            $context
-                ->buildViolation('errors.group.selectone', array())
-                ->atPath('rolesCollection')
-                ->addViolation();
-        }
+        use GroupPropertiesTrait;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Entity/GroupPropertiesTrait.php
+++ b/src/Kunstmaan/AdminBundle/Entity/GroupPropertiesTrait.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use FOS\UserBundle\Model\GroupInterface;
+use InvalidArgumentException;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * @final
+ *
+ * @internal
+ */
+trait GroupPropertiesTrait
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string")
+     */
+    protected $name;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Role")
+     * @ORM\JoinTable(name="kuma_groups_roles",
+     *      joinColumns={@ORM\JoinColumn(name="group_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="role_id", referencedColumnName="id")}
+     * )
+     */
+    protected $roles;
+
+    /**
+     * Construct a new group
+     *
+     * @param string $name Name of the group
+     */
+    public function __construct($name = '')
+    {
+        $this->name = $name;
+        $this->roles = new ArrayCollection();
+    }
+
+    /**
+     * Get id
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get string representation of object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Returns an array of strings (needed because Symfony ACL doesn't support using RoleInterface yet)
+     *
+     * @return array
+     */
+    public function getRoles()
+    {
+        $result = array();
+        /* @var $role RoleInterface */
+        foreach ($this->roles as $role) {
+            $result[] = $role->getRole();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns the true ArrayCollection of Roles.
+     *
+     * @return ArrayCollection
+     */
+    public function getRolesCollection()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * Pass a string, get the desired Role object or null.
+     *
+     * @param string $role
+     *
+     * @return Role|null
+     */
+    public function getRole($role = null)
+    {
+        /* @var $roleItem RoleInterface */
+        foreach ($this->roles as $roleItem) {
+            if ($role == $roleItem->getRole()) {
+                return $roleItem;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Pass a string, checks if we have that Role. Same functionality as getRole() except it returns a boolean.
+     *
+     * @param string $role
+     *
+     * @return bool
+     */
+    public function hasRole($role)
+    {
+        if ($this->getRole($role)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Adds a Role object to the ArrayCollection. Can't type hint due to interface so throws Exception.
+     *
+     * @param Role $role
+     *
+     * @return GroupInterface
+     *
+     * @throws InvalidArgumentException
+     */
+    public function addRole($role)
+    {
+        if (!$role instanceof Role) {
+            throw new InvalidArgumentException('addRole takes a Role object as the parameter');
+        }
+
+        if (!$this->hasRole($role->getRole())) {
+            $this->roles->add($role);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Pass a string, remove the Role object from collection.
+     *
+     * @param string $role
+     *
+     * @return GroupInterface
+     */
+    public function removeRole($role)
+    {
+        $roleElement = $this->getRole($role);
+        if ($roleElement) {
+            $this->roles->removeElement($roleElement);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Pass an ARRAY of Role objects and will clear the collection and re-set it with new Roles.
+     *
+     * @param Role[] $roles array of Role objects
+     *
+     * @return GroupInterface
+     */
+    public function setRoles(array $roles)
+    {
+        $this->roles->clear();
+        foreach ($roles as $role) {
+            $this->addRole($role);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Directly set the ArrayCollection of Roles. Type hinted as Collection which is the parent of (Array|Persistent)Collection.
+     *
+     * @param Collection $collection
+     *
+     * @return GroupInterface
+     */
+    public function setRolesCollection(Collection $collection)
+    {
+        $this->roles = $collection;
+
+        return $this;
+    }
+
+    /**
+     * Return the name of the group
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the name of the group
+     *
+     * @param string $name New name of the group
+     *
+     * @return GroupInterface
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @Assert\Callback
+     *
+     * @param ExecutionContextInterface $context
+     */
+    public function isGroupValid(ExecutionContextInterface $context)
+    {
+        if (!(count($this->getRoles()) > 0)) {
+            $context
+                ->buildViolation('errors.group.selectone', array())
+                ->atPath('rolesCollection')
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

I wouldn't consider removing the interface as a "real" BC break the code for users keeps working and the `RoleInterface` shouldn't be used the indentify the `Group` entity in the first place. If we do consider this a BC break, I can rewrite the path to something [like they do in symfony/panthere](https://github.com/symfony/panther/blob/master/src/PantherTestCase.php#L19-L29).
