### PR TITLE
[TranslatorBundle] importer requires wrong locales

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
@@ -38,7 +38,7 @@ final class ImportTranslationsFromFileCommand extends Command
         parent::__construct();
         $this->importer = $importer;
         $this->translator = $translator;
-        $this->locales = explode('|', $locales);
+        $this->locales = $locales;
     }
 
     /**

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -216,7 +216,7 @@ class TranslatorController extends AdminListController
         if (Request::METHOD_POST === $request->getMethod()) {
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
-                $locales = explode('|', $this->container->getParameter('requiredlocales'));
+                $locales = $this->getParameter('kuma_translator.managed_locales');
                 $data = $form->getData();
                 $file = $data['file'];
                 $force = $data['force'];

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
@@ -27,7 +27,7 @@ services:
         arguments:
             - '@kunstmaan_translator.service.importer.importer'
             - '@kunstmaan_translator.service.translator.translator'
-            - '%requiredlocales%'
+            - '%kuma_translator.managed_locales%'
         tags:
             - { name: console.command }
 

--- a/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/Importer.php
@@ -74,8 +74,8 @@ class Importer
         }
 
         $headers = ['domain', 'keyword'];
+        $locales = array_map('strtolower', $locales);
         $requiredHeaders = array_merge($headers, $locales);
-        $requiredHeaders = array_map('strtolower', $requiredHeaders);
 
         try {
             $reader = ReaderFactory::create($format);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This requires the wrong locales so the view in cms and export excel show different locales than what the importer wants for locales.
