### PR TITLE
[NodeBundle] Register services that enable the node bundle entity tabs

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -23,6 +23,19 @@ services:
             - { name: 'doctrine.event_listener', event: 'prePersist', method: 'prePersist' }
             - { name: 'doctrine.event_listener', event: 'preUpdate', method: 'preUpdate' }
 
+    kunstmaan_node.node_tabs.listener:
+        class: Kunstmaan\NodeBundle\EventListener\NodeTabListener
+        tags:
+            - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
+
+    kunstmaan_node.entity_tabs.listener:
+        class: Kunstmaan\NodeBundle\EventListener\EntityTabListener
+        arguments:
+            - '@request_stack'
+            - '@form.factory'
+        tags:
+            - { name: kernel.event_listener, event: kunstmaan_admin.adaptSimpleForm, method: adaptForm }
+
     kunstmaan_node.menu.adaptor.pages:
         class: Kunstmaan\NodeBundle\Helper\Menu\PageMenuAdaptor
         arguments: ['@doctrine.orm.entity_manager', '@kunstmaan_admin.acl.native.helper', '@kunstmaan_node.pages_configuration', '@kunstmaan_admin.domain_configuration']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The latest addition of entity tabs doesn't work, because the services that add the tabs to the forms aren't registered.