### PR TITLE
[AdminBundle] Improve twig template deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "symfony-cmf/routing-bundle": "~2.0",
         "fpn/doctrine-extensions-taggable": "~0.9",
         "sensio/generator-bundle": "~3.0",
-        "twig/twig": "^1.12|^2.0",
+        "twig/twig": "^1.36|^2.6",
         "twig/extensions": "~1.0",
         "egulias/email-validator": "^1.2.8|^2.0",
         "box/spout": "^2.5",

--- a/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword.html.twig
@@ -1,2 +1,3 @@
-{# Deprecated: This template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use change_password.html.twig instead #}
+{% deprecated 'The "' ~ _self ~ '" template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use "change_password.html.twig" instead' %}
+
 {% extends 'change_password.html.twig' %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword_content.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/ChangePassword/changePassword_content.html.twig
@@ -1,2 +1,3 @@
-{# Deprecated: This template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use change_password_content.html.twig instead #}
+{% deprecated 'The "' ~ _self ~ '" template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use "change_password_content.html.twig" instead' %}
+
 {% extends 'change_password_content.html.twig' %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Resetting/checkEmail.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Resetting/checkEmail.html.twig
@@ -1,2 +1,3 @@
-{# Deprecated: This template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use check_email.html.twig instead #}
+{% deprecated 'The "' ~ _self ~ '" template is deprecated since kunstmaanAdminBundle 5.1 and will be removed in kunstmaanAdminBundle 6.0. Use "check_email.html.twig" instead' %}
+
 {% extends 'check_email.html.twig' %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Use the new [twig `{% deprecated %}` tag ](https://symfony.com/blog/new-in-twig-deprecated-tag) to improve the template deprecations we did in 5.1