### PR TITLE
[DashboardBundle] Mark google analytics helper service as public

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -47,3 +47,4 @@ services:
     kunstmaan_dashboard.helper.google.analytics.query:
         class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\QueryHelper'
         arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@kunstmaan_dashboard.helper.google.analytics.config']
+        public: true

--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -35,6 +35,7 @@ services:
     kunstmaan_dashboard.helper.google.analytics.service:
         class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ServiceHelper'
         arguments: ['@kunstmaan_dashboard.helper.google.client']
+        public: true
 
     # config helper
     kunstmaan_dashboard.helper.google.analytics.config:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 


Running the `bin/console kuma:dashboard:collect` command on sf4 will throw an error that this service is private. I currently run this command without a google account configured, so maybe more services fixes are required. I will create new pr's if necessary.