### PR TITLE
[GeneratorBundle] Typehint againt interface instead of concrete class

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/BikesTwigExtension.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Twig/BikesTwigExtension.php
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }}\Twig;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
 
 class BikesTwigExtension extends \Twig_Extension
@@ -17,7 +17,7 @@ class BikesTwigExtension extends \Twig_Extension
      *
      * @param EntityManager $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
 	$this->em = $em;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This will make sure the twig extension is autowireable