### PR TITLE
[AdminBundle][MediaBundle] Configure bundle dependencies by default

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -119,6 +119,9 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $twigConfig['paths'][] = ['value' => dirname(__DIR__).'/Resources/views', 'namespace' => 'FOSUser'];
         $container->prependExtensionConfig('twig', $twigConfig);
 
+        $frameworkConfig['templating']['engines'] = ['twig'];
+        $container->prependExtensionConfig('framework', $frameworkConfig);
+
         $configs = $container->getExtensionConfig($this->getAlias());
         $this->processConfiguration(new Configuration(), $configs);
     }

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -160,3 +160,9 @@ services:
             - '@liip_imagine.cache.signer'
             - '@event_dispatcher'
             - '%liip_imagine.cache.resolver.default%'
+
+    Gedmo\Tree\TreeListener:
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+        calls:
+            - [ setAnnotationReader, [ "@annotation_reader" ] ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

These are dependencies only for our bundles so don't bother the user with setting up config for these dependencies. 

- FosUserBundle needs the templating service
- The media library needs the gedmo tree listener service to be registered

I would consider this a bugfix for 5.2 as installing the cms-skeleton will throw errors after install on cache:clear