### PR TITLE
[GeneratorBundle] Fixed Page(part) generating

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/page/Entity/Pages/ExtraFunctions.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/page/Entity/Pages/ExtraFunctions.php
@@ -23,7 +23,7 @@
     {
         return [
 {% for section in sections %}
-            '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ section }}',
+            '{% if not isV4 %}{{ bundle }}:{%endif%}{{ section }}',
 {% endfor %}
         ];
     }
@@ -33,7 +33,7 @@
      */
     public function getPageTemplates()
     {
-        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ template }}'];
+        return ['{% if not isV4 %}{{ bundle }}:{%endif%}{{ template }}'];
     }
 
     /**
@@ -43,5 +43,5 @@
      */
     public function getDefaultView()
     {
-        return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}Pages/Common{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
+        return '{% if not isV4 %}{{ bundle }}:{%endif%}Pages/Common{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This PR fixes some problems when generating a Page(part).

The error that was reported was:

```
In ExtraFunctions.php line 26:
                                                                                                    
  Impossible to invoke a method ("getName") on a string variable ("TestWebsiteBundle").  
```
And
```
In ExtraFunctions.php line 8:
                                                                                                                                                                                                           
  An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Object of class Test\WebsiteBundle\TestWebsiteBundle could not be converted to string").  
                                                                                                                                                                                                           

In Environment.php(378) : eval()'d code line 33:
                                                                                                                                      
  Catchable Fatal Error: Object of class Test\WebsiteBundle\TestWebsiteBundle could not be converted to string  
```

Another possible solution would be to modify the `Entity/Pages/ExtraFunctions.php` file so that it's using `{{ bundle }}` instead of `{{ bundle.getName() }}`.
If this is the desired fix then let me know and I'll change the PR accordingly.
                                                       