### PR TITLE
[AdminBundle] Deprecate service class parameters

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/DeprecateClassParametersPass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class DeprecateClassParametersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $expectedValues = [
+            'kunstmaan_admin.consoleexception.class' => \Kunstmaan\AdminBundle\EventListener\ConsoleExceptionListener::class,
+            'kunstmaan_admin.menubuilder.class' => \Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder::class,
+            'kunstmaan_admin.admin_panel.class' => \Kunstmaan\AdminBundle\Helper\AdminPanel\AdminPanel::class,
+            'kunstmaan_admin.login.listener.class' => \Kunstmaan\AdminBundle\EventListener\LoginListener::class,
+            'kunstmaan_admin.admin_locale.listener.class' => \Kunstmaan\AdminBundle\EventListener\AdminLocaleListener::class,
+            'kunstmaan_admin.acl.helper.class' => \Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper::class,
+            'kunstmaan_admin.acl.native.helper.class' => \Kunstmaan\AdminBundle\Helper\Security\Acl\AclNativeHelper::class,
+            'kunstmaan_admin.security.acl.permission.map.class' => \Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap::class,
+            'kunstmaan_admin.clone.listener.class' => \Kunstmaan\AdminBundle\EventListener\CloneListener::class,
+            'kunstmaan_admin.session_security.class' => \Kunstmaan\AdminBundle\EventListener\SessionSecurityListener::class,
+            'kunstmaan_admin.password_resetting.listener.class' => \Kunstmaan\AdminBundle\EventListener\PasswordResettingListener::class,
+            'kunstmaan_admin.password_check.listener.class' => \Kunstmaan\AdminBundle\EventListener\PasswordCheckListener::class,
+            'kunstmaan_admin.domain_configuration.class' => \Kunstmaan\AdminBundle\Helper\DomainConfiguration::class,
+            'kunstmaan_admin.validator.password_restrictions.class' => \Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictionsValidator::class,
+            'kunstmaan_admin.adminroute.helper.class' => \Kunstmaan\AdminBundle\Helper\AdminRouteHelper::class,
+            'kunstmaan_admin.adminroute.twig.class' => \Kunstmaan\AdminBundle\Twig\AdminRouteHelperTwigExtension::class,
+            'kunstmaan_admin.exception.listener.class' => \Kunstmaan\AdminBundle\EventListener\ExceptionSubscriber::class,
+            'kunstmaan_admin.toolbar.listener.class' => \Kunstmaan\AdminBundle\EventListener\ToolbarListener::class,
+            'kunstmaan_admin.toolbar.collector.bundle.class' => \Kunstmaan\AdminBundle\Toolbar\BundleVersionDataCollector::class,
+            'kunstmaan_admin.toolbar.collector.exception.class' => \Kunstmaan\AdminBundle\Toolbar\ExceptionDataCollector::class,
+        ];
+
+        foreach ($expectedValues as $parameter => $expectedValue) {
+            if (false === $container->hasParameter($parameter)) {
+                continue;
+            }
+
+            $currentValue = $container->getParameter($parameter);
+            if ($currentValue !== $expectedValue) {
+                @trigger_error(sprintf('Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanAdminBundle 5.2 and will be removed in KunstmaanAdminBundle 6.0. Use service decoration or a service alias instead.', $parameter), E_USER_DEPRECATED);
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -6,6 +6,7 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AddLogProcessorsCompilerP
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\AdminPanelCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\ConsoleCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
@@ -30,6 +31,8 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new DataCollectorPass());
         $container->addCompilerPass(new DomainConfigurationPass());
         $container->addCompilerPass(new ConsoleCompilerPass());
+
+        $container->addCompilerPass(new DeprecateClassParametersPass());
 
         $container->registerExtension(new KunstmaanAdminExtension());
     }

--- a/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/DependencyInjection/Compiler/DeprecateClassParametersPassTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class DeprecateClassParametersPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecateClassParametersPass());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the "%s" parameter to change the class of the service definition is deprecated in KunstmaanAdminBundle 5.2 and will be removed in KunstmaanAdminBundle 6.0. Use service decoration or a service alias instead.
+     */
+    public function testServiceClassParameterOverride()
+    {
+        $this->setParameter('kunstmaan_admin.consoleexception.class', 'Custom\Class');
+
+        $this->compile();
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
@@ -18,7 +18,7 @@ class KunstmaanAdminBundleTest extends PHPUnit_Framework_TestCase
         $resources = $containerBuilder->getResources();
         $extensions = $containerBuilder->getExtensions();
 
-        $this->assertCount(7, $resources);
+        $this->assertCount(8, $resources);
         $this->assertCount(1, $extensions);
         $this->assertArrayHasKey('kunstmaan_admin', $extensions);
         $this->assertInstanceOf(KunstmaanAdminExtension::class, $extensions['kunstmaan_admin']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate service class parameters to override the class of the service definition