### PR TITLE
[AdminListbundle] Bugfix/wrong param in docblock

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -372,7 +372,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
     /**
      * @param string     $name     The field name
      * @param string     $header   The header title
-     * @param string     $sort     Sortable column or not
+     * @param bool       $sort     Sortable column or not
      * @param string     $template The template
      * @param FieldAlias $alias    The alias
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The $sort param uses the wrong type for the method addfield.
