### PR TITLE
[GeneratorBundle] Enable generators that have support for sf4

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/DependencyInjection/KunstmaanGeneratorExtension.php
+++ b/src/Kunstmaan/GeneratorBundle/DependencyInjection/KunstmaanGeneratorExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kunstmaan\GeneratorBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class KunstmaanGeneratorExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/Kunstmaan/GeneratorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/config/services.yml
@@ -1,0 +1,20 @@
+services:
+    Kunstmaan\GeneratorBundle\Command\GenerateEntityCommand:
+        tags:
+          - { name: console.command }
+
+    Kunstmaan\GeneratorBundle\Command\GenerateLayoutCommand:
+        tags:
+          - { name: console.command }
+
+    Kunstmaan\GeneratorBundle\Command\GenerateDefaultSiteCommand:
+        tags:
+          - { name: console.command }
+
+    Kunstmaan\GeneratorBundle\Command\GenerateDefaultPagePartsCommand:
+        tags:
+          - { name: console.command }
+
+    Kunstmaan\GeneratorBundle\Command\GenerateArticleCommand:
+        tags:
+          - { name: console.command }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

These generators are ready for use in symfony 4. See #2220, #2221, #2222, #2223 
