### PR TITLE
[NodeBundle] Fixed schedule publish route typo

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
@@ -18,7 +18,7 @@
                     |raw
                 }}
             {% endif %}
-            <a href="{{ path('KunstmaanNodeBundle_nodes_unschedule_publish', { 'id': node.id}) }}" class="btn btn-warning btn--raise-on-hover alert__action">
+            <a href="{{ path('KunstmaanNodeBundle_nodes_unschedulepublish', { 'id': node.id}) }}" class="btn btn-warning btn--raise-on-hover alert__action">
                 {{ 'kuma_node.status.button.schedulle_cancel'|trans() }}
             </a>
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Deprecations? |no
| Fixed tickets | n/a

Currently publishing pages later breaks due to a typo in routes. This is a temporary fix for that. It looks like the routing needs checking in `Kunstmaan\NodeBundle\Controller\NodeAdminController`.