### PR TITLE
[GeneratorBundle] Use new multi language parameter as the check is broken on empty install

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -442,8 +442,8 @@ class DefaultSiteGenerator extends KunstmaanGenerator
     private function isMultiLangEnvironment()
     {
         // use the multilanguage parameter, if it exists
-        if ($this->container->hasParameter('multilanguage')) {
-            return $this->container->getParameter('multilanguage');
+        if ($this->container->hasParameter('kunstmaan_admin.multi_language')) {
+            return $this->container->getParameter('kunstmaan_admin.multi_language');
         }
 
         // This is a pretty silly implementation.

--- a/src/Kunstmaan/GeneratorBundle/Tests/unit/Generator/DefaultSiteGeneratorTest.php
+++ b/src/Kunstmaan/GeneratorBundle/Tests/unit/Generator/DefaultSiteGeneratorTest.php
@@ -26,7 +26,7 @@ class DefaultSiteGeneratorTest extends TestCase
         $container
             ->expects($this->any())
             ->method('hasParameter')
-            ->with('multilanguage')
+            ->with('kunstmaan_admin.multi_language')
             ->will($this->returnValue(true))
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Use the new multi_language parameter that is always set (even on empty installs)
