### PR TITLE
[AdminBundle] Use new admin bundle parameters instead of the old deprecated

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -335,7 +335,7 @@ services:
     Kunstmaan\AdminBundle\Twig\AdminBundleTwigExtension:
         arguments:
             - '%kunstmaan_admin.website_title%'
-            - '%defaultlocale%'
-            - '%requiredlocales%'
+            - '%kunstmaan_admin.default_locale%'
+            - '%kunstmaan_admin.required_locales%'
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Use the correct parameters added in #2273 otherwise this service definition throws an exception when using the new admin bundle config
