### PR TITLE
[GeneratorBundle] Fix old optional parameter usages

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/DataFixtures/ORM/ArticleGenerator/ArticleFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/DataFixtures/ORM/ArticleGenerator/ArticleFixtures.php
@@ -33,8 +33,8 @@ class {{ entity_class }}ArticleFixtures extends AbstractFixture implements Order
      */
     public function load(ObjectManager $manager)
 {
-    if ($this->container->getParameter('multilanguage')) {
-        $languages = explode('|', $this->container->getParameter('requiredlocales'));
+    if ($this->container->getParameter('kunstmaan_admin.multi_language')) {
+        $languages = explode('|', $this->container->getParameter('kunstmaan_admin.required_locales'));
     }
     if (!is_array($languages) || count($languages) < 1) {
         $languages = array('en');

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
@@ -30,8 +30,8 @@ class SearchFixtures extends AbstractFixture implements OrderedFixtureInterface,
      */
     public function load(ObjectManager $manager)
     {
-        if ($this->container->getParameter('multilanguage')) {
-            $languages = explode('|', $this->container->getParameter('requiredlocales'));
+        if ($this->container->getParameter('kunstmaan_admin.multi_language')) {
+            $languages = explode('|', $this->container->getParameter('kunstmaan_admin.required_locales'));
         }
         if (!is_array($languages) || count($languages) < 1) {
             $languages = array('en');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Without this fix the fixtures will fail on a sf4 skeleton installation
