### PR TITLE
[NodeBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_node.slugrouter.class' => \Kunstmaan\NodeBundle\Router\SlugRouter::class,
+            'kunstmaan_node.sluglistener.class' => \Kunstmaan\NodeBundle\EventListener\SlugListener::class,
+            'kunstmaan_node.helper.url.class' => \Kunstmaan\NodeBundle\Helper\URLHelper::class,
+            'kunstmaan_node.url_replace.twig.class' => \Kunstmaan\NodeBundle\Twig\UrlReplaceTwigExtension::class,
+            'kunstmaan_multi_domain.url_replace.controller.class' => \Kunstmaan\NodeBundle\Controller\UrlReplaceController::class,
+            'kunstmaan_node.toolbar.collector.node.class' => \Kunstmaan\NodeBundle\Toolbar\NodeDataCollector::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanNodeBundle 5.2 and will be removed in KunstmaanNodeBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
+++ b/src/Kunstmaan/NodeBundle/KunstmaanNodeBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\NodeBundle;
 
+use Kunstmaan\NodeBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\NodeBundle\DependencyInjection\Compiler\FixRouterPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,5 +19,6 @@ class KunstmaanNodeBundle extends Bundle
 
         // Use -1 priority to run this compiler pass after the symfony-cmf/router compiler pass
         $container->addCompilerPass(new FixRouterPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/NodeBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\NodeBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanNodeBundle 5.2 and will be removed in KunstmaanNodeBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_node.slugrouter.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition