### PR TITLE
[TranslatorBundle] Speed up bulk import of large translation files

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -55,14 +55,14 @@ services:
 
     kunstmaan_translator.service.importer.importer:
         class: 'Kunstmaan\TranslatorBundle\Service\Command\Importer\Importer'
-        calls:
-            - [setTranslationGroupManager, ['@kunstmaan_translator.service.group_manager']] # default, maken via config var
+        arguments:
+            - '@kunstmaan_translator.service.group_manager'
         public: true
 
     kunstmaan_translator.service.group_manager:
         class: 'Kunstmaan\TranslatorBundle\Service\TranslationGroupManager'
-        calls:
-            - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
+        arguments:
+            - '@kunstmaan_translator.repository.translation'
 
     # TODO: needs to be refactored, should not need to be public
     kunstmaan_translator.service.translator.loader:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  #2211 

Old setup worked in this way.
for each translation
     fetch translation from database
     create/update translation
     flush
endfor

new setup will fetch entire translations database in memory and do the logic internally. Memory usage is limited because the translation object is super small. avg 15mb per 5500 records. 
