### PR TITLE
[AllBundles] Add php-cs-fixer cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 *test.db
 .vscode
 src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/dist
+.php_cs.cache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Php-cs-fixer config and the style-ci setup was added in #2175, but the php-cs-fixer cache file was not ignored
