### PR TITLE
[MediaBundle] Move aviary_api_key parameter to media bundle config instead of parameter

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -16,6 +16,11 @@ AdminBundle
   the `FOS\UserBundle\Model\GroupInterface`. The `Group` entity won't change if you run on symfony 3.4 but it's adviced to make 
   this change already.
 
+MediaBundle
+-----------
+
+ * Not providing a value for the `kunstmaan_media.aviary_api_key` config while setting the `aviary_api_key` parameter is deprecated, this config value will replace the `aviary_api_key` parameter in KunstmaanMediaBundle 6.0.
+
 NodeSearchBundle
 ----------------
 

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/Configuration.php
@@ -26,6 +26,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('soundcloud_api_key')->defaultValue('YOUR_CLIENT_ID')->end()
+                ->scalarNode('aviary_api_key')->defaultNull()->end()
                 ->arrayNode('remote_video')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -32,7 +32,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $container->setParameter(
             'twig.form.resources',
             array_merge(
-                $container->getParameter('twig.form.resources'),
+                $container->hasParameter('twig.form.resources') ? $container->getParameter('twig.form.resources') : [],
                 array('KunstmaanMediaBundle:Form:formWidgets.html.twig')
             )
         );
@@ -60,6 +60,8 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
         $container->setAlias('liip_imagine.cache.resolver.prototype.web_path', 'Kunstmaan\MediaBundle\Helper\Imagine\WebPathResolver');
         $container->setAlias('liip_imagine.cache.manager', 'Kunstmaan\MediaBundle\Helper\Imagine\CacheManager')->setPublic(true);
         $container->setAlias('liip_imagine.filter.loader.background', 'kunstmaan_media.imagine.filter.loader.background')->setPublic(true);
+
+        $this->addAvairyApiKeyParameter($container, $config);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -87,5 +89,19 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
     public function getAlias()
     {
         return 'kunstmaan_media';
+    }
+
+    private function addAvairyApiKeyParameter(ContainerBuilder $container, array $config)
+    {
+        $aviaryApiKey = $container->hasParameter('aviary_api_key') ? $container->getParameter('aviary_api_key') : null;
+        if (null === $config['aviary_api_key'] && null !== $aviaryApiKey) {
+            @trigger_error('Not providing a value for the "kunstmaan_media.aviary_api_key" config while setting the "aviary_api_key" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "aviary_api_key" parameter in KunstmaanDashboardBundle 6.0.', E_USER_DEPRECATED);
+        }
+
+        if (null !== $config['aviary_api_key']) {
+            $aviaryApiKey = $config['aviary_api_key'];
+        }
+
+        $container->setParameter('kunstmaan_media.aviary_api_key', $aviaryApiKey);
     }
 }

--- a/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/handlers.yml
@@ -4,7 +4,6 @@ parameters:
     kunstmaan_media.media_handler.remote_audio.class: 'Kunstmaan\MediaBundle\Helper\RemoteAudio\RemoteAudioHandler'
     kunstmaan_media.media_handler.image.class: 'Kunstmaan\MediaBundle\Helper\Image\ImageHandler'
     kunstmaan_media.media_handler.file.class: 'Kunstmaan\MediaBundle\Helper\File\FileHandler'
-    aviary_api_key: null
     kunstmaan_media.media_path: '/uploads/media/'
 
 services:
@@ -28,7 +27,7 @@ services:
 
     kunstmaan_media.media_handlers.image:
         class: '%kunstmaan_media.media_handler.image.class%'
-        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory', '%aviary_api_key%']
+        arguments: [1, '@kunstmaan_media.mimetype_guesser.factory', '@kunstmaan_media.extension_guesser.factory', '%kunstmaan_media.aviary_api_key%']
         calls:
             - [ setFileSystem, [ '@kunstmaan_media.filesystem' ] ]
             - [ setMediaPath, [ '%kunstmaan_media.media_path%' ] ]

--- a/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -26,6 +26,7 @@ class ConfigurationTest extends TestCase
     {
         $array = [
             'soundcloud_api_key' => 'thisismykey',
+            'aviary_api_key' => 'apikey',
             'remote_video' => [
                 'vimeo' => false,
                 'youtube' => true,

--- a/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/KunstmaanMediaExtensionTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/unit/DependencyInjection/KunstmaanMediaExtensionTest.php
@@ -21,10 +21,8 @@ class KunstmaanMediaExtensionTest extends AbstractExtensionTestCase
 
     public function testCorrectParametersHaveBeenSet()
     {
-        $this->container->setParameter('twig.form.resources', []);
         $this->load(['enable_pdf_preview' => true]);
 
-        $this->assertContainerBuilderHasParameter('twig.form.resources');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.soundcloud_api_key', 'YOUR_CLIENT_ID');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.remote_video');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.enable_pdf_preview', true);
@@ -46,8 +44,37 @@ class KunstmaanMediaExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_media.media_handler.remote_audio.class', 'Kunstmaan\MediaBundle\Helper\RemoteAudio\RemoteAudioHandler');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.media_handler.image.class', 'Kunstmaan\MediaBundle\Helper\Image\ImageHandler');
         $this->assertContainerBuilderHasParameter('kunstmaan_media.media_handler.file.class', 'Kunstmaan\MediaBundle\Helper\File\FileHandler');
-        $this->assertContainerBuilderHasParameter('aviary_api_key', null);
+        $this->assertContainerBuilderHasParameter('kunstmaan_media.aviary_api_key', null);
         $this->assertContainerBuilderHasParameter('kunstmaan_media.media_path', '/uploads/media/');
         $this->assertContainerBuilderHasParameter('liip_imagine.filter.loader.background.class', 'Kunstmaan\MediaBundle\Helper\Imagine\BackgroundFilterLoader');
+    }
+
+    public function testAviaryApiKeyWithNoConfig()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_media.aviary_api_key', null);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not providing a value for the "kunstmaan_media.aviary_api_key" config while setting the "aviary_api_key" parameter is deprecated since KunstmaanDashboardBundle 5.2, this config value will replace the "aviary_api_key" parameter in KunstmaanDashboardBundle 6.0.
+     */
+    public function testAviaryApiKeyWithParameterSet()
+    {
+        $this->setParameter('aviary_api_key', 'api_key');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_media.aviary_api_key', 'api_key');
+    }
+
+    public function testAviaryApiKeyWithParameterAndConfigSet()
+    {
+        $this->setParameter('aviary_api_key', 'api_key');
+
+        $this->load(['aviary_api_key' => 'other_api_key']);
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_media.aviary_api_key', 'other_api_key');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 