### PR TITLE
[LeadGenerationBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_lead_generation.popup.twig.extension.class' => \Kunstmaan\LeadGenerationBundle\Twig\PopupTwigExtension::class,
+            'kunstmaan_lead_generation.popup.manager.class' => \Kunstmaan\LeadGenerationBundle\Service\PopupManager::class,
+            'kunstmaan_lead_generation.menu.adaptor.class' => \Kunstmaan\LeadGenerationBundle\Service\MenuAdaptor::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanLeadGenerationBundle 5.2 and will be removed in KunstmaanLeadGenerationBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/LeadGenerationBundle/KunstmaanLeadGenerationBundle.php
+++ b/src/Kunstmaan/LeadGenerationBundle/KunstmaanLeadGenerationBundle.php
@@ -2,8 +2,14 @@
 
 namespace Kunstmaan\LeadGenerationBundle;
 
+use Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class KunstmaanLeadGenerationBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
 }

--- a/src/Kunstmaan/LeadGenerationBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\LeadGenerationBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\LeadGenerationBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanLeadGenerationBundle 5.2 and will be removed in KunstmaanLeadGenerationBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_lead_generation.popup.twig.extension.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition