### PR TITLE
[AdminListBundle] Fix getStringValue to allow displaying \DateTimeImmutable objects

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -619,7 +619,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
         if (is_bool($result)) {
             return $result ? 'true' : 'false';
         }
-        if ($result instanceof \DateTime) {
+        if ($result instanceof \DateTimeInterface) {
             return $result->format('Y-m-d H:i:s');
         } else {
             if ($result instanceof PersistentCollection) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
