### PR TITLE
[NodeBundle] Remove old/incorrect doc about lock command

### DIFF
--- a/docs/bundles/node-bundle/locking.md
+++ b/docs/bundles/node-bundle/locking.md
@@ -1,7 +1,5 @@
 # Node version lock implementation in NodeBundle
 
-The KunstmaanNodeBundle implements the [Symfony CMF](http://cmf.symfony.com/) [RoutingExtra](https://github.com/symfony-cmf/RoutingExtraBundle) bundle.
-
 ## Lock?
 
 When you edit a node, and at the same time someone else edits the node, the node of the user who does the last save will be kept. 
@@ -12,14 +10,10 @@ When saving the node, a new version of the page will be saved.
 
 Enable this feature by using:
 
+```yaml
 kunstmaan_node:
     lock:
         enabled: true
         threshold: 35 #seconds, optional
         check_interval: 15 #seconds, optional
-        
-There is also a command that should be ran on cron for cleaning up those locks after the threshold is exceeded.
-
-php bin/console kuma:nodes:clean-lock
-        
-
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The command doesn't exsist anymore, the lock cleanup is integrated into the lock check in the controller.
