### PR TITLE
[AdminBundle] Move admin locale parameters to admin_bundle config instead of parameters

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -15,6 +15,10 @@ AdminBundle
   The interface was deprecated and removed in symfony 4. If you used this interface to check the `Group` entity change it to
   the `FOS\UserBundle\Model\GroupInterface`. The `Group` entity won't change if you run on symfony 3.4 but it's adviced to make 
   this change already.
+ * Setting the `multilanguage` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.multi_language` config instead.
+ * Setting the `requiredlocales` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.required_locales` config instead.
+ * Setting the `defaultlocale` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.default_locale` config instead.
+ * Setting the `websitetitle` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.website_title` config instead.
 
 NodeSearchBundle
 ----------------

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -28,6 +28,15 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('menu_item')
             ->children()
                 ->scalarNode('website_title')->defaultNull()->end()
+                ->scalarNode('multi_language') //NEXT_MAJOR: change type to booleanNode and make required or provide default value
+                    ->defaultNull()
+                    ->beforeNormalization()->ifString()->then(function ($v) {
+                        // Workaroud to allow detecting if value is not provided. Can be removed when type is switched to booleanNode
+                        return (bool) $v;
+                    })->end()
+                ->end()
+                ->scalarNode('required_locales')->defaultNull()->end() //NEXT_MAJOR: make config required
+                ->scalarNode('default_locale')->defaultNull()->end() //NEXT_MAJOR: make config required
                 ->scalarNode('admin_password')->end()
                 ->scalarNode('dashboard_route')->end()
                 ->scalarNode('admin_prefix')->defaultValue('admin')->end()

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -82,14 +82,10 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
             $this->addSimpleMenuAdaptor($container, $config['menu_items']);
         }
 
-        $websiteTitle = $container->hasParameter('websitetitle') ? $container->getParameter('websitetitle') : '';
-        if (null === $config['website_title']) {
-            @trigger_error('Not providing a value for the "kunstmaan_admin.website_title" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
-        } else {
-            $websiteTitle = $config['website_title'];
-        }
-
-        $container->setParameter('kunstmaan_admin.website_title', $websiteTitle);
+        $this->addWebsiteTitleParameter($container, $config);
+        $this->addMultiLanguageParameter($container, $config);
+        $this->addRequiredLocalesParameter($container, $config);
+        $this->addDefaultLocaleParameter($container, $config);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -171,5 +167,54 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $urlSlice = preg_quote($urlSlice);
 
         return $urlSlice;
+    }
+
+    private function addWebsiteTitleParameter(ContainerBuilder $container, array $config)
+    {
+        $websiteTitle = $config['website_title'];
+        if (null === $config['website_title']) {
+            @trigger_error('Not providing a value for the "kunstmaan_admin.website_title" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
+
+            $websiteTitle = $container->hasParameter('websitetitle') ? $container->getParameter('websitetitle') : '';
+        }
+
+        $container->setParameter('kunstmaan_admin.website_title', $websiteTitle);
+    }
+
+    private function addMultiLanguageParameter(ContainerBuilder $container, array $config)
+    {
+        $multilanguage = $config['multi_language'];
+        if (null === $multilanguage) {
+            @trigger_error('Not providing a value for the "kunstmaan_admin.multi_language" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
+
+            $multilanguage = $container->hasParameter('multilanguage') ? $container->getParameter('multilanguage') : '';
+        }
+
+        $container->setParameter('kunstmaan_admin.multi_language', $multilanguage);
+    }
+
+    private function addRequiredLocalesParameter(ContainerBuilder $container, array $config)
+    {
+        $requiredLocales = $config['required_locales'];
+        if (null === $config['required_locales']) {
+            @trigger_error('Not providing a value for the "kunstmaan_admin.required_locales" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
+
+            $requiredLocales = $container->hasParameter('requiredlocales') ? $container->getParameter('requiredlocales') : '';
+        }
+
+        $container->setParameter('kunstmaan_admin.required_locales', $requiredLocales);
+        $container->setParameter('requiredlocales', $requiredLocales); //Keep old parameter for to keep BC with routing config
+    }
+
+    private function addDefaultLocaleParameter(ContainerBuilder $container, array $config)
+    {
+        $defaultLocale = $config['default_locale'];
+        if (null === $config['default_locale']) {
+            @trigger_error('Not providing a value for the "kunstmaan_admin.default_locale" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.', E_USER_DEPRECATED);
+
+            $defaultLocale = $container->hasParameter('defaultlocale') ? $container->getParameter('defaultlocale') : '';
+        }
+
+        $container->setParameter('kunstmaan_admin.default_locale', $defaultLocale);
     }
 }

--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
@@ -36,16 +36,9 @@ class DomainConfiguration implements DomainConfigurationInterface
             @trigger_error('Container injection and the usage of the container is deprecated in KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0.', E_USER_DEPRECATED);
 
             $this->container = $requestStack;
-            $this->multiLanguage = $this->container->getParameter(
-                'multilanguage'
-            );
-            $this->defaultLocale = $this->container->getParameter(
-                'defaultlocale'
-            );
-            $this->requiredLocales = explode(
-                '|',
-                $this->container->getParameter('requiredlocales')
-            );
+            $this->multiLanguage = $this->container->getParameter('kunstmaan_admin.multi_language');
+            $this->defaultLocale = $this->container->getParameter('kunstmaan_admin.default_locale');
+            $this->requiredLocales = explode('|', $this->container->getParameter('kunstmaan_admin.required_locales'));
             $this->requestStack = $this->container->get('request_stack');
 
             return;

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -226,7 +226,7 @@ services:
 
     kunstmaan_admin.domain_configuration:
         class: '%kunstmaan_admin.domain_configuration.class%'
-        arguments: ['@request_stack', '%multilanguage%', '%defaultlocale%', '%requiredlocales%']
+        arguments: ['@request_stack', '%kunstmaan_admin.multi_language%', '%kunstmaan_admin.default_locale%', '%kunstmaan_admin.required_locales%']
         public: true
 
     kunstmaan_admin.oauth_authenticator:

--- a/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -25,6 +25,9 @@ class ConfigurationTest extends TestCase
     {
         $array = [
             'website_title' => null,
+            'multi_language' => null,
+            'required_locales' => null,
+            'default_locale' => null,
             'admin_password' => 'l3tM31n!',
             'admin_locales' => [],
             'session_security' => [

--- a/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/KunstmaanAdminExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/KunstmaanAdminExtensionTest.php
@@ -62,15 +62,87 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.website_title', 'My real website');
     }
 
+    public function testMultiLanguageWithParameterSet()
+    {
+        $this->setParameter('multilanguage', true);
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.multi_language', true);
+    }
+
+    public function testMultiLanguageWithParameterAndConfigSet()
+    {
+        $this->setParameter('multilanguage', false);
+
+        $this->load(['multi_language' => true]);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.multi_language', true);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testMultiLanguageScalarParameter()
+    {
+        $this->setParameter('multilanguage', true);
+
+        $this->load(['multi_language' => 'randomvalue']);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.multi_language', true);
+    }
+
+    public function testRequiredLocalesWithParameterSet()
+    {
+        $this->setParameter('requiredlocales', 'nl|en');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.required_locales', 'nl|en');
+    }
+
+    public function testRequiredLocalesWithParameterAndConfigSet()
+    {
+        $this->setParameter('requiredlocales', 'nl|en');
+
+        $this->load(['required_locales' => 'nl|en|fr']);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.required_locales', 'nl|en|fr');
+    }
+
+    public function testDefaultLocaleWithParameterSet()
+    {
+        $this->setParameter('defaultlocale', 'en');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.default_locale', 'en');
+    }
+
+    public function testDefaultLocaleWithParameterAndConfigSet()
+    {
+        $this->setParameter('defaultlocale', 'en');
+
+        $this->load(['default_locale' => 'nl']);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.default_locale', 'nl');
+    }
+
     /**
      * @group legacy
      * @expectedDeprecation Not providing a value for the "kunstmaan_admin.website_title" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.
+     * @expectedDeprecation Not providing a value for the "kunstmaan_admin.multi_language" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.
+     * @expectedDeprecation Not providing a value for the "kunstmaan_admin.required_locales" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.
+     * @expectedDeprecation Not providing a value for the "kunstmaan_admin.default_locale" config is deprecated since KunstmaanAdminBundle 5.2, this config value will be required in KunstmaanAdminBundle 6.0.
      */
-    public function testLegacyParameterSecretParameter()
+    public function testLegacyParameters()
     {
         $this->load();
 
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.website_title', '');
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.multi_language', '');
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.required_locales', '');
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.default_locale', '');
     }
 
     protected function setUp()

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/DomainConfigurationTest.php
@@ -124,11 +124,11 @@ class DomainConfigurationTest extends TestCase
 
     private function getSingleLanguageDomainConfiguration()
     {
-        $map = array(
-            array('multilanguage', false),
-            array('defaultlocale', 'en'),
-            array('requiredlocales', 'en'),
-        );
+        $map = [
+            ['kunstmaan_admin.multi_language', false],
+            ['kunstmaan_admin.default_locale', 'en'],
+            ['kunstmaan_admin.required_locales', 'en'],
+        ];
 
         $object = new DomainConfiguration($this->getContainer($map));
 
@@ -137,11 +137,11 @@ class DomainConfigurationTest extends TestCase
 
     private function getMultiLanguageDomainConfiguration()
     {
-        $map = array(
-            array('multilanguage', true),
-            array('defaultlocale', 'nl'),
-            array('requiredlocales', 'nl|fr|en'),
-        );
+        $map = [
+            ['kunstmaan_admin.multi_language', true],
+            ['kunstmaan_admin.default_locale', 'nl'],
+            ['kunstmaan_admin.required_locales', 'nl|fr|en'],
+        ];
 
         $object = new DomainConfiguration($this->getContainer($map));
 

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/Helper/DomainConfigurationTest.php
@@ -23,9 +23,9 @@ class DomainConfigurationTest extends TestCase
     public function setUp()
     {
         $map = array(
-            array('multilanguage', true),
-            array('defaultlocale', 'nl'),
-            array('requiredlocales', 'nl|fr|en'),
+            array('kunstmaan_admin.multi_language', true),
+            array('kunstmaan_admin.default_locale', 'nl'),
+            array('kunstmaan_admin.required_locales', 'nl|fr|en'),
         );
 
         $this->object = new DomainConfiguration($this->getContainer($map));

--- a/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MultiDomainBundle/Resources/config/services.yml
@@ -25,5 +25,5 @@ services:
 
     kunstmaan_multi_domain.domain_configuration:
         class: '%kunstmaan_multi_domain.domain_configuration.class%'
-        arguments: ['@request_stack', '%multilanguage%', '%defaultlocale%', '%requiredlocales%', '@kunstmaan_admin.adminroute.helper', '@doctrine.orm.entity_manager', '%kunstmaan_multi_domain.hosts%']
+        arguments: ['@request_stack', '%kunstmaan_admin.multi_language%', '%kunstmaan_admin.default_locale%', '%kunstmaan_admin.required_locales%', '@kunstmaan_admin.adminroute.helper', '@doctrine.orm.entity_manager', '%kunstmaan_multi_domain.hosts%']
         public: true

--- a/src/Kunstmaan/MultiDomainBundle/Tests/unit/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/unit/Helper/DomainConfigurationTest.php
@@ -422,9 +422,9 @@ class DomainConfigurationTest extends TestCase
         );
 
         $map = array(
-            array('multilanguage', false),
-            array('defaultlocale', 'en'),
-            array('requiredlocales', 'en'),
+            array('kunstmaan_admin.multi_language', false),
+            array('kunstmaan_admin.default_locale', 'en'),
+            array('kunstmaan_admin.required_locales', 'en'),
             array('kunstmaan_multi_domain.hosts', $hostMap),
         );
 

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/KunstmaanTranslatorExtension.php
@@ -65,8 +65,8 @@ class KunstmaanTranslatorExtension extends Extension
 
         $translator->addMethodCall('setFallbackLocales', [['en']]);
 
-        if ($container->hasParameter('defaultlocale')) {
-            $translator->addMethodCall('setFallbackLocales', [[$container->getParameter('defaultlocale')]]);
+        if ($container->hasParameter('kunstmaan_admin.default_locale')) {
+            $translator->addMethodCall('setFallbackLocales', [[$container->getParameter('kunstmaan_admin.default_locale')]]);
         }
     }
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/unit/DependencyInjection/KunstmaanTranslatorExtensionTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/unit/DependencyInjection/KunstmaanTranslatorExtensionTest.php
@@ -51,7 +51,7 @@ class KunstmaanTranslatorExtensionTest extends TestCase
         $container->setParameter('kernel.root_dir', 'src/Kunstmaan/TranslatorBundle');
         $container->setParameter('kernel.bundles', array(new \Kunstmaan\TranslatorBundle\KunstmaanTranslatorBundle()));
         $container->setParameter('kernel.debug', true);
-        $container->setParameter('defaultlocale', 'en');
+        $container->setParameter('kunstmaan_admin.default_locale', 'en');
 
         return $container;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecated setting the locale parameters as parameters directly.
