### PR TITLE
[ConfigBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/ConfigBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kunstmaan\ConfigBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_config.menu.adaptor.class' => \Kunstmaan\ConfigBundle\Helper\Menu\ConfigMenuAdaptor::class,
+            'kunstmaan_config.twig.extension.class' => \Kunstmaan\ConfigBundle\Twig\ConfigTwigExtension::class,
+            'kunstmaan_config.controller.config.class' => \Kunstmaan\ConfigBundle\Controller\ConfigController::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanConfigBundle 5.2 and will be removed in KunstmaanConfigBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/ConfigBundle/KunstmaanConfigBundle.php
+++ b/src/Kunstmaan/ConfigBundle/KunstmaanConfigBundle.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\ConfigBundle;
 
+use Kunstmaan\ConfigBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\ConfigBundle\DependencyInjection\Compiler\KunstmaanConfigConfigurationPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -12,5 +13,6 @@ class KunstmaanConfigBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new KunstmaanConfigConfigurationPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new DeprecateClassParametersPass());
     }
 }

--- a/src/Kunstmaan/ConfigBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/ConfigBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\ConfigBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\ConfigBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanConfigBundle 5.2 and will be removed in KunstmaanConfigBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_config.menu.adaptor.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition