### PR TITLE
[NodeSearchBundle] Added tag for node searcher services

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -9,9 +9,15 @@ General
  * The `symfony/monolog-bundle` package was removed as it was no dependency of the kunstmaan cms. If you use this in your project, add the `"symfony/monolog-bundle": "~2.8|~3.0"` constraint to your project `composer.json`.
 
 AdminBundle
--------
+-----------
 
 * We've removed the `RoleInterface` on the `Kunstmaan\AdminBundle\Entity\Group` entity if you run your code on symfony 4. 
   The interface was deprecated and removed in symfony 4. If you used this interface to check the `Group` entity change it to
   the `FOS\UserBundle\Model\GroupInterface`. The `Group` entity won't change if you run on symfony 3.4 but it's adviced to make 
   this change already.
+
+NodeSearchBundle
+----------------
+
+* Depending on the service container to retrieve searchers is deprecated and will be removed in 6.0. Tag your custom node
+  searchers with the "kunstmaan_node_search.node_searcher" tag, to have them available for the NodeSearchBundle.

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/NodeSearcherCompilerPass.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/NodeSearcherCompilerPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class NodeSearcherCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('kunstmaan_node_search.search.service')) {
+            return;
+        }
+
+        $searchers = [];
+        foreach ($container->findTaggedServiceIds('kunstmaan_node_search.node_searcher') as $id => $tags) {
+            $searchers[$id] = new Reference($id);
+        }
+
+        $container
+            ->getDefinition('kunstmaan_node_search.search.service')
+            ->replaceArgument(3, $searchers)
+        ;
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
+++ b/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\NodeSearchBundle;
 
+use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\NodeSearcherCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,4 +11,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanNodeSearchBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new NodeSearcherCompilerPass());
+    }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -23,6 +23,8 @@ services:
             - [ setTokenStorage, ['@security.token_storage']]
             - [ setDomainConfiguration, ['@kunstmaan_admin.domain_configuration']]
             - [ setEntityManager, ['@doctrine.orm.entity_manager']]
+        tags:
+            - { name: kunstmaan_node_search.node_searcher }
 
     kunstmaan_node_search.service.indexable_pageparts:
         class: Kunstmaan\NodeSearchBundle\Helper\IndexablePagePartsService
@@ -48,4 +50,8 @@ services:
 
     kunstmaan_node_search.search.service:
         class: "%kunstmaan_node_search.search_service.class%"
-        arguments: ['@service_container', '@request_stack']
+        arguments:
+            - '@service_container'
+            - '@request_stack'
+            - 10
+            - ~ #Will be replace by the NodeSearcherCompilerPass

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/DependencyInjection/Compiler/NodeSearcherCompilerPassTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/DependencyInjection/Compiler/NodeSearcherCompilerPassTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Tests\unit\DependencyInjection\Compiler;
+
+use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\NodeSearcherCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class NodeSearcherCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTaggerSearchers()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('kunstmaan_node_search.search.service', 'Kunstmaan\NodeSearchBundle\Services\SearchService')
+            ->setArguments([new Reference('service_container'), new Reference('request_stack'), 10, []])
+        ;
+
+        $container->register('custom_searcher_1', 'stdClass')->addTag('kunstmaan_node_search.node_searcher');
+        $container->register('custom_searcher_2', 'stdClass');
+
+        $pass = new NodeSearcherCompilerPass();
+        $pass->process($container);
+        $arguments = $container->getDefinition('kunstmaan_node_search.search.service')->getArguments();
+
+        $expected = [
+            'custom_searcher_1',
+        ];
+
+        $this->assertCount(4, $arguments);
+        $this->assertEquals($expected, array_keys($arguments[3]));
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/Services/SearchServiceTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/Services/SearchServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Tests\unit\Services;
+
+use Elastica\Query;
+use Kunstmaan\NodeSearchBundle\Entity\AbstractSearchPage;
+use Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher;
+use Kunstmaan\NodeSearchBundle\Services\SearchService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SearchServiceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation Getting the node searcher "%s" from the container is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Tag your searcher service with the "kunstmaan_node_search.node_searcher" tag to add a searcher.
+     */
+    public function testLegacyContainerSearcher()
+    {
+        $entity = new AbstractSearchPage();
+        $parameterBag = new ParameterBag();
+        $parameterBag->add([
+            '_entity' => $entity,
+            'query' => '',
+            'type' => 'html/text',
+        ]);
+
+        $request = $this->createMock(Request::class);
+        $request->attributes = $parameterBag;
+        $request->query = $parameterBag;
+
+        $elasticSearcher = $this->createMock(AbstractElasticaSearcher::class);
+        $elasticSearcher->method('setData')->willReturnSelf();
+        $elasticSearcher->method('setContentType')->willReturnSelf();
+        $elasticSearcher->method('getQuery')->willReturn(new Query());
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('kunstmaan_node_search.search.node')->willReturn($elasticSearcher);
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $searcher = new SearchService($container, $requestStack, 10, []);
+
+        $searcher->search();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     */
+    public function testUnknownSearcher()
+    {
+        $entity = $this->createMock(AbstractSearchPage::class);
+        $entity->method('getSearcher')->willReturn('unknown_searcher');
+
+        $parameterBag = new ParameterBag();
+        $parameterBag->set('_entity', $entity);
+
+        $request = $this->createMock(Request::class);
+        $request->attributes = $parameterBag;
+        $request->query = $parameterBag;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with('unknown_searcher')->willThrowException(new ServiceNotFoundException('unknown_searcher'));
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+
+        $searcher = new SearchService($container, $requestStack, 10, []);
+
+        $searcher->search();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Add a tag for node searcher services to deprecate using the container to directly get the search service during a search