### PR TITLE
[NodeBundle] Mark node version lock helper service as public

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -60,6 +60,7 @@ services:
     kunstmaan_node.admin_node.node_version_lock_helper:
         class: Kunstmaan\NodeBundle\Helper\NodeAdmin\NodeVersionLockHelper
         arguments: ['@service_container', '@doctrine.orm.entity_manager']
+        public: true
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This service is used in the node admin controller
