### PR TITLE
[GeneratorBundle] Improved the generated article classes

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
@@ -26,6 +26,6 @@ class {{ entity_class }}AuthorAdminListConfigurator extends AbstractArticleAutho
      */
     public function getEntityName()
     {
-	    return '{{ entity_class }}Author';
+        return '{{ entity_class }}Author';
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
@@ -39,6 +39,6 @@ class {{ entity_class }}CategoryAdminListConfigurator extends AbstractArticleCat
      */
     public function getEntityName()
     {
-	    return '{{ entity_class }}Category';
+        return '{{ entity_class }}Category';
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
@@ -27,7 +27,7 @@ class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdm
      */
     public function getEntityName()
     {
-	    return 'Pages\{{ entity_class }}Page';
+        return 'Pages\{{ entity_class }}Page';
     }
 
     /**
@@ -37,7 +37,7 @@ class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdm
     {
         parent::adaptQueryBuilder($queryBuilder);
 
-	    $queryBuilder->setParameter('class', '{{ namespace }}\Entity\Pages\{{ entity_class }}Page');
+        $queryBuilder->setParameter('class', '{{ namespace }}\Entity\Pages\{{ entity_class }}Page');
     }
 
     /**
@@ -45,7 +45,7 @@ class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdm
      */
     public function getOverviewPageRepository()
     {
-	    return $this->em->getRepository('{{ bundle.getName() }}:Pages\{{ entity_class }}OverviewPage');
+        return $this->em->getRepository('{{ bundle.getName() }}:Pages\{{ entity_class }}OverviewPage');
     }
 
     /**
@@ -53,6 +53,6 @@ class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdm
      */
     public function getListTemplate()
     {
-	    return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}AdminList/{{ entity_class }}PageAdminList{% if not isV4 %}:{% else %}/{% endif %}list.html.twig';
+        return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}AdminList/{{ entity_class }}PageAdminList{% if not isV4 %}:{% else %}/{% endif %}list.html.twig';
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
@@ -38,6 +38,6 @@ class {{ entity_class }}TagAdminListConfigurator extends AbstractArticleTagAdmin
      */
     public function getEntityName()
     {
-	    return '{{ entity_class }}Tag';
+        return '{{ entity_class }}Tag';
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/ArticleController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/ArticleController.php
@@ -1,17 +1,15 @@
 <?php
 namespace {{ namespace }}\Controller;
 
-use Gedmo\Tree\RepositoryInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Exception\OutOfRangeCurrentPageException;
 use Pagerfanta\Pagerfanta;
 
-class {{ entity_class }}ArticleController extends Controller
+class {{ entity_class }}ArticleController extends AbstractController
 {
-
     public function serviceAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
@@ -36,7 +34,7 @@ class {{ entity_class }}ArticleController extends Controller
             $repo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
             $nt = $repo->getNodeTranslationByLanguageAndInternalName($request->getLocale(), '{{ entity_class|lower }}');
             $url = $nt ? $nt->getUrl() : '';
-            $url = $this->get('router')->generate('_slug', array('url' => $url, '_locale' => $request->getLocale()));
+            $url = $this->generateUrl('_slug', array('url' => $url, '_locale' => $request->getLocale()));
 
             return new RedirectResponse($url);
         }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
@@ -5,15 +5,13 @@ namespace {{ namespace }}\Controller;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleAuthorAdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}AuthorAdminListConfigurator;
 {% if isV4 %}
 
 /**
- * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/author", requirements={"_locale"="%requiredlocales%"})
+ * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-author", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
 class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorAdminListController

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
@@ -5,14 +5,12 @@ namespace {{ namespace }}\Controller;
 use {{ namespace }}\AdminList\{{ entity_class }}CategoryAdminListConfigurator;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleCategoryAdminListController;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 {% if isV4 %}
 
 /**
- * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/category", requirements={"_locale"="%requiredlocales%"})
+ * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-category", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
 class {{ entity_class }}CategoryAdminListController extends AbstractArticleCategoryAdminListController

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
@@ -5,15 +5,13 @@ namespace {{ namespace }}\Controller;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticlePageAdminListController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}PageAdminListConfigurator;
 {% if isV4 %}
 
 /**
- * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/page", requirements={"_locale"="%requiredlocales%"})
+ * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-page", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
 class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdminListController

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
@@ -5,14 +5,12 @@ namespace {{ namespace }}\Controller;
 use {{ namespace }}\AdminList\{{ entity_class }}TagAdminListConfigurator;
 use Kunstmaan\ArticleBundle\Controller\AbstractArticleTagAdminListController;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 {% if isV4 %}
 
 /**
- * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/tag", requirements={"_locale"="%requiredlocales%"})
+ * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-tag", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
 class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminListController

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Author.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Author.php
@@ -4,7 +4,6 @@ namespace {{ namespace }}\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\ArticleBundle\Entity\AbstractAuthor;
-use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\{{ entity_class }}AuthorAdminType;
 
 /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
@@ -5,7 +5,6 @@ namespace {{ namespace }}\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Kunstmaan\ArticleBundle\Entity\AbstractCategory;
-use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\{{ entity_class }}CategoryAdminType;
 
 /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/OverviewPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/OverviewPage.php
@@ -8,11 +8,7 @@ use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Kunstmaan\NodeBundle\Controller\SlugActionInterface;
 use Kunstmaan\ArticleBundle\Entity\AbstractArticleOverviewPage;
-use Kunstmaan\NodeBundle\Helper\RenderContext;
 use Kunstmaan\PagePartBundle\PagePartAdmin\AbstractPagePartAdminConfigurator;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Form\AbstractType;
 
 /**
  * The article overview page which shows its articles
@@ -27,7 +23,7 @@ class {{ entity_class }}OverviewPage extends AbstractArticleOverviewPage impleme
      */
     public function getPagePartAdminConfigurations()
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}main');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}main'];
     }
 
     /**
@@ -35,7 +31,7 @@ class {{ entity_class }}OverviewPage extends AbstractArticleOverviewPage impleme
      */
     public function getPageTemplates()
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}overviewpage');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}overviewpage'];
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/Page.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/Page.php
@@ -9,7 +9,6 @@ use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Kunstmaan\NodeBundle\Entity\HideSidebarInNodeEditInterface;
 use {{ namespace }}\Form\Pages\{{ entity_class }}PageAdminType;
-use Symfony\Component\Form\AbstractType;
 
 /**
  * @ORM\Entity(repositoryClass="{{ namespace }}\Repository\{{ entity_class }}PageRepository")
@@ -50,7 +49,7 @@ class {{ entity_class }}Page extends AbstractArticlePage implements HasPageTempl
      */
     public function getPagePartAdminConfigurations()
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}main');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}main'];
     }
 
     /**
@@ -58,7 +57,7 @@ class {{ entity_class }}Page extends AbstractArticlePage implements HasPageTempl
      */
     public function getPageTemplates()
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}page');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}{{ entity_class|lower }}page'];
     }
 
     public function getDefaultView()

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
@@ -5,7 +5,6 @@ namespace {{ namespace }}\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Kunstmaan\ArticleBundle\Entity\AbstractTag;
-use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\{{ entity_class }}TagAdminType;
 
 /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/AuthorAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/AuthorAdminType.php
@@ -14,9 +14,9 @@ class {{ entity_class }}AuthorAdminType extends AbstractAuthorAdminType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
 	        'data_class' => '{{ namespace }}\Entity\{{ entity_class }}Author'
-        ));
+        ]);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/OverviewPageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/OverviewPageAdminType.php
@@ -17,9 +17,9 @@ class {{ entity_class }}OverviewPageAdminType extends AbstractArticleOverviewPag
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
 	        'data_class' => '{{ namespace }}\Entity\Pages\{{ entity_class }}OverviewPage'
-        ));
+        ]);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/PageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/PageAdminType.php
@@ -33,9 +33,9 @@ class {{ entity_class }}PageAdminType extends AbstractArticlePageAdminType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
 	        'data_class' => '{{ namespace }}\Entity\Pages\{{ entity_class }}Page'
-        ));
+        ]);
     }
 
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/PageAdminTypePartial.php.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/Pages/PageAdminTypePartial.php.twig
@@ -1,7 +1,7 @@
         {% if type == 'Author' %}
         $builder->add('author');
         {% else %}
-        $builder->add('{{ pluralType }}', EntityType::class, array(
+        $builder->add('{{ pluralType }}', EntityType::class, [
             'class' => '{{ bundle.name }}:{{ entity_class }}{{ type }}',
             'choice_label' => 'name',
             'query_builder' => function(EntityRepository $er) {
@@ -11,10 +11,10 @@
             },
             'multiple' => true,
             'expanded' => false,
-            'attr' => array(
+            'attr' => [
                  'class' => 'js-advanced-select',
                  'data-placeholder' => 'Choose the related {{ pluralType }}'
-            ),
+            ],
             'required' => false
-        ));
+        ]);
         {% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Helper/Menu/MenuAdaptor.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Helper/Menu/MenuAdaptor.php
@@ -25,7 +25,7 @@ class {{ entity_class }}MenuAdaptor implements MenuAdaptorInterface
 
     public function adaptChildren(MenuBuilder $menu, array &$children, MenuItem $parent = null, Request $request = null)
     {
-        if (is_null($this->overviewpageIds)) {
+        if ($this->overviewpageIds === null) {
             $overviewPageNodes = $this->em->getRepository('KunstmaanNodeBundle:Node')->findByRefEntityName('{{ namespace|replace({"\\": "\\\\"}) }}\\Entity\\Pages\\{{ entity_class }}OverviewPage');
             $this->overviewpageIds = array();
             foreach ($overviewPageNodes as $overviewPageNode) {
@@ -33,17 +33,17 @@ class {{ entity_class }}MenuAdaptor implements MenuAdaptorInterface
             }
         }
 
-        if (!is_null($parent) && 'KunstmaanAdminBundle_modules' == $parent->getRoute()) {
+        if ($parent !== null && 'KunstmaanAdminBundle_modules' === $parent->getRoute()) {
             // submenu
             $menuItem = new TopMenuItem($menu);
             $menuItem
                 ->setUniqueId('{{ entity_class|lower }}')
                 ->setLabel('{{ entity_class }}')
                 ->setParent($parent);
-            if (in_array($request->attributes->get('_route'), array(
+            if (in_array($request->attributes->get('_route'), [
                 '{{ bundle.getName()|lower }}_admin_blogitem',
                 '{{ bundle.getName()|lower }}_admin_blogsubscription'
-            ))) {
+            ])) {
                 $menuItem->setActive(true);
                 $parent->setActive(true);
             }
@@ -51,7 +51,7 @@ class {{ entity_class }}MenuAdaptor implements MenuAdaptorInterface
 
         }
 
-        if (!is_null($parent) && '{{ entity_class|lower }}' == $parent->getUniqueId()) {
+        if ($parent !== null && '{{ entity_class|lower }}' === $parent->getUniqueId()) {
             // Page
             $menuItem = new TopMenuItem($menu);
             $menuItem
@@ -70,12 +70,12 @@ class {{ entity_class }}MenuAdaptor implements MenuAdaptorInterface
         }
 
         //don't load children
-        if (!is_null($parent) && 'KunstmaanNodeBundle_nodes_edit' == $parent->getRoute()) {
+        if ($parent !== null && 'KunstmaanNodeBundle_nodes_edit' === $parent->getRoute()) {
             foreach ($children as $key => $child) {
-                if ('KunstmaanNodeBundle_nodes_edit' == $child->getRoute()){
+                if ('KunstmaanNodeBundle_nodes_edit' === $child->getRoute()){
                     $params = $child->getRouteParams();
                     $id = $params['id'];
-                    if (in_array($id, $this->overviewpageIds)) {
+                    if (in_array($id, $this->overviewpageIds, true)) {
                         $child->setChildren(array());
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This PR improves the output of the generated article files. List of changes:

- Mixup of indentations (tabs and spaces) -> all spaces
- Removed unused uses
- Use the symfony best practice to extend from `AbstractController` instead of `Controller`
- Made all the generated base routes unique. `/admin/page` -> `/admin/blog-page`, this to avoid issues when generating multiple article style entities
- Short array usages