### PR TITLE
[GeneratorBundle] Fix incorrect plural of certain table names

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/KunstmaanGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/KunstmaanGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\GeneratorBundle\Generator;
 
+use Doctrine\Common\Inflector\Inflector;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\ORM\Tools\EntityGenerator;
@@ -142,7 +143,7 @@ class KunstmaanGenerator extends Generator
         }
         $class->setPrimaryTable(
             array(
-                'name' => strtolower($dbPrefix . strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $name))) . 's',
+                'name' => strtolower($dbPrefix) . Inflector::tableize(Inflector::pluralize($name)),
             )
         );
         $entityCode = $this->getEntityGenerator($extendClass)->generateEntityClass($class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

Just appending a "s" at the end of a table name isn't correct, use the `tableize` and `pluralize` methods from doctrine to generate a correct tablename.

A case that was broken in the current setup -> entity `Category` produced tablename `categorys`