### PR TITLE
[AdminBundle] Update _form-group.scss

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/forms/_form-group.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/forms/_form-group.scss
@@ -12,7 +12,7 @@
     max-width: 40rem;
 }
 
-.form-group--no-max-width {
+.form-group--no-max-width, .form-group--no-max-width textarea {
     max-width: none;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

In our cms, rawHtml type didn't respect the form-group--no-max-width because the textarea under has class form-control which overwrite with max-width: 40rem;