### PR TITLE
[SearchBundle] Make search analysis service public for kuma:search:setup command

### DIFF
--- a/src/Kunstmaan/SearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/SearchBundle/Resources/config/services.yml
@@ -23,6 +23,7 @@ services:
 
     kunstmaan_search.search.factory.analysis:
         class: '%kunstmaan_search.search.factory.analysis.class%'
+        public: true
 
     # Providers
     kunstmaan_search.search_provider_chain:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This is needed to make the kuma:search:setup command work in sf4