### PR TITLE
[MediaBundle] Fix incorrect service name in media compilerpass

### DIFF
--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Compiler/MediaHandlerCompilerPass.php
@@ -35,8 +35,8 @@ class MediaHandlerCompilerPass implements CompilerPassInterface
         }
 
         // Inject the tagged resolvers into our cache manager override
-        if ($container->hasDefinition('kunstmaan_media.imagine.cache.manager')) {
-            $manager = $container->getDefinition('kunstmaan_media.imagine.cache.manager');
+        if ($container->hasDefinition('Kunstmaan\MediaBundle\Helper\Imagine\CacheManager')) {
+            $manager = $container->getDefinition('Kunstmaan\MediaBundle\Helper\Imagine\CacheManager');
 
             foreach ($container->findTaggedServiceIds('liip_imagine.cache.resolver') as $id => $tag) {
                 $manager->addMethodCall('addResolver', [$tag[0]['resolver'], new Reference($id)]);

--- a/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/Compiler/MediaHandlerCompilerPassTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/Compiler/MediaHandlerCompilerPassTest.php
@@ -39,4 +39,21 @@ class MediaHandlerCompilerPassTest extends AbstractCompilerPassTestCase
             [new Reference('kunstmaan_media.icon_font_manager'), 'kunstmaan_media.icon_font_manager']
         );
     }
+
+    public function testLiipImageTaggedResolvers()
+    {
+        $this->setDefinition('Kunstmaan\MediaBundle\Helper\Imagine\CacheManager', new Definition());
+
+        $testResolver = new Definition();
+        $testResolver->addTag('liip_imagine.cache.resolver', ['resolver' => 'test']);
+        $this->setDefinition('test_resolver', $testResolver);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager',
+            'addResolver',
+            ['test', new Reference('test_resolver')]
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed a bug introduced in #2098. I've also added a test to avoid breaking this compiler pass again