### PR TITLE
[GeneratorBundle] Improve entity repository class output for symfony 4

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/KunstmaanGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/KunstmaanGenerator.php
@@ -122,10 +122,16 @@ class KunstmaanGenerator extends Generator
 
         $class = new ClassMetadataInfo($entityClass, new UnderscoreNamingStrategy());
         if ($withRepository) {
-            $entityClass = preg_replace('/\\\\Entity\\\\/', '\\Repository\\', $entityClass, 1);
-            $class->customRepositoryClassName = $entityClass.'Repository';
-            $path = $this->isSymfony4() ? $bundle->getPath() : $bundle->getPath().str_repeat('/..', substr_count(get_class($bundle), '\\'));
-            $this->writeEntityRepositoryClass($class->customRepositoryClassName, $path);
+            if ($this->isSymfony4()) {
+                $repositoryClass = preg_replace('/\\\\Entity\\\\/', '\\Repository\\', $entityClass, 1) . 'Repository';
+                $class->customRepositoryClassName = $repositoryClass;
+                $this->getSymfony4RepositoryGenerator()->writeEntityRepositoryClass($entityClass, $repositoryClass, $bundle->getPath());
+            } else {
+                $entityClass = preg_replace('/\\\\Entity\\\\/', '\\Repository\\', $entityClass, 1);
+                $class->customRepositoryClassName = $entityClass.'Repository';
+                $path = $bundle->getPath().str_repeat('/..', substr_count(get_class($bundle), '\\'));
+                $this->getRepositoryGenerator()->writeEntityRepositoryClass($class->customRepositoryClassName, $path);
+            }
         }
 
         foreach ($fields as $fieldSet) {
@@ -474,6 +480,14 @@ class KunstmaanGenerator extends Generator
     }
 
     /**
+     * @return \Kunstmaan\GeneratorBundle\Generator\Symfony4EntityRepositoryGenerator
+     */
+    protected function getSymfony4RepositoryGenerator()
+    {
+        return new \Kunstmaan\GeneratorBundle\Generator\Symfony4EntityRepositoryGenerator();
+    }
+
+    /**
      * @internal
      */
     protected function getTemplateDir(BundleInterface $bundle)
@@ -503,29 +517,5 @@ class KunstmaanGenerator extends Generator
     protected function isSymfony4()
     {
         return Kernel::VERSION_ID >= 40000;
-    }
-
-    private function writeEntityRepositoryClass($fullClassName, $outputDirectory)
-    {
-        $code = $this->getRepositoryGenerator()->generateEntityRepositoryClass($fullClassName);
-
-        $path = $outputDirectory . DIRECTORY_SEPARATOR . str_replace('\\', \DIRECTORY_SEPARATOR, $fullClassName) . '.php';
-
-        if ($this->isSymfony4()) {
-            $classParts = explode('\\', $fullClassName);
-            $className = end($classParts);
-            $path = $outputDirectory . DIRECTORY_SEPARATOR . 'Repository' . DIRECTORY_SEPARATOR . $className . '.php';
-        }
-
-        $dir = dirname($path);
-
-        if (!is_dir($dir)) {
-            mkdir($dir, 0775, true);
-        }
-
-        if (!file_exists($path)) {
-            file_put_contents($path, $code);
-            chmod($path, 0664);
-        }
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Generator/Symfony4EntityRepositoryGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/Symfony4EntityRepositoryGenerator.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Kunstmaan\GeneratorBundle\Generator;
+
+/**
+ * @internal
+ */
+final class Symfony4EntityRepositoryGenerator
+{
+    protected static $_template =
+        '<?php
+
+namespace <namespace>;
+
+use <entityClassName>;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class <repository> extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, <entity>::class);
+    }
+}
+';
+
+    /**
+     * @param string $entityClassName
+     * @param string $repositoryClassName
+     *
+     * @return string
+     */
+    public function generateEntityRepositoryClass(string $entityClass, string $repositoryClass)
+    {
+        $variables = [
+            '<namespace>' => $this->generateEntityRepositoryNamespace($repositoryClass),
+            '<entityClassName>' => $entityClass,
+            '<entity>' => $this->generateEntityName($entityClass),
+            '<repository>' => $this->generateClassName($repositoryClass),
+        ];
+
+        return str_replace(array_keys($variables), array_values($variables), self::$_template);
+    }
+
+    /**
+     * @param string $fullClassName
+     * @param string $outputDirectory
+     */
+    public function writeEntityRepositoryClass($entityClass, $repositoryClass, $outputDirectory)
+    {
+        $classNameParts = explode('\\', $repositoryClass);
+        $repositoryClassName = end($classNameParts);
+        $this->repositoryName = $repositoryClassName;
+        $code = $this->generateEntityRepositoryClass($entityClass, $repositoryClass);
+
+        $path = $outputDirectory . DIRECTORY_SEPARATOR . 'Repository' . DIRECTORY_SEPARATOR . end($classNameParts) . '.php';
+
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        if (!file_exists($path)) {
+            file_put_contents($path, $code);
+            chmod($path, 0664);
+        }
+    }
+
+    /**
+     * @param string $repositoryClassName
+     *
+     * @return bool|string
+     */
+    private function generateEntityRepositoryNamespace(string $repositoryClassName)
+    {
+        return substr($repositoryClassName, 0, strrpos($repositoryClassName, '\\'));
+    }
+
+    /**
+     * @param string $entityClassName
+     *
+     * @return bool|string
+     */
+    private function generateEntityName(string $entityClassName)
+    {
+        return substr(strrchr($entityClassName, '\\'), 1);
+    }
+
+    /**
+     * Generates the class name
+     *
+     * @param string $fullClassName
+     *
+     * @return string
+     */
+    private function generateClassName($fullClassName)
+    {
+        $namespace = $this->getClassNamespace($fullClassName);
+
+        $className = $fullClassName;
+
+        if ($namespace) {
+            $className = substr($fullClassName, strrpos($fullClassName, '\\') + 1, strlen($fullClassName));
+        }
+
+        return $className;
+    }
+
+    /**
+     * Generates the namespace, if class do not have namespace, return empty string instead.
+     *
+     * @param string $fullClassName
+     *
+     * @return string $namespace
+     */
+    private function getClassNamespace($fullClassName)
+    {
+        $namespace = substr($fullClassName, 0, strrpos($fullClassName, '\\'));
+
+        return $namespace;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Improved version of #2228. This pr improves the `Repository` class output for symfony 4, this way the class is ready for autowiring. Template based on the makerbundle template

Example:
```php
<?php

namespace App\Repository;

use App\Entity\Example;
use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
use Symfony\Bridge\Doctrine\RegistryInterface;

class ExampleRepository extends ServiceEntityRepository
{
    public function __construct(RegistryInterface $registry)
    {
        parent::__construct($registry, Example::class);
    }
}
```