### PR TITLE
[FormBundle] Moved FormMailer dependency to separate listener

### DIFF
--- a/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
+++ b/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
@@ -21,7 +21,7 @@ class SubmissionEvent extends Event
 
     /**
      * @param FormSubmission $submission
-     * @param AbstractPage   $page
+     * @param FormPageInterface $page
      */
     public function __construct(FormSubmission $submission, FormPageInterface $page)
     {

--- a/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
+++ b/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
@@ -4,7 +4,6 @@ namespace Kunstmaan\FormBundle\Event;
 
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\FormBundle\Helper\FormPageInterface;
-use Kunstmaan\NodeBundle\Entity\AbstractPage;
 use Symfony\Component\EventDispatcher\Event;
 
 class SubmissionEvent extends Event
@@ -15,7 +14,7 @@ class SubmissionEvent extends Event
     protected $submission;
 
     /**
-     * @var AbstractPage
+     * @var FormPageInterface
      */
     protected $page;
 

--- a/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
+++ b/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
@@ -20,7 +20,7 @@ class SubmissionEvent extends Event
     protected $page;
 
     /**
-     * @param FormSubmission $submission
+     * @param FormSubmission    $submission
      * @param FormPageInterface $page
      */
     public function __construct(FormSubmission $submission, FormPageInterface $page)

--- a/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
+++ b/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\FormBundle\Event;
 
 use Kunstmaan\FormBundle\Entity\FormSubmission;
+use Kunstmaan\FormBundle\Helper\FormPageInterface;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -22,7 +23,7 @@ class SubmissionEvent extends Event
      * @param FormSubmission $submission
      * @param AbstractPage   $page
      */
-    public function __construct(FormSubmission $submission, AbstractPage $page)
+    public function __construct(FormSubmission $submission, FormPageInterface $page)
     {
         $this->submission = $submission;
         $this->page = $page;
@@ -37,7 +38,7 @@ class SubmissionEvent extends Event
     }
 
     /**
-     * @return AbstractPage
+     * @return FormPageInterface
      */
     public function getPage()
     {

--- a/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
+++ b/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
@@ -8,7 +8,7 @@ use Kunstmaan\FormBundle\Helper\FormMailerInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * An event listener send formsubmissions to the subscriber
+ * An event listener for sending an email after the form submission is completed
  */
 class SendEmailListener
 {

--- a/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
+++ b/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
@@ -2,10 +2,8 @@
 
 namespace Kunstmaan\FormBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
 use Kunstmaan\FormBundle\Event\SubmissionEvent;
 use Kunstmaan\FormBundle\Helper\FormMailerInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * An event listener for sending an email after the form submission is completed

--- a/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
+++ b/src/Kunstmaan/FormBundle/EventListener/SendEmailListener.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kunstmaan\FormBundle\EventListener;
+
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\FormBundle\Event\SubmissionEvent;
+use Kunstmaan\FormBundle\Helper\FormMailerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * An event listener send formsubmissions to the subscriber
+ */
+class SendEmailListener
+{
+    /**
+     * @var FormMailerInterface
+     */
+    private $formMailer;
+
+    /**
+     * @param FormMailerInterface $formMailer The form Mailer
+     */
+    public function __construct(FormMailerInterface $formMailer)
+    {
+        $this->formMailer = $formMailer;
+    }
+
+    /**
+     * Configure the form submissions link on top of the form in the sub action menu
+     *
+     * @param SubmissionEvent $event
+     */
+    public function onSubmission(SubmissionEvent $event)
+    {
+        $page = $event->getPage();
+        $formSubmission = $event->getSubmission();
+
+        $from = $page->getFromEmail();
+        $to = $page->getToEmail();
+        $subject = $page->getSubject();
+        if (!empty($from) && !empty($to) && !empty($subject)) {
+            $this->formMailer->sendContactMail($formSubmission, $from, $to, $subject);
+        }
+    }
+}

--- a/src/Kunstmaan/FormBundle/Helper/FormHandler.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormHandler.php
@@ -82,14 +82,6 @@ class FormHandler implements FormHandlerInterface
                 $event = new SubmissionEvent($formSubmission, $page);
                 $this->container->get('event_dispatcher')->dispatch(FormEvents::ADD_SUBMISSION, $event);
 
-                $from = $page->getFromEmail();
-                $to = $page->getToEmail();
-                $subject = $page->getSubject();
-                if (!empty($from) && !empty($to) && !empty($subject)) {
-                    $mailer = $this->container->get('kunstmaan_form.form_mailer');
-                    $mailer->sendContactMail($formSubmission, $from, $to, $subject);
-                }
-
                 return new RedirectResponse($page->generateThankYouUrl($router, $context));
             }
         }

--- a/src/Kunstmaan/FormBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
   kunstmaan_form.form_mailer.class: 'Kunstmaan\FormBundle\Helper\FormMailer'
   kunstmaan_form.form_handler.class: 'Kunstmaan\FormBundle\Helper\FormHandler'
+  kunstmaan_form.sendemail_listener.class: 'Kunstmaan\FormBundle\EventListener\SendEmailListener'
 
 services:
     kunstmaan_form.menu.adaptor.forms:
@@ -23,3 +24,9 @@ services:
         arguments: ['@doctrine.orm.entity_manager', '@router']
         tags:
             - { name: 'kernel.event_listener', event: 'kunstmaan_node.configureSubActionMenu', method: 'onSubActionMenuConfigure' }
+
+    kunstmaan_form.send_email_listener:
+        class: "%kunstmaan_form.sendemail_listener.class%"
+        arguments: ['@kunstmaan_form.form_mailer']
+        tags:
+            - { name: 'kernel.event_listener', event: 'kunstmaan_form.add_submission', method: 'onSubmission' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2390

Moved sending the email to a listener. The listener can be removed when no email needs to be send after form submission. For example when the form submission is used to create a MailChimp user.