### PR TITLE
[NodeSearchBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_node_search.search_configuration.node.class' => \Kunstmaan\NodeSearchBundle\Configuration\NodePagesConfiguration::class,
+            'kunstmaan_node_search.search.node.class' => \Kunstmaan\NodeSearchBundle\Search\NodeSearcher::class,
+            'kunstmaan_node_search.search_service.class' => \Kunstmaan\NodeSearchBundle\Services\SearchService::class,
+            'kunstmaan_node_search.node_index_update.listener.class' => \Kunstmaan\NodeSearchBundle\EventListener\NodeIndexUpdateEventListener::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
+++ b/src/Kunstmaan/NodeSearchBundle/KunstmaanNodeSearchBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\NodeSearchBundle;
 
+use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\NodeSearcherCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -14,5 +15,6 @@ class KunstmaanNodeSearchBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new NodeSearcherCompilerPass());
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\NodeSearchBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\NodeSearchBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_node_search.search_configuration.node.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition
