### PR TITLE
[CacheBundle] Fixed incorrect composer autoload namespace

### DIFF
--- a/src/Kunstmaan/CacheBundle/composer.json
+++ b/src/Kunstmaan/CacheBundle/composer.json
@@ -26,7 +26,7 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-4": { "Kunstmaan\\ConfigBundle\\": "" }
+        "psr-4": { "Kunstmaan\\CacheBundle\\": "" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The incorrect namespace was added in #2259 
