### PR TITLE
[KunstmaanTranslatorBundle] improvements to import command

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @final since 5.1
+ * @final      since 5.1
  *
  * @deprecated since 5.1
  * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
@@ -26,14 +26,37 @@ class ImportTranslationsCommand extends ContainerAwareCommand
     private $importCommandHandler;
 
     /**
-     * @param ImportCommandHandler|null $importCommandHandler
+     * @var string
      */
-    public function __construct(/* ImportCommandHandler */ $importCommandHandler = null)
-    {
+    private $defaultBundle;
+
+    /**
+     * @var array
+     */
+    private $bundles;
+
+    /**
+     * ImportTranslationsCommand constructor.
+     *
+     * @param ImportCommandHandler $importCommandHandler
+     * @param string               $defaultBundle
+     * @param array                $bundles
+     */
+    public function __construct(/* ImportCommandHandler */
+        $importCommandHandler = null,
+        string $defaultBundle,
+        array $bundles
+    ) {
         parent::__construct();
 
         if (!$importCommandHandler instanceof ImportCommandHandler) {
-            @trigger_error(sprintf('Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(
+                sprintf(
+                    'Passing a command name as the first argument of "%s" is deprecated since version symfony 3.4 and will be removed in symfony 4.0. If the command was registered by convention, make it a service instead. ',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
 
             $this->setName(null === $importCommandHandler ? 'kuma:translator:import' : $importCommandHandler);
 
@@ -41,6 +64,8 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         }
 
         $this->importCommandHandler = $importCommandHandler;
+        $this->defaultBundle = $defaultBundle;
+        $this->bundles = $bundles;
     }
 
     /**
@@ -54,9 +79,18 @@ class ImportTranslationsCommand extends ContainerAwareCommand
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force import, overwrite all existing database entries')
             ->addOption('locales', 'l', InputOption::VALUE_REQUIRED, 'Language import, only import a specific locale')
             ->addOption('globals', 'g', InputOption::VALUE_NONE, 'Global app import, import the global translations of your app')
-            ->addOption('defaultbundle', 'd', InputOption::VALUE_REQUIRED, 'Import the translations for specific bundles, use "own", "all" or "custom"')
-            ->addOption('bundles', 'b', InputOption::VALUE_OPTIONAL, 'A list of bundle names that need to be imported (comma delimited) , only used When "defaultbundle" is set to "custom"')
-        ;
+            ->addOption(
+                'defaultbundle',
+                'd',
+                InputOption::VALUE_REQUIRED,
+                'Import the translations for specific bundles, use "own", "all" or "custom"'
+            )
+            ->addOption(
+                'bundles',
+                'b',
+                InputOption::VALUE_OPTIONAL,
+                'A list of bundle names that need to be imported (comma delimited) , only used When "defaultbundle" is set to "custom"'
+            );
     }
 
     /**
@@ -68,8 +102,8 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         $force = $input->getOption('force');
         $locales = $input->getOption('locales');
         $globals = $input->getOption('globals');
-        $defaultBundle = $input->getOption('defaultbundle');
-        $bundles = $input->hasOption('bundles') ? array_map('trim', explode(',', $input->getOption('bundles'))) : array();
+        $defaultBundle = $input->getOption('defaultbundle') ?: $this->defaultBundle;
+        $bundles = $input->getOption('bundles') ? array_map('trim', explode(',', $input->getOption('bundles'))) : $this->bundles;
         if (null === $this->importCommandHandler) {
             $this->importCommandHandler = $this->getContainer()->get('kunstmaan_translator.service.importer.command_handler');
         }

--- a/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/commands.yml
@@ -1,6 +1,9 @@
 services:
     Kunstmaan\TranslatorBundle\Command\ImportTranslationsCommand:
-        arguments: ['@kunstmaan_translator.service.importer.command_handler']
+        arguments:
+            - '@kunstmaan_translator.service.importer.command_handler'
+            - '%kuma_translator.default_bundle%'
+            - '%kuma_translator.bundles%'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I've improved the import translations command for better use. Default parameters configured in your  configuration files are now the standard. You can override them if you like.

The command can be used now like `php bin/console kuma:translator:import --globals` instead of having to provide all values.
