### PR TITLE
[TranslatorBundle] Export fails to print non standard characters correctly.

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Service/Command/Exporter/CSVFileExporter.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/Exporter/CSVFileExporter.php
@@ -42,7 +42,7 @@ class CSVFileExporter implements FileExporterInterface
 
                 if (isset($translation[$locale])) {
                     $item = $translation[$locale];
-                    $row[] = utf8_decode($item->getText());
+                    $row[] = $item->getText();
                 } else {
                     $row[] = '';
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I assume when the code was written "utf8_decode" was wrongfully assumed to guarantee that all text is returned in utf8 encoding. It does nothing like that at all and it is much better to enfore encoding in database or spreadsheet software.