### PR TITLE
[UtilitiesBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_utilities.slugifier.class' => \Kunstmaan\UtilitiesBundle\Helper\Slugifier::class,
+            'kunstmaan_utilities.shell.class' => \Kunstmaan\UtilitiesBundle\Helper\Shell\Shell::class,
+            'kunstmaan_utilities.cipher.class' => \Kunstmaan\UtilitiesBundle\Helper\Cipher\UrlSafeCipher::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanUtilitiesBundle 5.2 and will be removed in KunstmaanUtilitiesBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/UtilitiesBundle/KunstmaanUtilitiesBundle.php
+++ b/src/Kunstmaan/UtilitiesBundle/KunstmaanUtilitiesBundle.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\UtilitiesBundle;
 
+use Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,4 +11,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanUtilitiesBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
 }

--- a/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/UtilitiesBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\UtilitiesBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\UtilitiesBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "kunstmaan_utilities.slugifier.class" parameter to change the class of the service definition is deprecated in KunstmaanUtilitiesBundle 5.2 and will be removed in KunstmaanUtilitiesBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_utilities.slugifier.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition