### PR TITLE
[UtilitiesBundle] Deprecate direct set of parameter and use kernel.secret by default

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,18 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('kunstmaan_utilities');
+        $rootNode = $treeBuilder->root('kunstmaan_utilities');
+
+        $rootNode
+            ->children()
+                ->arrayNode('cipher')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('secret')->defaultValue('%kernel.secret%')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/KunstmaanUtilitiesExtension.php
@@ -22,10 +22,12 @@ class KunstmaanUtilitiesExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (isset($config['cipher'], $config['cipher']['secret'])) {
-            $container->setParameter('kunstmaan_utilities.cipher.secret', $config['cipher']['secret']);
-        } elseif (!$container->hasParameter('kunstmaan_utilities.cipher.secret')) {
+        if ($container->hasParameter('kunstmaan_utilities.cipher.secret')) {
+            @trigger_error('Setting the "kunstmaan_utilities.cipher.secret" parameter is deprecated since KunstmaanUtilitiesBundle 5.2, this value will be ignored/overwritten in KunstmaanUtilitiesBundle 6.0. Use the "kunstmaan_utilities.cipher.secret" config instead if you want to set a different value than the default "%kernel.secret%".', E_USER_DEPRECATED);
+        } elseif ($container->hasParameter('secret')) {
             $container->setParameter('kunstmaan_utilities.cipher.secret', $container->getParameter('secret'));
+        } else {
+            $container->setParameter('kunstmaan_utilities.cipher.secret', $config['cipher']['secret']);
         }
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -23,7 +23,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testProcessedValueContainsRequiredValue()
     {
-        $array = [];
+        $array = ['cipher' => ['secret' => '%kernel.secret%']];
 
         $this->assertProcessedConfigurationEquals([$array], $array);
     }

--- a/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/KunstmaanUtilitiesExtensionTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/KunstmaanUtilitiesExtensionTest.php
@@ -19,12 +19,32 @@ class KunstmaanUtilitiesExtensionTest extends AbstractPrependableExtensionTestCa
         return [new KunstmaanUtilitiesExtension()];
     }
 
-    public function testCorrectParametersHaveBeenSet()
+    public function testCorrectDefaultParametersHaveBeenSet()
     {
-        $this->container->setParameter('empty_extension', true);
-        $this->container->setParameter('secret', 'super_secret_value');
         $this->load();
 
-        $this->assertContainerBuilderHasParameter('empty_extension', true);
+        $this->assertContainerBuilderHasParameter('kunstmaan_utilities.cipher.secret', '%kernel.secret%');
+    }
+
+    public function testParameterWithSecretParameter()
+    {
+        $this->setParameter('secret', 'testvalue');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_utilities.cipher.secret', 'testvalue');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Setting the "kunstmaan_utilities.cipher.secret" parameter is deprecated since KunstmaanUtilitiesBundle 5.2, this value will be ignored/overwritten in KunstmaanUtilitiesBundle 6.0. Use the "kunstmaan_utilities.cipher.secret" config instead if you want to set a different value than the default "%kernel.secret%".
+     */
+    public function testLegacyParameterSecretParameter()
+    {
+        $this->setParameter('kunstmaan_utilities.cipher.secret', 'testvalue');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_utilities.cipher.secret', 'testvalue');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate setting the cipher secret parameter directly and replace by a bundle config. This also removes the need of a extra `secret` parameter being set by the user as symfony provides a `kernel.secret` parameter by default. 
