### PR TITLE
[AdminBundle] Move websitetitle to bundle config to remove extra parameter

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('admin_locale')
             ->fixXmlConfig('menu_item')
             ->children()
+                ->scalarNode('website_title')->defaultNull()->end()
                 ->scalarNode('admin_password')->end()
                 ->scalarNode('dashboard_route')->end()
                 ->scalarNode('admin_prefix')->defaultValue('admin')->end()

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -77,6 +77,15 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         if (0 !== count($config['menu_items'])) {
             $this->addSimpleMenuAdaptor($container, $config['menu_items']);
         }
+
+        $websiteTitle = $container->hasParameter('websitetitle') ? $container->getParameter('websitetitle') : '';
+        if (null === $config['website_title']) {
+            @trigger_error('Not providing a value for the "kunstmaan_admin.website_title" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
+        } else {
+            $websiteTitle = $config['website_title'];
+        }
+
+        $container->setParameter('kunstmaan_admin.website_title', $websiteTitle);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -24,6 +24,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     public function testConfigGeneratesAsExpected()
     {
         $array = [
+            'website_title' => null,
             'admin_password' => 'l3tM31n!',
             'admin_locales' => [],
             'session_security' => [

--- a/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/KunstmaanAdminExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/KunstmaanAdminExtensionTest.php
@@ -21,8 +21,6 @@ class KunstmaanAdminExtensionTest extends AbstractPrependableExtensionTestCase
 
     public function testCorrectParametersHaveBeenSet()
     {
-        $this->container->setParameter('kernel.logs_dir', '/somewhere/over/the/rainbow');
-        $this->container->setParameter('kernel.environment', 'staging');
         $this->load([
             'dashboard_route' => true,
             'admin_password' => 'omgchangethis',
@@ -44,5 +42,43 @@ class KunstmaanAdminExtensionTest extends AbstractPrependableExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.google_signin.client_id');
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.google_signin.client_secret');
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.google_signin.hosted_domains');
+    }
+
+    public function testWebsiteTitleWithParameterSet()
+    {
+        $this->setParameter('websitetitle', 'Mywebsite');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.website_title', 'Mywebsite');
+    }
+
+    public function testWebsiteTitleWithParameterAndConfigSet()
+    {
+        $this->setParameter('websitetitle', 'Mywebsite');
+
+        $this->load(['website_title' => 'My real website']);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.website_title', 'My real website');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_admin.website_title" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.
+     */
+    public function testLegacyParameterSecretParameter()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.website_title', '');
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Some parameters required for the admin extension
+        $this->container->setParameter('kernel.logs_dir', '/somewhere/over/the/rainbow');
+        $this->container->setParameter('kernel.environment', 'staging');
     }
 }

--- a/src/Kunstmaan/SeoBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
         class: Kunstmaan\SeoBundle\Twig\SeoTwigExtension
         arguments: ['@doctrine.orm.entity_manager']
         calls:
-            - [setWebsiteTitle, ['%websitetitle%']]
+            - [setWebsiteTitle, ['%kunstmaan_admin.website_title%']]
         tags:
             - { name: twig.extension }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Remove an unnecessary parameters provided by the KunstmaanBundlesStandardEdition to make installations more user friendly