### PR TITLE
[AdminBundle] Provide fos/user-bundle default values for from_email config

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -87,8 +87,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->prependExtensionConfig('knp_menu', $knpMenuConfig);
 
         $fosUserConfig['db_driver'] = 'orm'; // other valid values are 'mongodb', 'couchdb'
-        $fosUserConfig['from_email']['address'] = 'admin@kunstmaan.be';
-        $fosUserConfig['from_email']['sender_name'] = 'admin';
+        $fosUserConfig['from_email']['address'] = 'kunstmaancms@myproject.dev';
+        $fosUserConfig['from_email']['sender_name'] = 'KunstmaanCMS';
         $fosUserConfig['firewall_name'] = 'main';
         $fosUserConfig['user_class'] = 'Kunstmaan\AdminBundle\Entity\User';
         $fosUserConfig['group']['group_class'] = 'Kunstmaan\AdminBundle\Entity\Group';

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -94,8 +94,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $fosUserConfig['group']['group_class'] = 'Kunstmaan\AdminBundle\Entity\Group';
         $fosUserConfig['resetting']['token_ttl'] = 86400;
         // Use this node only if you don't want the global email address for the resetting email
-        $fosUserConfig['resetting']['email']['from_email']['address'] = 'admin@kunstmaan.be';
-        $fosUserConfig['resetting']['email']['from_email']['sender_name'] = 'admin';
+        $fosUserConfig['resetting']['email']['from_email']['address'] = 'kunstmaancms@myproject.dev';
+        $fosUserConfig['resetting']['email']['from_email']['sender_name'] = 'KunstmaanCMS';
         $fosUserConfig['resetting']['email']['template'] = 'FOSUserBundle:Resetting:email.txt.twig';
         $fosUserConfig['resetting']['form']['type'] = ResettingFormType::class;
         $fosUserConfig['resetting']['form']['name'] = 'fos_user_resetting_form';

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -87,6 +87,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->prependExtensionConfig('knp_menu', $knpMenuConfig);
 
         $fosUserConfig['db_driver'] = 'orm'; // other valid values are 'mongodb', 'couchdb'
+        $fosUserConfig['from_email']['address'] = 'admin@kunstmaan.be';
+        $fosUserConfig['from_email']['sender_name'] = 'admin';
         $fosUserConfig['firewall_name'] = 'main';
         $fosUserConfig['user_class'] = 'Kunstmaan\AdminBundle\Entity\User';
         $fosUserConfig['group']['group_class'] = 'Kunstmaan\AdminBundle\Entity\Group';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fos/user-bundle has removed the default values for the `from_email` since v2.0. When installing a new  project this throws an exception during composer install/create-project. So let's provide the default values, like we do for the resetting email, to improve DX.