### PR TITLE
[GeneratorBundle] Remove password replace for sf4

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
@@ -9,6 +9,7 @@ use Kunstmaan\AdminBundle\Entity\User;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Fixture for creating the admin and guest user
@@ -59,10 +60,12 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface, C
             "<comment>  > User 'admin' created with password '$password'</comment>",
         ));
 
-        $file = $this->container->get('kernel')->getRootDir().'/config/config.yml';
-        $contents = file_get_contents($file);
-        $contents = str_replace('-adminpwd-', $password, $contents);
-        file_put_contents($file, $contents);
+        if (Kernel::VERSION_ID < 40000) {
+            $file = $this->container->get('kernel')->getRootDir() . '/config/config.yml';
+            $contents = file_get_contents($file);
+            $contents = str_replace('-adminpwd-', $password, $contents);
+            file_put_contents($file, $contents);
+        }
 
         $this->setReference(self::REFERENCE_ADMIN_USER, $user1);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

It's not required to have the admin interface working (we check a db value if the password needs to be changed) + in sf4 it will be harder to "guess" the correct config file. So removing it for sf4 seems like the best solutions
