### PR TITLE
[MediaBundle] Check if media metadata has width/height info

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
@@ -218,7 +218,7 @@
                                         {% endif %}
                                         <figcaption class="media-thumbnail__caption">
                                             {{ media.name }}<br>
-                                            {% if media.metadata.original_width is not empty and media.metadata.original_height is not empty %}
+                                            {% if media.metadata.original_width is defined and media.metadata.original_height is defined and media.metadata.original_width is not empty and media.metadata.original_height is not empty %}
                                                 {{ media.metadata.original_width }}px x {{ media.metadata.original_height }}px
                                             {% endif %}
                                         </figcaption>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

PR #2158 added the width/height info to the media bundle chooser view but some media metadata might not contain this info, in my case a video didn't have that info. Check first if we have this data before printing it.