### PR TITLE
[AllBundles] Set default menu adaptor priorities enabled bundle order doesn't matter

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -31,13 +31,13 @@ services:
     kunstmaan_admin.menu.adaptor.modules:
         class: Kunstmaan\AdminBundle\Helper\Menu\ModulesMenuAdaptor
         tags:
-            -  { name: 'kunstmaan_admin.menu.adaptor' }
+            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 200 }
 
     kunstmaan_admin.menu.adaptor.settings:
         class: Kunstmaan\AdminBundle\Helper\Menu\SettingsMenuAdaptor
         arguments: ['@security.authorization_checker', "%version_checker.enabled%"]
         tags:
-            -  { name: 'kunstmaan_admin.menu.adaptor' }
+            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 100 }
 
     kunstmaan_admin.login.listener:
         class: '%kunstmaan_admin.login.listener.class%'

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -68,7 +68,7 @@ services:
         class: '%kunstmaan_media.menu.adaptor.class%'
         arguments: ['@kunstmaan_media.repository.folder']
         tags:
-            -  { name: 'kunstmaan_admin.menu.adaptor' }
+            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 150  }
 
     kunstmaan_media.folder_manager:
         class: '%kunstmaan_media.folder_manager.class%'

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -27,7 +27,7 @@ services:
         class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor
         arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.acl.native.helper', '@kunstmaan_node.pages_configuration', '@kunstmaan_admin.domain_configuration']
         tags:
-            -  { name: 'kunstmaan_admin.menu.adaptor' }
+            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 250 }
 
     kunstmaan_node.form.type.urlchooser:
         class: Kunstmaan\NodeBundle\Form\Type\URLChooserType

--- a/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/UserManagementBundle/Resources/config/services.yml
@@ -7,4 +7,4 @@ services:
         class: '%kunstmaan_user_management.menu.adaptor.class%'
         arguments: ['@security.authorization_checker']
         tags:
-            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 100 }
+            -  { name: 'kunstmaan_admin.menu.adaptor', priority: 250 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Define some default priorities so the menu order in the cms admin doesn't change when you don't enabling the bundles in a specific order. This more likely to happen with sf4 and the subtree split.