### PR TITLE
[NodeBundle] Start page reorder weight at 1 instead of 0

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -747,7 +747,7 @@ class NodeAdminController extends Controller
             $nodes[] = $node;
         }
 
-        $weight = 0;
+        $weight = 1;
         foreach ($nodes as $node) {
             $newParentId = isset($changeParents[$node->getId()]) ? $changeParents[$node->getId()] : null;
             if ($newParentId) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed the start value of the weight reorder of pages so that is in line with manual adding pages (the weight starts at 1 when adding)
