### PR TITLE
[MultiDomainBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/CompilerPass/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/CompilerPass/DeprecateClassParametersPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kunstmaan\MultiDomainBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_multi_domain.domain_configuration.class' => \Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanMultiDomainBundle 5.2 and will be removed in KunstmaanMultiDomainBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/MultiDomainBundle/KunstmaanMultiDomainBundle.php
+++ b/src/Kunstmaan/MultiDomainBundle/KunstmaanMultiDomainBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\MultiDomainBundle;
 
+use Kunstmaan\MultiDomainBundle\DependencyInjection\CompilerPass\DeprecateClassParametersPass;
 use Kunstmaan\MultiDomainBundle\DependencyInjection\CompilerPass\MultidomainConfigurationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -11,5 +12,6 @@ class KunstmaanMultiDomainBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new MultidomainConfigurationPass());
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/MultiDomainBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\MultiDomainBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\MultiDomainBundle\DependencyInjection\CompilerPass\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "kunstmaan_multi_domain.domain_configuration.class" parameter to change the class of the service definition is deprecated in KunstmaanMultiDomainBundle 5.2 and will be removed in KunstmaanMultiDomainBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_multi_domain.domain_configuration.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition