### PR TITLE
[SearchBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\SearchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_search.search_configuration_chain.class' => \Kunstmaan\SearchBundle\Configuration\SearchConfigurationChain::class,
+            'kunstmaan_search.search_provider_chain.class' => \Kunstmaan\SearchBundle\Provider\SearchProviderChain::class,
+            'kunstmaan_search.search.class' => \Kunstmaan\SearchBundle\Search\Search::class,
+            'kunstmaan_search.search_provider.elastica.class' => \Kunstmaan\SearchBundle\Provider\ElasticaProvider::class,
+            'kunstmaan_search.search.factory.analysis.class' => \Kunstmaan\SearchBundle\Search\LanguageAnalysisFactory::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanSearchBundle 5.2 and will be removed in KunstmaanSearchBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/SearchBundle/KunstmaanSearchBundle.php
+++ b/src/Kunstmaan/SearchBundle/KunstmaanSearchBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SearchBundle;
 
+use Kunstmaan\SearchBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\SearchBundle\DependencyInjection\Compiler\SearchConfigurationCompilerPass;
 use Kunstmaan\SearchBundle\DependencyInjection\Compiler\SearchProviderCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,5 +19,6 @@ class KunstmaanSearchBundle extends Bundle
 
         $container->addCompilerPass(new SearchConfigurationCompilerPass());
         $container->addCompilerPass(new SearchProviderCompilerPass());
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/SearchBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/SearchBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\SearchBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\SearchBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanSearchBundle 5.2 and will be removed in KunstmaanSearchBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_search.search_configuration_chain.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition