### PR TITLE
[MenuBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/MenuBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/MenuBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kunstmaan\MenuBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_menu.menu.adaptor.class' => \Kunstmaan\MenuBundle\Service\MenuAdaptor::class,
+            'kunstmaan_menu.menu.service.class' => \Kunstmaan\MenuBundle\Service\MenuService::class,
+            'kunstmaan_menu.menu.twig.extension.class' => \Kunstmaan\MenuBundle\Twig\MenuTwigExtension::class,
+            'kunstmaan_menu.menu.repository.class' => \Kunstmaan\MenuBundle\Repository\MenuItemRepository::class,
+            'kunstmaan_menu.menu.render_service.class' => \Kunstmaan\MenuBundle\Service\RenderService::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanMenuBundle 5.2 and will be removed in KunstmaanMenuBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/MenuBundle/KunstmaanMenuBundle.php
+++ b/src/Kunstmaan/MenuBundle/KunstmaanMenuBundle.php
@@ -2,8 +2,14 @@
 
 namespace Kunstmaan\MenuBundle;
 
+use Kunstmaan\MenuBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class KunstmaanMenuBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
 }

--- a/src/Kunstmaan/MenuBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/MenuBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\MenuBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\MenuBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanMenuBundle 5.2 and will be removed in KunstmaanMenuBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_menu.menu.adaptor.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition
