### PR TITLE
[PagePartBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/PagePartBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/PagePartBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\PagePartBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_pagepart.page_part_configuration_reader.class' => \Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReader::class,
+            'kunstmaan_pagepart.page_part_configuration_parser.class' => \Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationParser::class,
+            'kunstmaan_pagepart.page_template_configuration_reader.class' => \Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationReader::class,
+            'kunstmaan_pagepart.page_template_configuration_parser.class' => \Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationParser::class,
+            'kunstmaan_page_part.page_template.page_template_configuration_service.class' => \Kunstmaan\PagePartBundle\PageTemplate\PageTemplateConfigurationService::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanPagePartBundle 5.2 and will be removed in KunstmaanPagePartBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/PagePartBundle/KunstmaanPagePartBundle.php
+++ b/src/Kunstmaan/PagePartBundle/KunstmaanPagePartBundle.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\PagePartBundle;
 
+use Kunstmaan\PagePartBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -9,4 +11,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class KunstmaanPagePartBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
 }

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\PagePartBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\PagePartBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanPagePartBundle 5.2 and will be removed in KunstmaanPagePartBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_pagepart.page_part_configuration_reader.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition