### PR TITLE
[NodeBundle] Fix for missing validation of url/email link chooser

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
@@ -8,6 +8,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Url;
 
 class URLChooserFormSubscriber implements EventSubscriberInterface
 {
@@ -17,6 +19,7 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
     {
         return [
             FormEvents::POST_SET_DATA => 'postSetData',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
         ];
     }
 
@@ -27,15 +30,27 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
      */
     public function postSetData(FormEvent $event)
     {
+        $this->formModifier($event);
+    }
+
+    public function preSubmit(FormEvent $event)
+    {
+        $this->formModifier($event);
+    }
+
+    private function formModifier(FormEvent $event)
+    {
         $form = $event->getForm();
         $data = $form->getData();
 
+        $constraints = [];
         $attributes['class'] = 'js-change-urlchooser';
 
         if (!empty($data) && $form->has('link_type')) {
             // Check if e-mail address
             if ($this->isEmailAddress($data)) {
                 $form->get('link_type')->setData(URLChooserType::EMAIL);
+                $constraints[] = new Email();
             } // Check if internal link
             elseif ($this->isInternalLink($data) || $this->isInternalMediaLink($data)) {
                 $form->get('link_type')->setData(URLChooserType::INTERNAL);
@@ -43,6 +58,7 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
             } // Else, it's an external link
             else {
                 $form->get('link_type')->setData(URLChooserType::EXTERNAL);
+                $constraints[] = new Url();
             }
         } else {
             $choices = $form->get('link_type')->getConfig()->getOption('choices');
@@ -55,6 +71,11 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
                     break;
                 case URLChooserType::EXTERNAL:
                     $attributes['placeholder'] = 'https://';
+                    $constraints[] = new Url();
+
+                    break;
+                case URLChooserType::EMAIL:
+                    $constraints[] = new Email();
 
                     break;
             }
@@ -69,6 +90,8 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
                 'label' => 'URL',
                 'required' => true,
                 'attr' => $attributes,
+                'constraints' => $constraints,
+                'error_bubbling' => true,
             ]
         );
     }

--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserLinkTypeSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserLinkTypeSubscriber.php
@@ -7,6 +7,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Url;
 
 /**
  * Class URLChooserLinkTypeSubscriber
@@ -34,6 +36,7 @@ class URLChooserLinkTypeSubscriber implements EventSubscriberInterface
         // Suppress validation
         $event->stopPropagation();
 
+        $constraints = [];
         $attributes['class'] = 'js-change-urlchooser';
 
         $form = $event->getForm()->getParent();
@@ -49,6 +52,11 @@ class URLChooserLinkTypeSubscriber implements EventSubscriberInterface
                     break;
                 case URLChooserType::EXTERNAL:
                     $attributes['placeholder'] = 'https://';
+                    $constraints[] = new Url();
+
+                    break;
+                case URLChooserType::EMAIL:
+                    $constraints[] = new Email();
 
                     break;
             }
@@ -57,6 +65,8 @@ class URLChooserLinkTypeSubscriber implements EventSubscriberInterface
                 'label' => 'URL',
                 'required' => true,
                 'attr' => $attributes,
+                'constraints' => $constraints,
+                'error_bubbling' => true,
             ));
         }
     }

--- a/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
@@ -49,6 +49,7 @@
                                     </li>
                                 {% endfor %}
                             </ul>
+                            <input type="hidden" name="{{ linkType.vars.full_name }}" value="{{ linkType.vars.data }}" id="{{ linkType.vars.id }}" class="form-control">
                         </div>
                     {% endif %}
                     <div id="{{ linkUrl.id }}-widget" class="input-group urlchooser-widget {% if form.link_type is defined %}urlchooser__link-url{% endif %}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The external url and email value of the url chooser type was not validated.

Url validation (http/https is required): 
![image](https://user-images.githubusercontent.com/1374857/55158474-54ebe700-515f-11e9-8fab-5ae590babe01.png)

Email validation
![image](https://user-images.githubusercontent.com/1374857/55158502-633a0300-515f-11e9-8b0b-a775dde112b0.png)
