### PR TITLE
[AdminBundle] Use correct parameter to retrieve website title

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/VersionCheck/VersionChecker.php
+++ b/src/Kunstmaan/AdminBundle/Helper/VersionCheck/VersionChecker.php
@@ -103,7 +103,7 @@ class VersionChecker
         $console = realpath($this->container->get('kernel')->getRootDir().'/../bin/console');
         $installed = filectime($console);
         $bundles = $this->parseComposer();
-        $title = $this->container->getParameter('websitetitle');
+        $title = $this->container->getParameter('kunstmaan_admin.website_title');
 
         $jsonData = json_encode(array(
             'host' => $host,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In #2201 we introduced a new websitetitle parameter, so use the new parameter instead of the old deprecated parameter.
