### PR TITLE
[TranslatorBundle] Fix translations import on sf4 applications

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Service/TranslationFileExplorer.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/TranslationFileExplorer.php
@@ -29,11 +29,12 @@ class TranslationFileExplorer
      *
      * @return \Symfony\Component\Finder\Finder
      */
-    public function find($path, array $locales)
+    public function find($path, array $locales, $translationDirectory = null)
     {
         $finder = new Finder();
+        $translationDirectory = $translationDirectory ?? $this->defaultTranslationFolder;
 
-        $exploreDir = $path . '/' . $this->defaultTranslationFolder;
+        $exploreDir = $path . '/' . $translationDirectory;
 
         if (is_dir($exploreDir)) {
             $finder->files()

--- a/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/messages.en.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/messages.en.yml
@@ -1,0 +1,4 @@
+headers:
+    frontpage: "FrontPage"
+    homepage: "Hell Yeah"
+    sitemap: Sitemap

--- a/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/messages.nl.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/messages.nl.yml
@@ -1,0 +1,4 @@
+headers:
+    frontpage: "Voorste pagina"
+    homepage: "Hallo"
+    sitemap: website skelet

--- a/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/newdomain.de.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/unit/app/translations/newdomain.de.yml
@@ -1,0 +1,3 @@
+newdomain:
+    name: "a new domain"
+    description: "this domain can be loaded into the database, of not yet exists"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Some basic changes to make the translations import (cms admin and cli command) work on sf4. Some more cleanup (deprecations) should be done for the next minor.

