### PR TITLE
[ConfigBundle] Remove route service annotation as default route is already provided as service

### DIFF
--- a/src/Kunstmaan/ConfigBundle/Controller/ConfigController.php
+++ b/src/Kunstmaan/ConfigBundle/Controller/ConfigController.php
@@ -4,7 +4,6 @@ namespace Kunstmaan\ConfigBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\ConfigBundle\Entity\AbstractConfig;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -17,8 +16,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Class ConfigController
- *
- * @Route(service="kunstmaan_config.controller.config")
  */
 class ConfigController
 {

--- a/src/Kunstmaan/ConfigBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/ConfigBundle/Resources/config/services.yml
@@ -26,3 +26,4 @@ services:
       - "@doctrine.orm.entity_manager"
       - "%kunstmaan_config%"
       - "@form.factory"
+    public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Followup pr of #2184 and fix for build error detected in Kunstmaan/KunstmaanBundlesStandardEdition#268