### PR TITLE
[AdminBundle] Added missing monolog dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/http-foundation": "^3.4|^4.0",
         "symfony/http-kernel": "^3.4|^4.0",
         "symfony/inflector": "^3.4|^4.0",
+        "symfony/monolog-bridge": "^3.4|^4.0",
         "symfony/options-resolver": "^3.4|^4.0",
         "symfony/property-access": "^3.4|^4.0",
         "symfony/routing": "^3.4|^4.0",

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -36,6 +36,7 @@
         "symfony/http-foundation": "^3.4|^4.0",
         "symfony/http-kernel": "^3.4|^4.0",
         "symfony/inflector": "^3.4|^4.0",
+        "symfony/monolog-bridge": "^3.4|^4.0",
         "symfony/options-resolver": "^3.4|^4.0",
         "symfony/property-access": "^3.4|^4.0",
         "symfony/routing": "^3.4|^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The `kunstmaan_admin.logger` and `kunstmaan_admin.logger.handler` have a dependency on the monolog-bridge/monolog packages. This was missed during the dependency split in 5.2