### PR TITLE
[DashboardBundle] Move google api parameters to dashboard bundle config instead of parameters

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -16,6 +16,14 @@ AdminBundle
   the `FOS\UserBundle\Model\GroupInterface`. The `Group` entity won't change if you run on symfony 3.4 but it's adviced to make 
   this change already.
 
+DashboardBundle
+---------------
+
+ * Not providing a value for the `kunstmaan_dashboard.google_analytics.api.client_secret` config while setting the `google.api.client_secret` parameter is deprecated, this config value will replace the `google.api.client_secret` parameter in KunstmaanDashboardBundle 6.0.
+ * Not providing a value for the `kunstmaan_dashboard.google_analytics.api.client_id` config while setting the `google.api.client_id` parameter is deprecated, this config value will replace the `google.api.client_id` parameter in KunstmaanDashboardBundle 6.0.
+ * Not providing a value for the `kunstmaan_dashboard.google_analytics.api.app_name` config while setting the `google.api.app_name` parameter is deprecated, this config value will replace the `google.api.app_name` parameter in KunstmaanDashboardBundle 6.0.
+ * Not providing a value for the `kunstmaan_dashboard.google_analytics.api.dev_key` config while setting the `google.api.dev_key` parameter is deprecated, this config value will replace the `google.api.dev_key` parameter in KunstmaanDashboardBundle 6.0.
+
 NodeSearchBundle
 ----------------
 

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
@@ -29,7 +29,7 @@ class GoogleAnalyticsController extends Controller
 
         // if token not set
         if (!$configHelper->tokenIsSet()) {
-            if ($this->getParameter('google.api.client_id') != '' && $this->getParameter('google.api.client_secret') != '' && $this->getParameter('google.api.dev_key') != '') {
+            if ($this->getParameter('kunstmaan_dashboard.google_analytics.api.client_id') != '' && $this->getParameter('kunstmaan_dashboard.google_analytics.api.client_secret') != '' && $this->getParameter('kunstmaan_dashboard.google_analytics.api.dev_key') != '') {
                 $params['authUrl'] = $configHelper->getAuthUrl($params['redirect_uri']);
             }
 

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/Configuration.php
@@ -18,11 +18,25 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('kunstmaan_dashboard');
+        $rootNode = $treeBuilder->root('kunstmaan_dashboard');
 
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
+        $rootNode
+            ->children()
+                ->arrayNode('google_analytics')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('api')->info('More info at https://kunstmaanbundlescms.readthedocs.io/en/latest/cookbook/google-analytics-dashboard/')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('client_id')->defaultNull()->end()
+                                ->scalarNode('client_secret')->defaultNull()->end()
+                                ->scalarNode('dev_key')->defaultNull()->end()
+                                ->scalarNode('app_name')->defaultNull()->end() // NEXT_MAJOR: Set default value to "Kuma Analytics Dashboard"
+                            ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/KunstmaanDashboardExtension.php
@@ -21,15 +21,81 @@ class KunstmaanDashboardExtension extends Extension implements PrependExtensionI
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('commands.yml');
+
+        $this->loadGoogleAnalyticsParameters($container, $config);
     }
 
     public function prepend(ContainerBuilder $container)
     {
         $container->prependExtensionConfig('framework', ['esi' => ['enabled' => true]]);
+    }
+
+    private function loadGoogleAnalyticsParameters(ContainerBuilder $container, array $config)
+    {
+        $this->addApplicationNameParameter($container, $config);
+        $this->addClientIdParameter($container, $config);
+        $this->addClientSecretParameter($container, $config);
+        $this->addDeveloperKeyParameter($container, $config);
+    }
+
+    private function addClientIdParameter(ContainerBuilder $container, array $config)
+    {
+        $clientId = $container->hasParameter('google.api.client_id') ? $container->getParameter('google.api.client_id') : '';
+        if (null === $config['google_analytics']['api']['client_id'] && $clientId !== '') {
+            @trigger_error('Not providing a value for the "kunstmaan_dashboard.google_analytics.api.client_id" config while setting the "google.api.client_id" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.client_id" parameter in KunstmaanDashboardBundle 6.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $config['google_analytics']['api']['client_id']) {
+            $clientId = $config['google_analytics']['api']['client_id'];
+        }
+
+        $container->setParameter('kunstmaan_dashboard.google_analytics.api.client_id', $clientId);
+    }
+
+    private function addClientSecretParameter(ContainerBuilder $container, array $config)
+    {
+        $clientSecret = $container->hasParameter('google.api.client_secret') ? $container->getParameter('google.api.client_secret') : '';
+        if (null === $config['google_analytics']['api']['client_secret'] && $clientSecret !== '') {
+            @trigger_error('Not providing a value for the "kunstmaan_dashboard.google_analytics.api.client_secret" config while setting the "google.api.client_secret" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.client_secret" parameter in KunstmaanDashboardBundle 6.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $config['google_analytics']['api']['client_secret']) {
+            $clientSecret = $config['google_analytics']['api']['client_secret'];
+        }
+
+        $container->setParameter('kunstmaan_dashboard.google_analytics.api.client_secret', $clientSecret);
+    }
+
+    private function addDeveloperKeyParameter(ContainerBuilder $container, array $config)
+    {
+        $devKey = $container->hasParameter('google.api.dev_key') ? $container->getParameter('google.api.dev_key') : '';
+        if (null === $config['google_analytics']['api']['dev_key'] && $devKey !== '') {
+            @trigger_error('Not providing a value for the "kunstmaan_dashboard.google_analytics.api.dev_key" config while setting the "google.api.dev_key" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.dev_key" parameter in KunstmaanDashboardBundle 6.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $config['google_analytics']['api']['dev_key']) {
+            $devKey = $config['google_analytics']['api']['dev_key'];
+        }
+
+        $container->setParameter('kunstmaan_dashboard.google_analytics.api.dev_key', $devKey);
+    }
+
+    private function addApplicationNameParameter(ContainerBuilder $container, array $config)
+    {
+        $appName = $container->hasParameter('google.api.app_name') ? $container->getParameter('google.api.app_name') : 'Kuma Analytics Dashboard';
+        if (null === $config['google_analytics']['api']['app_name'] && $appName !== '' && $appName !== 'Kuma Analytics Dashboard') {
+            @trigger_error('Not providing a value for the "kunstmaan_dashboard.google_analytics.api.app_name" config while setting the "google.api.app_name" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.app_name" parameter in KunstmaanDashboardBundle 6.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $config['google_analytics']['api']['app_name']) {
+            $appName = $config['google_analytics']['api']['app_name'];
+        }
+
+        $container->setParameter('kunstmaan_dashboard.google_analytics.api.app_name', $appName);
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -3,7 +3,6 @@ parameters:
     kunstmaan_dashboard.widget.googleanalytics.controller: Kunstmaan\DashboardBundle\Controller\GoogleAnalyticsController
     kunstmaan_dashboard.googleclient.class: 'Google_Client'
     kunstmaan_dashboard.googleclienthelper.class: 'Kunstmaan\DashboardBundle\Helper\GoogleClientHelper'
-    google.api.app_name: 'Kuma Analytics Dashboard'
 
 services:
     kunstmaan_dashboard.manager.widgets:
@@ -20,10 +19,10 @@ services:
     kunstmaan_dashboard.googleclient:
         class: '%kunstmaan_dashboard.googleclient.class%'
         calls:
-          - [ 'setApplicationName', [ '%google.api.app_name%' ] ]
-          - [ 'setClientId', [ '%google.api.client_id%' ] ]
-          - [ 'setClientSecret', [ '%google.api.client_secret%' ] ]
-          - [ 'setDeveloperKey', [ '%google.api.dev_key%' ] ]
+          - [ 'setApplicationName', [ '%kunstmaan_dashboard.google_analytics.api.app_name%' ] ]
+          - [ 'setClientId', [ '%kunstmaan_dashboard.google_analytics.api.client_id%' ] ]
+          - [ 'setClientSecret', [ '%kunstmaan_dashboard.google_analytics.api.client_secret%' ] ]
+          - [ 'setDeveloperKey', [ '%kunstmaan_dashboard.google_analytics.api.dev_key%' ] ]
           - [ 'setScopes', [ 'https://www.googleapis.com/auth/analytics.readonly' ] ]
           - [ 'setUseObjects', [ true ] ]
 

--- a/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -23,7 +23,16 @@ class ConfigurationTest extends TestCase
 
     public function testProcessedValueContainsRequiredValue()
     {
-        $array = [];
+        $array = [
+            'google_analytics' => [
+                'api' => [
+                    'client_id' => null,
+                    'client_secret' => null,
+                    'dev_key' => null,
+                    'app_name' => null,
+                ],
+            ],
+        ];
 
         $this->assertProcessedConfigurationEquals([$array], $array);
     }

--- a/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/KunstmaanDashboardExtensionTest.php
+++ b/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/KunstmaanDashboardExtensionTest.php
@@ -27,6 +27,122 @@ class KunstmaanDashboardExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.widget.googleanalytics.controller');
         $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.googleclient.class');
         $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.googleclienthelper.class');
-        $this->assertContainerBuilderHasParameter('google.api.app_name');
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.app_name');
+    }
+
+    public function testGoogleAnalyticsApiClientIdWithNoConfig()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_id', '');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_dashboard.google_analytics.api.client_id" config while setting the "google.api.client_id" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.client_id" parameter in KunstmaanDashboardBundle 6.0.
+     */
+    public function testGoogleAnalyticsApiClientIdWithParameterSet()
+    {
+        $this->setParameter('google.api.client_id', 'client_id');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_id', 'client_id');
+    }
+
+    public function testGoogleAnalyticsApiClientIdWithParameterAndConfigSet()
+    {
+        $this->setParameter('google.api.client_id', 'client_id');
+
+        $this->load(['google_analytics' => ['api' => ['client_id' => 'custom_client_id']]]);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_id', 'custom_client_id');
+    }
+
+    public function testGoogleAnalyticsApiClientSecretWithNoConfig()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_secret', '');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_dashboard.google_analytics.api.client_secret" config while setting the "google.api.client_secret" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.client_secret" parameter in KunstmaanDashboardBundle 6.0.
+     */
+    public function testGoogleAnalyticsApiClientSecretWithParameterSet()
+    {
+        $this->setParameter('google.api.client_secret', 'client_secret');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_secret', 'client_secret');
+    }
+
+    public function testGoogleAnalyticsApiClientSecretWithParameterAndConfigSet()
+    {
+        $this->setParameter('google.api.client_secret', 'client_secret');
+
+        $this->load(['google_analytics' => ['api' => ['client_secret' => 'custom_client_secret']]]);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.client_secret', 'custom_client_secret');
+    }
+
+    public function testGoogleAnalyticsApiDevKeyWithNoConfig()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.dev_key', '');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_dashboard.google_analytics.api.dev_key" config while setting the "google.api.dev_key" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.dev_key" parameter in KunstmaanDashboardBundle 6.0.
+     */
+    public function testGoogleAnalyticsApiDevKeyWithParameterSet()
+    {
+        $this->setParameter('google.api.dev_key', 'dev_key');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.dev_key', 'dev_key');
+    }
+
+    public function testGoogleAnalyticsApiDevKeyWithParameterAndConfigSet()
+    {
+        $this->setParameter('google.api.dev_key', 'dev_key');
+
+        $this->load(['google_analytics' => ['api' => ['dev_key' => 'custom_dev_key']]]);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.dev_key', 'custom_dev_key');
+    }
+
+    public function testGoogleAnalyticsApiAppNameWithNoConfig()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.app_name', 'Kuma Analytics Dashboard');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_dashboard.google_analytics.api.app_name" config while setting the "google.api.app_name" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "google.api.app_name" parameter in KunstmaanDashboardBundle 6.0.
+     */
+    public function testGoogleAnalyticsApiAppNameWithParameterSet()
+    {
+        $this->setParameter('google.api.app_name', 'app_name');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.app_name', 'app_name');
+    }
+
+    public function testGoogleAnalyticsApiAppNameWithParameterAndConfigSet()
+    {
+        $this->setParameter('google.api.app_name', 'app_name');
+
+        $this->load(['google_analytics' => ['api' => ['app_name' => 'custom_app_name']]]);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_dashboard.google_analytics.api.app_name', 'custom_app_name');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets |

Deprecated setting the google api parameters as parameters directly.
