### PR TITLE
[NodeBundle] Added missing translation keys

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
@@ -50,6 +50,9 @@ kuma_node:
         online_public.raw:                  Online / Public version
         offline.raw:                        Offline
         "go_to_draft_version.%url%.raw":    (Go to <a href="%url%">draft version</a>)
+    error:
+        title: 'Error'
+        validation: 'The form has not been saved because there are validation errors'
     admin:
         publish:
             flash:

--- a/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig
@@ -25,7 +25,7 @@
     {% endif %}
     {% if form_has_errors_recursive(form) %}
         <div class="alert alert-danger">
-            <strong>{{ "Error" | trans }}: </strong>{{ "The form has not been saved because there are validation errors" | trans }}
+            <strong>{{ "kuma_node.error.title" | trans }}: </strong>{{ "kuma_node.error.validation" | trans }}
             {{ form_errors(form) }}
             <button class="close" data-dismiss="alert">
                 <i class="fa fa-times"></i>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

These keys are used in the nodeAdmin template but were not translated

https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/a7fff6a4045d20deb0b6dc832176c7ddb2254b38/src/Kunstmaan/NodeBundle/Resources/views/NodeAdmin/edit.html.twig#L28

Now they are available to be translated in crowdin