### PR TITLE
[AdminBundle] Provide twig globals with twig extension

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -331,3 +331,11 @@ services:
         arguments: ["@doctrine.orm.entity_manager"]
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: 'KunstmaanAdminBundle:Toolbar:exception.html.twig', id: kuma_exception }
+
+    Kunstmaan\AdminBundle\Twig\AdminBundleTwigExtension:
+        arguments:
+            - '%kunstmaan_admin.website_title%'
+            - '%defaultlocale%'
+            - '%requiredlocales%'
+        tags:
+            - { name: twig.extension }

--- a/src/Kunstmaan/AdminBundle/Twig/AdminBundleTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/AdminBundleTwigExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+class AdminBundleTwigExtension extends AbstractExtension implements GlobalsInterface
+{
+    /** @var string */
+    private $websiteTitle;
+
+    /** @var string */
+    private $defaultLocale;
+
+    /** @var string */
+    private $requiredLocales;
+
+    public function __construct($websiteTitle, $defaultLocale, $requiredLocales)
+    {
+        $this->websiteTitle = $websiteTitle;
+        $this->defaultLocale = $defaultLocale;
+        $this->requiredLocales = $requiredLocales;
+    }
+
+    public function getGlobals()
+    {
+        return [
+            'websitetitle' => $this->websiteTitle,
+            'defaultlocale' => $this->defaultLocale,
+            'requiredlocales' => $this->requiredLocales,
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Register twig globals needed in the cms with an extension to reduce the amount of config a user need to provide (reduce sf4 config).

This won't break current user code as the values provided by yaml config (as done in the standard edition) will override the twig extension values.
