### PR TITLE
[TranslatorBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\TranslatorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_translator.menu.adaptor.class' => \Kunstmaan\TranslatorBundle\Service\Menu\TranslatorMenuAdaptor::class,
+            'kunstmaan_translator.service.exporter.csv.class' => \Kunstmaan\TranslatorBundle\Service\Command\Exporter\CSVFileExporter::class,
+            'kunstmaan_translator.toolbar.collector.translator.class' => \Kunstmaan\TranslatorBundle\Toolbar\TranslatorDataCollector::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanTranslatorBundle 5.2 and will be removed in KunstmaanTranslatorBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/TranslatorBundle/KunstmaanTranslatorBundle.php
+++ b/src/Kunstmaan/TranslatorBundle/KunstmaanTranslatorBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\TranslatorBundle;
 
+use Kunstmaan\TranslatorBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\TranslatorBundle\DependencyInjection\Compiler\KunstmaanTranslatorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -12,5 +13,6 @@ class KunstmaanTranslatorBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new KunstmaanTranslatorCompilerPass());
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\TranslatorBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\TranslatorBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanTranslatorBundle 5.2 and will be removed in KunstmaanTranslatorBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_translator.menu.adaptor.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition
