### PR TITLE
[FormBundle] In newer versions of symfony the @templating service is replaced by the delegatingengine by default

### DIFF
--- a/src/Kunstmaan/FormBundle/Helper/FormMailer.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormMailer.php
@@ -5,8 +5,8 @@ namespace Kunstmaan\FormBundle\Helper;
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Swift_Mailer;
 use Swift_Message;
-use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * The form mailer
@@ -16,7 +16,7 @@ class FormMailer implements FormMailerInterface
     /** @var \Swift_Mailer */
     private $mailer;
 
-    /** @var \Symfony\Bundle\TwigBundle\TwigEngine */
+    /** @var EngineInterface */
     private $templating;
 
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
@@ -24,10 +24,10 @@ class FormMailer implements FormMailerInterface
 
     /**
      * @param Swift_Mailer       $mailer     The mailer service
-     * @param TwigEngine         $templating The templating service
+     * @param EngineInterface    $templating The templating service
      * @param ContainerInterface $container  The container
      */
-    public function __construct(Swift_Mailer $mailer, TwigEngine $templating, ContainerInterface $container)
+    public function __construct(Swift_Mailer $mailer, EngineInterface $templating, ContainerInterface $container)
     {
         $this->mailer = $mailer;
         $this->templating = $templating;
@@ -52,10 +52,10 @@ class FormMailer implements FormMailerInterface
             ->setBody(
                 $this->templating->render(
                     'KunstmaanFormBundle:Mailer:mail.html.twig',
-                    array(
+                    [
                         'submission' => $submission,
-                        'host' => $request->getScheme() . '://' . $request->getHttpHost(),
-                    )
+                        'host' => $request->getScheme().'://'.$request->getHttpHost(),
+                    ]
                 ),
                 'text/html'
             );

--- a/src/Kunstmaan/FormBundle/Tests/unit/Helper/FormMailerTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/unit/Helper/FormMailerTest.php
@@ -5,29 +5,33 @@ namespace Kunstmaan\FormBundle\Tests\Helper;
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\FormBundle\Helper\FormMailer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Templating\DelegatingEngine;
 
 class FormMailerTest extends TestCase
 {
     public function testSendContactMail()
     {
+        /** @var \Swift_Mailer $mailer */
         $mailer = $this->createMock(\Swift_Mailer::class);
-        $twigEngine = $this->createMock(TwigEngine::class);
+        /** @var DelegatingEngine $twigEngine */
+        $twigEngine = $this->createMock(DelegatingEngine::class);
+        /** @var ContainerInterface $container */
         $container = $this->createMock(ContainerInterface::class);
         $request = $this->createMock(Request::class);
         $requestStack = $this->createMock(RequestStack::class);
 
         $mailer->expects($this->once())->method('send');
-        $request->expects($this->once())->method('getScheme')->will($this->returnValue('http'));
-        $request->expects($this->once())->method('getHttpHost')->will($this->returnValue('example.com'));
-        $requestStack->expects($this->once())->method('getCurrentRequest')->will($this->returnValue($request));
-        $container->expects($this->once())->method('get')->will($this->returnValue($requestStack));
+        $request->expects($this->once())->method('getScheme')->willReturn('http');
+        $request->expects($this->once())->method('getHttpHost')->willReturn('example.com');
+        $requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
+        $container->expects($this->once())->method('get')->willReturn($requestStack);
 
         $formMailer = new FormMailer($mailer, $twigEngine, $container);
 
+        /** @var FormSubmission $formSubmission */
         $formSubmission = $this->createMock(FormSubmission::class);
 
         $formMailer->sendContactMail($formSubmission, 'from@example.com', 'to@example.com', 'subject');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
