### PR TITLE
[TranslatorBundle] Fixed --globals flag for kuma:translator:import command

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/ImportCommandHandler.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/Importer/ImportCommandHandler.php
@@ -36,7 +36,7 @@ class ImportCommandHandler extends AbstractCommandHandler
      */
     public function executeImportCommand(ImportCommand $importCommand)
     {
-        if ($importCommand->getDefaultBundle() === false || $importCommand->getDefaultBundle() === null) {
+        if ($importCommand->getGlobals() || $importCommand->getDefaultBundle() === false || $importCommand->getDefaultBundle() === null) {
             return $this->importGlobalTranslationFiles($importCommand);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The --globals flag was not working anymore. This prevented translation files from being imported from the app/Resources/translations directory. 
