### PR TITLE
[AdminBundle] Load scripts in head with defer

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -21,6 +21,7 @@ AdminBundle
  * Setting the `requiredlocales` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.required_locales` config instead.
  * Setting the `defaultlocale` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.default_locale` config instead.
  * Setting the `websitetitle` directly is deprecated and support for this parameter will be removed in 6.0. Provide the `kunstmaan_admin.website_title` config instead.
+ * We moved the Javascript to the head section of the pages with a `defer` attribute. Custom added Javascript might be broken if it depends on jQuery as it might be executed before our scripts (including jQuery) are loaded. In that case, make sure to load your scripts with a defer attribute or wait for the `DOMContentLoaded`-event for inline scripts.
 
 MediaBundle
 -----------

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer.html.twig
@@ -1,37 +1,6 @@
-{% include "@KunstmaanAdmin/Default/_ckeditor_configs.html.twig" %}
-
-<script>
-    CKEDITOR_BASEPATH = '/bundles/kunstmaanadmin/default-theme/ckeditor/';
-    MORE_BUTTON_LABEL = '{{ 'kuma_js.auto_collapse.more_button_label' | trans | e('js') }}';
-</script>
-
-{# Dynamically load the scripts, and only add the Polyfills when they are necessary #}
-<script>
-    {# scripts without polyfills #}
-    var scripts = [
-        '{{ asset('bundles/kunstmaanadmin/js/admin-bundle.min.js') }}',
-        '{{ asset('bundles/kunstmaanadmin/js/admin-bundle.next.js') }}',
-
-        {%- block extra_async_javascripts %}{% endblock -%}
-
-        {%- set jsPath = 'frontend/js/admin-bundle-extra.js' -%}
-        {% if file_exists(jsPath) %}'{{ asset('/' ~ jsPath) }}'{% endif %}
-    ];
-
-    if (!('fetch' in window &&
-        'Promise' in window &&
-        'assign' in Object &&
-        'keys' in Object
-    )) {
-        scripts.unshift('{{ asset('bundles/kunstmaanadmin/js/admin-bundle-polyfills.js') }}');
-    }
-
-    scripts.forEach(function(src) {
-        var scriptEl = document.createElement('script');
-        scriptEl.src = src;
-        scriptEl.async = false;
-        document.head.appendChild(scriptEl);
-    });
-</script>
+{#
+  Note: Loading javascript in the body is not recommended.
+        Put it in the head and add a defer or async attribute
+#}
 
 {% include "@KunstmaanAdmin/Default/_js_footer_extra.html.twig" %}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer_extra.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_footer_extra.html.twig
@@ -1,21 +1,7 @@
 {#
   Don't edit this file in the Kunstmaan Bundles.
   You can extend this file to add javascript without removing the complete configuration.
-  
-  Example extra ckEditor config:
-  
-  ckEditorConfigs['simple'] = {
-        skin: 'bootstrapck',
-        startupFocus: false,
-        bodyClass: 'CKEditor',
-        filebrowserWindowWidth: 970,
-        filebrowserImageWindowWidth: 970,
-        filebrowserImageUploadUrl: '',
-            toolbar: [
-        {
-            name: 'basicstyles',
-            items: ['Bold', 'Italic', 'Underline', 'RemoveFormat']
-        }
-    ]};
 
+  Note: Loading javascript in the body is not recommended.
+        Put it in the head and add a defer or async attribute
 #}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Default/_js_header.html.twig
@@ -1,1 +1,27 @@
+{% include "@KunstmaanAdmin/Default/_ckeditor_configs.html.twig" %}
+
+<script>
+    CKEDITOR_BASEPATH = '/bundles/kunstmaanadmin/default-theme/ckeditor/';
+    MORE_BUTTON_LABEL = '{{ 'kuma_js.auto_collapse.more_button_label' | trans | e('js') }}';
+
+    if (!('fetch' in window &&
+            'Promise' in window &&
+            'assign' in Object &&
+            'keys' in Object
+        )) {
+        const scriptEl = document.createElement('script');
+        scriptEl.src = '{{ asset('bundles/kunstmaanadmin/js/admin-bundle-polyfills.js') }}';
+        scriptEl.async = false;
+        document.head.appendChild(scriptEl);
+    }
+</script>
+
+<script defer src="{{ asset('bundles/kunstmaanadmin/js/admin-bundle.min.js') }}"></script>
+<script defer src="{{ asset('bundles/kunstmaanadmin/js/admin-bundle.next.js') }}"></script>
+
+{%- set jsPath = 'frontend/js/admin-bundle-extra.js' %}
+{% if file_exists(jsPath) %}
+    <script defer src="{{ asset('/' ~ jsPath) }}"></script>
+{% endif %}
+
 {% include "@KunstmaanAdmin/Default/_js_header_extra.html.twig" %}

--- a/src/Kunstmaan/SeoBundle/Resources/views/GoogleAnalyticsTwigExtension/init.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/GoogleAnalyticsTwigExtension/init.html.twig
@@ -1,6 +1,6 @@
 <script>
 
-    jQuery(function() {
+    document.addEventListener('DOMContentLoaded', () => {
         {% if not app.debug %}
         googleAnalyticsApi.init(false);
         {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #1617 

**BC or not?**

We moved our scripts from the end of the body to the head with a `defer` attribute.

If you added custom javascript (for example in `_js_footer_extra.html.twig`) which depends on jQuery, your custom code might be broken because jQuery isn't available yet. If that's the case, you need to make sure to load your scripts with a `defer` attribute:
```
<script defer src="custom-jquery-script.js"></script>
```
or wait for the `DOMContentLoaded`-event for inline scripts:

```
<script>
    document.addEventListener('DOMContentLoaded', () => {
        console.log('$ and jQuery are available here.')
    });
</script>
```
or don't use jQuery :-)

FYI: https://alligator.io/html/defer-async/#async-vs-defer
