### PR TITLE
[CacheBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/CacheBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/CacheBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_cache.menu_adaptor.varnish.class' => \Kunstmaan\CacheBundle\Helper\Menu\VarnishMenuAdaptor::class,
+            'kunstmaan_cache.helper.varnish.class' => \Kunstmaan\CacheBundle\Helper\VarnishHelper::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanCacheBundle 5.2 and will be removed in KunstmaanCacheBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
+++ b/src/Kunstmaan/CacheBundle/KunstmaanCacheBundle.php
@@ -2,8 +2,14 @@
 
 namespace Kunstmaan\CacheBundle;
 
+use Kunstmaan\CacheBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class KunstmaanCacheBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
 }

--- a/src/Kunstmaan/CacheBundle/Tests/_support/Helper/Unit.php
+++ b/src/Kunstmaan/CacheBundle/Tests/_support/Helper/Unit.php
@@ -1,0 +1,10 @@
+<?php
+namespace Kunstmaan\CacheBundle\Tests\Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Unit extends \Codeception\Module
+{
+
+}

--- a/src/Kunstmaan/CacheBundle/Tests/_support/UnitTester.php
+++ b/src/Kunstmaan/CacheBundle/Tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+namespace Kunstmaan\CacheBundle\Tests;
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/src/Kunstmaan/CacheBundle/Tests/unit.suite.yml
+++ b/src/Kunstmaan/CacheBundle/Tests/unit.suite.yml
@@ -1,0 +1,5 @@
+actor: UnitTester
+modules:
+  enabled:
+  - Asserts
+  - Kunstmaan\CacheBundle\Tests\Helper\Unit

--- a/src/Kunstmaan/CacheBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/CacheBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\CacheBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\CacheBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanCacheBundle 5.2 and will be removed in KunstmaanCacheBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_cache.menu_adaptor.varnish.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}

--- a/src/Kunstmaan/CacheBundle/codeception.yml
+++ b/src/Kunstmaan/CacheBundle/codeception.yml
@@ -1,0 +1,9 @@
+namespace: Kunstmaan\CacheBundle\Tests
+settings:
+    shuffle: true
+    lint: true
+paths:
+    tests: Tests
+    output: Tests/_output
+    support: Tests/_support
+    data: Tests/_data


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition