### PR TITLE
[FormBundle] Replace Gemdo urlizer class with behat transliterator

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/FileFormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/FileFormSubmissionField.php
@@ -2,8 +2,8 @@
 
 namespace Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes;
 
+use Behat\Transliterator\Transliterator;
 use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Sluggable\Util\Urlizer;
 use Kunstmaan\FormBundle\Entity\FormSubmissionField;
 use Kunstmaan\FormBundle\Form\FileFormSubmissionType;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -135,7 +135,7 @@ class FileFormSubmissionField extends FormSubmissionField
         $newExtension = !empty($mimeTypeExtension) ? $mimeTypeExtension : $fileExtension;
 
         $baseName = !empty($fileExtension) ? basename($this->file->getClientOriginalName(), $fileExtension) : $this->file->getClientOriginalName();
-        $safeBaseName = Urlizer::urlize($baseName);
+        $safeBaseName = Transliterator::urlize($baseName);
 
         return $safeBaseName . (!empty($newExtension) ? '.' . $newExtension : '');
     }

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.1",
-        "gedmo/doctrine-extensions": "^2.4.34",
+        "behat/transliterator": "~1.2",
         "symfony/swiftmailer-bundle": "^2.3|^3.0",
         "kunstmaan/adminlist-bundle": "~5.2",
         "kunstmaan/node-bundle": "~5.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The gedmo urlizer class uses the behat transliterator class without any extra added features, so replace our current dependency to remove the extra overhead dependency on the gedmo/doctrine-extensions. See https://github.com/Atlantic18/DoctrineExtensions/pull/1079
