### PR TITLE
[FormBundle][GeneratorBundle] Fix constraints on form pageparts 

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
@@ -94,8 +94,8 @@ class CheckboxPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
@@ -94,33 +94,34 @@ class CheckboxPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
         $bfsf = new BooleanFormSubmissionField();
-        $bfsf->setFieldName('field_' . $this->getUniqueId());
+        $bfsf->setFieldName('field_'.$this->getUniqueId());
         $bfsf->setLabel($this->getLabel());
         $bfsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $bfsf;
-        $constraints = array();
+        $data['formwidget_'.$this->getUniqueId()] = $bfsf;
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
             $constraints[] = new NotBlank($options);
         }
-        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+        $formBuilder->add(
+            'formwidget_'.$this->getUniqueId(),
             BooleanFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required' => $this->getRequired(),
-            )
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
@@ -80,8 +80,8 @@ class ChoicePagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
@@ -89,17 +89,17 @@ class ChoicePagePart extends AbstractFormPagePart
         $choices = array_map('trim', $choices);
 
         $cfsf = new ChoiceFormSubmissionField();
-        $cfsf->setFieldName('field_' . $this->getUniqueId());
+        $cfsf->setFieldName('field_'.$this->getUniqueId());
         $cfsf->setLabel($this->getLabel());
         $cfsf->setChoices($choices);
         $cfsf->setRequired($this->required);
         $cfsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $cfsf;
-        $constraints = array();
+        $data['formwidget_'.$this->getUniqueId()] = $cfsf;
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
@@ -107,17 +107,17 @@ class ChoicePagePart extends AbstractFormPagePart
         }
 
         $formBuilder->add(
-            'formwidget_' . $this->getUniqueId(),
+            'formwidget_'.$this->getUniqueId(),
             ChoiceFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
                 'required' => $this->getRequired(),
                 'expanded' => $this->getExpanded(),
                 'multiple' => $this->getMultiple(),
                 'choices' => $choices,
                 'placeholder' => $this->getEmptyValue(),
-                'constraints' => $constraints,
-            )
+                'value_constraints' => $constraints,
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
@@ -80,8 +80,8 @@ class ChoicePagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
@@ -126,8 +126,8 @@ class EmailPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
@@ -126,40 +126,41 @@ class EmailPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
         $efsf = new EmailFormSubmissionField();
-        $efsf->setFieldName('field_' . $this->getUniqueId());
+        $efsf->setFieldName('field_'.$this->getUniqueId());
         $efsf->setLabel($this->getLabel());
         $efsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $efsf;
+        $data['formwidget_'.$this->getUniqueId()] = $efsf;
 
-        $constraints = array();
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
             $constraints[] = new NotBlank($options);
         }
-        $options = array();
+        $options = [];
         if (!empty($this->errorMessageInvalid)) {
             $options['message'] = $this->getErrorMessageInvalid();
         }
         $constraints[] = new Email($options);
 
-        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+        $formBuilder->add(
+            'formwidget_'.$this->getUniqueId(),
             EmailFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required' => $this->getRequired(),
-            )
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
@@ -37,8 +37,8 @@ class FileUploadPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
@@ -37,22 +37,22 @@ class FileUploadPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
         $ffsf = new FileFormSubmissionField();
-        $ffsf->setFieldName('field_' . $this->getUniqueId());
+        $ffsf->setFieldName('field_'.$this->getUniqueId());
         $ffsf->setLabel($this->getLabel());
         $ffsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $ffsf;
+        $data['formwidget_'.$this->getUniqueId()] = $ffsf;
 
-        $constraints = array();
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
@@ -60,13 +60,13 @@ class FileUploadPagePart extends AbstractFormPagePart
         }
 
         $formBuilder->add(
-            'formwidget_' . $this->getUniqueId(),
+            'formwidget_'.$this->getUniqueId(),
             FileFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required' => $this->getRequired(),
-            )
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
@@ -157,29 +157,29 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
         $mfsf = new TextFormSubmissionField();
-        $mfsf->setFieldName('field_' . $this->getUniqueId());
+        $mfsf->setFieldName('field_'.$this->getUniqueId());
         $mfsf->setLabel($this->getLabel());
         $mfsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $mfsf;
+        $data['formwidget_'.$this->getUniqueId()] = $mfsf;
 
-        $constraints = array();
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
             $constraints[] = new NotBlank($options);
         }
         if ($this->getRegex()) {
-            $options = array('pattern' => $this->getRegex());
+            $options = ['pattern' => $this->getRegex()];
             if (!empty($this->errorMessageRegex)) {
                 $options['message'] = $this->errorMessageRegex;
             }
@@ -187,13 +187,13 @@ class MultiLineTextPagePart extends AbstractFormPagePart
         }
 
         $formBuilder->add(
-            'formwidget_' . $this->getUniqueId(),
+            'formwidget_'.$this->getUniqueId(),
             TextFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required' => $this->getRequired(),
-            )
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
@@ -157,8 +157,8 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
@@ -157,42 +157,43 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject          $fields      The fields
-     * @param int                  $sequence    The sequence of the form field
+     * @param ArrayObject $fields The fields
+     * @param int $sequence The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {
         $sfsf = new StringFormSubmissionField();
-        $sfsf->setFieldName('field_' . $this->getUniqueId());
+        $sfsf->setFieldName('field_'.$this->getUniqueId());
         $sfsf->setLabel($this->getLabel());
         $sfsf->setSequence($sequence);
 
         $data = $formBuilder->getData();
-        $data['formwidget_' . $this->getUniqueId()] = $sfsf;
+        $data['formwidget_'.$this->getUniqueId()] = $sfsf;
 
-        $constraints = array();
+        $constraints = [];
         if ($this->getRequired()) {
-            $options = array();
+            $options = [];
             if (!empty($this->errorMessageRequired)) {
                 $options['message'] = $this->errorMessageRequired;
             }
             $constraints[] = new NotBlank($options);
         }
         if ($this->getRegex()) {
-            $options = array('pattern' => $this->getRegex());
+            $options = ['pattern' => $this->getRegex()];
             if (!empty($this->errorMessageRegex)) {
                 $options['message'] = $this->errorMessageRegex;
             }
             $constraints[] = new Regex($options);
         }
 
-        $formBuilder->add('formwidget_' . $this->getUniqueId(),
+        $formBuilder->add(
+            'formwidget_'.$this->getUniqueId(),
             StringFormSubmissionType::class,
-            array(
+            [
                 'label' => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required' => $this->getRequired(),
-            )
+            ]
         );
         $formBuilder->setData($data);
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
@@ -157,8 +157,8 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      * Modify the form with the fields of the current page part
      *
      * @param FormBuilderInterface $formBuilder The form builder
-     * @param ArrayObject $fields The fields
-     * @param int $sequence The sequence of the form field
+     * @param ArrayObject          $fields      The fields
+     * @param int                  $sequence    The sequence of the form field
      */
     public function adaptForm(FormBuilderInterface $formBuilder, ArrayObject $fields, $sequence)
     {

--- a/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
@@ -18,7 +18,7 @@ class BooleanFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
@@ -14,23 +14,33 @@ class BooleanFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options The options
+     * @param array $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'constraints'), null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(['label', 'required', 'constraints'], null);
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
 
         $builder->add('value', CheckboxType::class, $fieldOptions);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-            'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\BooleanFormSubmissionField',
-        ]);
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\BooleanFormSubmissionField',
+                'value_constraints' => [],
+            ]
+        );
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/BooleanFormSubmissionType.php
@@ -14,7 +14,7 @@ class BooleanFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options The options
+     * @param array                $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
@@ -18,7 +18,7 @@ class ChoiceFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
@@ -14,14 +14,24 @@ class ChoiceFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options The options
+     * @param array $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(['label', 'required', 'expanded', 'multiple', 'choices', 'placeholder', 'constraints'], null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(
+            ['label', 'required', 'expanded', 'multiple', 'choices', 'placeholder', 'constraints'],
+            null
+        );
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
         $fieldOptions['choices'] = array_flip($fieldOptions['choices']);
         $fieldOptions['empty_data'] = null;
 
@@ -38,12 +48,15 @@ class ChoiceFormSubmissionType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
+        $resolver->setDefaults(
+            [
                 'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\ChoiceFormSubmissionField',
                 'choices' => [],
                 'placeholder' => null,
                 'expanded' => null,
                 'multiple' => null,
-        ]);
+                'value_constraints' => [],
+            ]
+        );
     }
 }

--- a/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoiceFormSubmissionType.php
@@ -14,7 +14,7 @@ class ChoiceFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options The options
+     * @param array                $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
@@ -14,7 +14,7 @@ class EmailFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options The options
+     * @param array                $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
@@ -18,7 +18,7 @@ class EmailFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/EmailFormSubmissionType.php
@@ -14,22 +14,32 @@ class EmailFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options The options
+     * @param array $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'constraints'), null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(['label', 'required', 'constraints'], null);
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
         $builder->add('value', EmailType::class, $fieldOptions);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\EmailFormSubmissionField',
-        ));
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\EmailFormSubmissionField',
+                'value_constraints' => [],
+            ]
+        );
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
@@ -14,23 +14,33 @@ class FileFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options An array with options
+     * @param array $options An array with options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'constraints'), null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(['label', 'required', 'constraints'], null);
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
 
         $builder->add('file', FileType::class, $fieldOptions);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\FileFormSubmissionField',
-        ));
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\FileFormSubmissionField',
+                'value_constraints' => [],
+            ]
+        );
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
@@ -18,7 +18,7 @@ class FileFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/FileFormSubmissionType.php
@@ -14,7 +14,7 @@ class FileFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options An array with options
+     * @param array                $options An array with options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
@@ -14,22 +14,32 @@ class StringFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options The options
+     * @param array $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'constraints'), null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(['label', 'required', 'constraints'], null);
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
         $builder->add('value', TextType::class, $fieldOptions);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\StringFormSubmissionField',
-        ));
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\StringFormSubmissionField',
+                'value_constraints' => [],
+            ]
+        );
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
@@ -14,7 +14,7 @@ class StringFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options The options
+     * @param array                $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/StringFormSubmissionType.php
@@ -18,7 +18,7 @@ class StringFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
@@ -14,7 +14,7 @@ class TextFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array $options The options
+     * @param array                $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
@@ -18,7 +18,7 @@ class TextFormSubmissionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (isset($options['value_constraints'])) {
+        if (isset($options['value_constraints']) && !empty($options['value_constraints'])) {
             $options['constraints'] = $options['value_constraints'];
         }
 

--- a/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
+++ b/src/Kunstmaan/FormBundle/Form/TextFormSubmissionType.php
@@ -14,24 +14,34 @@ class TextFormSubmissionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface $builder The form builder
-     * @param array                $options The options
+     * @param array $options The options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $keys = array_fill_keys(array('label', 'required', 'constraints'), null);
-        $fieldOptions = array_filter(array_replace($keys, array_intersect_key($options, $keys)), function ($v) {
-            return isset($v);
-        });
-        $fieldOptions['attr'] = array('rows' => '6');
+        if (isset($options['value_constraints'])) {
+            $options['constraints'] = $options['value_constraints'];
+        }
+
+        $keys = array_fill_keys(['label', 'required', 'constraints'], null);
+        $fieldOptions = array_filter(
+            array_replace($keys, array_intersect_key($options, $keys)),
+            function ($v) {
+                return isset($v);
+            }
+        );
+        $fieldOptions['attr'] = ['rows' => '6'];
 
         $builder->add('value', TextareaType::class, $fieldOptions);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\TextFormSubmissionField',
-        ));
+        $resolver->setDefaults(
+            [
+                'data_class' => 'Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\TextFormSubmissionField',
+                'value_constraints' => [],
+            ]
+        );
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
@@ -146,7 +146,7 @@ class {{ pagepart }} extends AbstractFormPagePart
             BooleanFormSubmissionType::class,
             array(
                 'label'       => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required'    => $this->getRequired()
             )
         );

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
@@ -123,7 +123,7 @@ class {{ pagepart }} extends AbstractFormPagePart
                 'multiple'    => $this->getMultiple(),
                 'choices'     => $choices,
                 'placeholder' => $this->getEmptyValue(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
             )
         );
         $formBuilder->setData($data);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
@@ -185,7 +185,7 @@ class {{ pagepart }} extends AbstractFormPagePart
             EmailFormSubmissionType::class,
             array(
                 'label'       => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required'    => $this->getRequired()
             )
         );

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
@@ -71,7 +71,7 @@ class {{ pagepart }} extends AbstractFormPagePart
             FileFormSubmissionType::class,
             array(
                 'label'       => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required'    => $this->getRequired()
             )
         );

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
@@ -219,7 +219,7 @@ class {{ pagepart }} extends AbstractFormPagePart
             TextFormSubmissionType::class,
             array(
                 'label'       => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required'    => $this->getRequired()
             )
         );

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
@@ -218,7 +218,7 @@ class {{ pagepart }} extends AbstractFormPagePart
             StringFormSubmissionType::class,
             array(
                 'label'       => $this->getLabel(),
-                'constraints' => $constraints,
+                'value_constraints' => $constraints,
                 'required'    => $this->getRequired()
             )
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2435 

The form pageparts use the default `constraints` option to pass the constraints from the `adaptForm` method to the actual form. Problem is that this will set the constraints on the parent Form object also which means that if you have for instance a `SingleLineTextPagePart` that is not required and used a pattern to be filled in, the form will be stuck because of the constraints that are set on the `StringFormSubmissionType` while the validation on the `value` property passes.
