### PR TITLE
[PagePartBundle] Make sure column names are independent of the doctrine naming strategy

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Entity/PagePartRef.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/PagePartRef.php
@@ -22,12 +22,12 @@ class PagePartRef
     protected $id;
 
     /**
-     * @ORM\Column(type="bigint")
+     * @ORM\Column(name="pageId", type="bigint")
      */
     protected $pageId;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(name="pageEntityname", type="string")
      */
     protected $pageEntityname;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Define the columnames to be independent of the doctrine naming strategy
