### PR TITLE
[NodeSearchBundle] Deprecate container access in NodeIndexUpdateEventListener

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -19,8 +19,9 @@ AdminBundle
 NodeSearchBundle
 ----------------
 
-* Depending on the service container to retrieve searchers is deprecated and will be removed in 6.0. Tag your custom node
-  searchers with the "kunstmaan_node_search.node_searcher" tag, to have them available for the NodeSearchBundle.
+ * Depending on the service container to retrieve searchers is deprecated and will be removed in 6.0. Tag your custom node
+   searchers with the "kunstmaan_node_search.node_searcher" tag, to have them available for the NodeSearchBundle.
+ * Passing the container as the first argument of `\Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener` is deprecated and will be removed in 6.0. Inject the `kunstmaan_node_search.search_configuration.node` service instead.
 
 NodeBundle
 ----------

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -44,7 +44,6 @@ services:
         calls:
             - [ setAclProvider, ['@security.acl.provider']]
             - [ setIndexablePagePartsService, ['@kunstmaan_node_search.service.indexable_pageparts']]
-        public: true
         tags:
             - { name: kunstmaan_search.search_configuration, alias: Node }
 

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     kunstmaan_node_search.node_index_update.listener:
         class: '%kunstmaan_node_search.node_index_update.listener.class%'
-        arguments: ['@service_container']
+        arguments: ['@kunstmaan_node_search.search_configuration.node']
         tags:
             - { name: doctrine.event_listener, event: preUpdate,   method: preUpdate }
             - { name: kernel.event_listener, event: kunstmaan_node.postPublish,   method: onPostPublish }

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/EventListener/NodeIndexUpdateEventListenerTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/EventListener/NodeIndexUpdateEventListenerTest.php
@@ -34,7 +34,7 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(true)));
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true));
         $listener->onPostPersist($nodeEvent);
     }
 
@@ -66,7 +66,7 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false));
         $listener->onPostPersist($nodeEvent);
     }
 
@@ -90,7 +90,7 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false));
         $listener->onPostPersist($nodeEvent);
     }
 
@@ -114,8 +114,17 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(true)));
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true));
         $listener->onPostPersist($nodeEvent);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing the container as the first argument of "Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener" is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Inject the "kunstmaan_node_search.search_configuration.node" service instead.
+     */
+    public function testContainerDeprecation()
+    {
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
     }
 
     private function getContainer($searchConfigMock)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Inject the correct dependency instead of the full service container.