### PR TITLE
[DashboardBundle] Enable esi by default for the dashboard bundle

### DIFF
--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\DashboardBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -12,7 +13,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class KunstmaanDashboardExtension extends Extension
+class KunstmaanDashboardExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -25,5 +26,10 @@ class KunstmaanDashboardExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('commands.yml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $container->prependExtensionConfig('framework', ['esi' => ['enabled' => true]]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The dashboard bundle uses esi in [`index.html.twig`](https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/cc9a81d769b266a200e47d895f3d28f56dfd24d1/src/Kunstmaan/DashboardBundle/Resources/views/Dashboard/index.html.twig#L12) , by default this is not enabled in symfony 4 (the framework bundle recipe). So make sure it's enabled when the dashboard bundle is used.
