### PR TITLE
[AdminBundle] Log console errors as critical instead of error

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionListener.php
@@ -56,6 +56,6 @@ class ConsoleExceptionListener
             $error->getLine(),
             $command->getName()
         );
-        $this->logger->error($message, ['error' => $error]);
+        $this->logger->critical($message, ['error' => $error]);
     }
 }

--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
@@ -62,6 +62,6 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
             $error->getLine(),
             $command->getName()
         );
-        $this->logger->error($message, ['error' => $error]);
+        $this->logger->critical($message, ['error' => $error]);
     }
 }

--- a/src/Kunstmaan/AdminBundle/Tests/unit/EventListener/ConsoleExceptionSubscriberTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/EventListener/ConsoleExceptionSubscriberTest.php
@@ -21,7 +21,7 @@ class ConsoleExceptionSubscriberTest extends Unit
         }
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->willReturn(true);
+        $logger->expects($this->once())->method('critical')->willReturn(true);
         $subscriber = new ConsoleExceptionSubscriber($logger);
 
         $command = new ApplyAclCommand();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Because our standard sentry config has error logging on `critical`, console errors never showed up.
