### PR TITLE
[NodeSearchBundle] fix #2380 childs of structurenodes never get indexed and tests

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/EventListener/NodeIndexUpdateEventListener.php
+++ b/src/Kunstmaan/NodeSearchBundle/EventListener/NodeIndexUpdateEventListener.php
@@ -2,7 +2,9 @@
 
 namespace Kunstmaan\NodeSearchBundle\EventListener;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Kunstmaan\NodeBundle\Event\NodeEvent;
@@ -18,16 +20,18 @@ class NodeIndexUpdateEventListener implements NodeIndexUpdateEventListenerInterf
     /** @var ContainerInterface */
     private $container;
 
+    /** @var EntityManagerInterface */
+    private $em;
+
     /** @var NodePagesConfiguration */
     private $nodePagesConfiguration;
 
     /** @var array */
     private $entityChangeSet;
 
-    /**
-     * @param ContainerInterface $container
-     */
-    public function __construct(/* NodePagesConfiguration */ $nodePagesConfiguration)
+    public function __construct(/* NodePagesConfiguration */
+        $nodePagesConfiguration, /* EntityManagerInterface */
+        $em = null)
     {
         if ($nodePagesConfiguration instanceof ContainerInterface) {
             @trigger_error(sprintf('Passing the container as the first argument of "%s" is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Inject the "%s" service instead.', __CLASS__, 'kunstmaan_node_search.search_configuration.node'), E_USER_DEPRECATED);
@@ -35,10 +39,19 @@ class NodeIndexUpdateEventListener implements NodeIndexUpdateEventListenerInterf
             $this->container = $nodePagesConfiguration;
             $this->nodePagesConfiguration = $this->container->get('kunstmaan_node_search.search_configuration.node');
 
+            if (null === $em) {
+                $this->em = $this->container->get('doctrine.orm.default_entity_manager');
+            }
+
             return;
         }
 
+        if (!($em instanceof EntityManagerInterface)) {
+            @trigger_error(sprintf('Passing null or something other than an entitymanagerinterface as the second argument of "%s" is deprecated in KunstmaanNodeSearchBundle 5.2 and will be removed in KunstmaanNodeSearchBundle 6.0. Inject the "%s" service instead.', __CLASS__, 'doctrine.orm.default_entity_manager'), E_USER_DEPRECATED);
+        }
+
         $this->nodePagesConfiguration = $nodePagesConfiguration;
+        $this->em = $em;
     }
 
     /**
@@ -127,11 +140,32 @@ class NodeIndexUpdateEventListener implements NodeIndexUpdateEventListenerInterf
     private function hasOfflineParents(NodeTranslation $nodeTranslation)
     {
         $lang = $nodeTranslation->getLang();
-        foreach ($nodeTranslation->getNode()->getParents() as $node) {
-            $nodeNT = $node->getNodeTranslation($lang, true);
-            if ($nodeNT && !$nodeNT->isOnline() && !$nodeNT instanceof StructureNode) {
-                return true;
+        $node = $nodeTranslation->getNode();
+        if (null !== $this->em) {
+            $em = $this->em;
+        } else {
+            $lang = $nodeTranslation->getLang();
+            foreach ($nodeTranslation->getNode()->getParents() as $node) {
+                $nodeNT = $node->getNodeTranslation($lang, true);
+                if ($nodeNT && !$nodeNT->isOnline()) {
+                    return true;
+                }
             }
+            return false;
+        }
+
+        foreach ($node->getParents() as $parent) {
+            $parentNodeTranslation = $parent->getNodeTranslation($lang, true);
+            if (null === $parentNodeTranslation) {
+                continue;
+            }
+            $parentRef = $parentNodeTranslation->getRef($em);
+            // Continue looping unless we find an offline page that is not a StructureNode
+            if ($parentRef instanceof StructureNode || $parentNodeTranslation->isOnline()) {
+                continue;
+            }
+
+            return true;
         }
 
         return false;

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/update_listener.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     kunstmaan_node_search.node_index_update.listener:
         class: '%kunstmaan_node_search.node_index_update.listener.class%'
-        arguments: ['@kunstmaan_node_search.search_configuration.node']
+        arguments: ['@kunstmaan_node_search.search_configuration.node', '@doctrine.orm.default_entity_manager']
         tags:
             - { name: doctrine.event_listener, event: preUpdate,   method: preUpdate }
             - { name: kernel.event_listener, event: kunstmaan_node.postPublish,   method: onPostPublish }

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/EventListener/NodeIndexUpdateEventListenerTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/EventListener/NodeIndexUpdateEventListenerTest.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\NodeSearchBundle\Tests\EventListener;
 
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\NodeBundle\Entity\AbstractPage;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\StructureNode;
@@ -14,8 +16,11 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 {
     public function testUpdateOfChildPageWithStructuredNodeParent()
     {
-        $parentNodeTranslation = $this->createMock(StructureNode::class);
-        $parentNodeTranslation->method('isOnline')->willReturn(false);
+        $parentPage = $this->createMock(StructureNode::class);
+
+        $parentNodeTranslation = $this->createMock(NodeTranslation::class);
+        $parentNodeTranslation->method('getRef')->willReturn($parentPage);
+        $parentNodeTranslation->method('isOnline')->willReturn(true);
 
         $parentNode = $this->createMock(Node::class);
         $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
@@ -34,17 +39,23 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true));
+        $em = $this->createMock(EntityManager::class);
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true), $em);
         $listener->onPostPersist($nodeEvent);
     }
 
     public function testUpdateOfChildPageWithStructuredNodeParentAndOfflineParent()
     {
-        $parentNodeTranslation = $this->createMock(StructureNode::class);
-        $parentNodeTranslation->method('isOnline')->willReturn(false);
+        $parentPage = $this->createMock(StructureNode::class);
 
+        $parentNodeTranslation = $this->createMock(NodeTranslation::class);
+        $parentNodeTranslation->method('getRef')->willReturn($parentPage);
+        $parentNodeTranslation->method('isOnline')->willReturn(true);
+
+        $parentPageNotStructured = $this->createMock(AbstractPage::class);
         $parentNodeTranslation2 = $this->createMock(NodeTranslation::class);
         $parentNodeTranslation2->method('isOnline')->willReturn(false);
+        $parentNodeTranslation->method('getRef')->willReturn($parentPageNotStructured);
 
         $parentNode1 = $this->createMock(Node::class);
         $parentNode1->method('getNodeTranslation')->willReturn($parentNodeTranslation);
@@ -66,14 +77,17 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false));
+        $em = $this->createMock(EntityManager::class);
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false), $em);
         $listener->onPostPersist($nodeEvent);
     }
 
     public function testUpdateOfChildPageWithOfflineParent()
     {
+        $parentPage = $this->createMock(AbstractPage::class);
         $parentNodeTranslation = $this->createMock(NodeTranslation::class);
         $parentNodeTranslation->method('isOnline')->willReturn(false);
+        $parentNodeTranslation->method('getRef')->willReturn($parentPage);
 
         $parentNode = $this->createMock(Node::class);
         $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
@@ -90,14 +104,17 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false));
+        $em = $this->createMock(EntityManager::class);
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(false), $em);
         $listener->onPostPersist($nodeEvent);
     }
 
     public function testUpdateOfChildPageWithOnlineParent()
     {
+        $parentPage = $this->createMock(AbstractPage::class);
         $parentNodeTranslation = $this->createMock(NodeTranslation::class);
         $parentNodeTranslation->method('isOnline')->willReturn(true);
+        $parentNodeTranslation->method('getRef')->willReturn($parentPage);
 
         $parentNode = $this->createMock(Node::class);
         $parentNode->method('getNodeTranslation')->willReturn($parentNodeTranslation);
@@ -114,7 +131,8 @@ class NodeIndexUpdateEventListenerTest extends TestCase
 
         $nodeEvent->method('getNodeTranslation')->willReturn($nodeTranslation);
 
-        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true));
+        $em = $this->createMock(EntityManager::class);
+        $listener = new NodeIndexUpdateEventListener($this->getSearchConfiguration(true), $em);
         $listener->onPostPersist($nodeEvent);
     }
 
@@ -124,7 +142,8 @@ class NodeIndexUpdateEventListenerTest extends TestCase
      */
     public function testContainerDeprecation()
     {
-        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)));
+        $em = $this->createMock(EntityManager::class);
+        $listener = new NodeIndexUpdateEventListener($this->getContainer($this->getSearchConfiguration(false)), $em);
     }
 
     private function getContainer($searchConfigMock)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2380 

bugfix without bc break for above ticket.