### PR TITLE
[AllBundles] Backport page rename fix in docs config file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ pages:
     - "Installation":
         - Intro: installation/index.md
         - System requirements: installation/system-requirements.md
-        - Development environment: installation/development-environment.md
+        - Demo environment: installation/demo-environment.md
     - "Content management":
         - Intro: content-management/index.md
         - Creating a pagePart: content-management/creating-a-page-part.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This was fixed in #2418 (only on master/5.3), so backport this fix to make the 5.1 and 5.2 branches builds pass again