### PR TITLE
[DashboardBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kunstmaan\DashboardBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_dashboard.googleclient.class' => 'Google_Client',
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanDashboardBundle 5.2 and will be removed in KunstmaanDashboardBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/DashboardBundle/KunstmaanDashboardBundle.php
+++ b/src/Kunstmaan/DashboardBundle/KunstmaanDashboardBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\DashboardBundle;
 
+use Kunstmaan\DashboardBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\DashboardBundle\DependencyInjection\Compiler\WidgetCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -12,5 +13,6 @@ class KunstmaanDashboardBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new WidgetCompilerPass());
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/DashboardBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\DashboardBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\DashboardBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "kunstmaan_dashboard.googleclient.class" parameter to change the class of the service definition is deprecated in KunstmaanDashboardBundle 5.2 and will be removed in KunstmaanDashboardBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_dashboard.googleclient.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition