### PR TITLE
[UserManagementBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/UserManagementBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/UserManagementBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kunstmaan\UserManagementBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_user_management.user_admin_list_configurator.class' => \Kunstmaan\UserManagementBundle\AdminList\UserAdminListConfigurator::class,
+            'kunstmaan_user_management.menu.adaptor.class' => \Kunstmaan\UserManagementBundle\Helper\Menu\UserManagementMenuAdaptor::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanUserManagementBundle 5.2 and will be removed in KunstmaanUserManagementBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/UserManagementBundle/KunstmaanUserManagementBundle.php
+++ b/src/Kunstmaan/UserManagementBundle/KunstmaanUserManagementBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\UserManagementBundle;
 
+use Kunstmaan\UserManagementBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\UserManagementBundle\DependencyInjection\Compiler\FixUserManagerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -14,5 +15,6 @@ class KunstmaanUserManagementBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new FixUserManagerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/UserManagementBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/UserManagementBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\UserManagementBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\UserManagementBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanUserManagementBundle 5.2 and will be removed in KunstmaanUserManagementBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_user_management.user_admin_list_configurator.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition