### PR TITLE
[AdminListBundle] Improve the quality of the phpunit testcases

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/AdminListTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/AdminListTest.php
@@ -10,6 +10,7 @@ use Kunstmaan\AdminListBundle\AdminList\ItemAction\ItemActionInterface;
 use Kunstmaan\AdminListBundle\AdminList\ListAction\ListActionInterface;
 use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class AdminListTest
@@ -29,7 +30,7 @@ class AdminListTest extends TestCase
         $configurator->method('getExportFields')->willReturn(['c', 'd']);
         $configurator->method('getCount')->willReturn('666');
         $configurator->method('getItems')->willReturn(['item']);
-        $configurator->method('getSortFields')->willReturn(['e', 'f']);
+        $configurator->method('getSortFields')->willReturn(['e']);
         $configurator->method('canEdit')->willReturn(true);
         $configurator->method('canAdd')->willReturn(true);
         $configurator->method('canView')->willReturn(true);
@@ -54,6 +55,18 @@ class AdminListTest extends TestCase
         $configurator->method('getPagerfanta')->willReturn($this->createMock(Pagerfanta::class));
 
         $this->adminList = new AdminList($configurator);
+    }
+
+    public function testConstructor()
+    {
+        $configurator = $this->createMock(AdminListConfiguratorInterface::class);
+
+        $configurator->expects($this->once())->method('buildFilters');
+        $configurator->expects($this->once())->method('buildFields');
+        $configurator->expects($this->once())->method('buildItemActions');
+        $configurator->expects($this->once())->method('buildListActions');
+
+        new AdminList($configurator);
     }
 
     public function testGetConfigurator()
@@ -88,8 +101,19 @@ class AdminListTest extends TestCase
 
     public function testHasSort()
     {
-        $this->assertEquals(2, $this->adminList->hasSort());
+        $this->assertTrue($this->adminList->hasSort());
         $this->assertTrue($this->adminList->hasSort('e'));
+        $this->assertFalse($this->adminList->hasSort('x'));
+    }
+
+    public function testHasSortWithoutColumns()
+    {
+        $configurator = $this->createMock(AdminListConfiguratorInterface::class);
+        $configurator->method('getSortFields')->willReturn([]);
+
+        $adminList = new AdminList($configurator);
+
+        $this->assertFalse($adminList->hasSort());
     }
 
     public function testCanEdit()
@@ -215,5 +239,15 @@ class AdminListTest extends TestCase
     public function testGetPagerfanta()
     {
         $this->assertInstanceOf(Pagerfanta::class, $this->adminList->getPagerfanta());
+    }
+
+    public function testBindRequest()
+    {
+        $configurator = $this->createMock(AdminListConfiguratorInterface::class);
+
+        $configurator->expects($this->once())->method('bindRequest');
+        $adminList = new AdminList($configurator);
+
+        $adminList->bindRequest(new Request());
     }
 }

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Configurator/AbstractAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Configurator/AbstractAdminListConfiguratorTest.php
@@ -184,14 +184,17 @@ class AbstractAdminListConfiguratorTest extends TestCase
 
     public function testAddField()
     {
-        $this->abstractAdminListConfMock->addField('name', 'header', true);
+        $this->assertInstanceOf(AbstractAdminListConfigurator::class, $this->abstractAdminListConfMock->addField('name', 'header', true));
         $this->assertCount(1, $this->abstractAdminListConfMock->getFields());
     }
 
     public function testAddExportField()
     {
-        $this->abstractAdminListConfMock->addExportField('name', 'header', true);
-        $this->assertCount(1, $this->abstractAdminListConfMock->getExportFields());
+        $this->assertInstanceOf(AbstractAdminListConfigurator::class, $this->abstractAdminListConfMock->addExportField('name', 'header', true));
+        $exportFields = $this->abstractAdminListConfMock->getExportFields();
+        $this->assertCount(1, $exportFields);
+
+        $this->assertFalse($exportFields[0]->isSortable());
     }
 
     public function testAddFilter()
@@ -252,7 +255,7 @@ class AbstractAdminListConfiguratorTest extends TestCase
     public function testAddHasGetListAction()
     {
         $listActionInterfaceMock = $this->createMock(ListActionInterface::class);
-        $this->abstractAdminListConfMock->addListAction($listActionInterfaceMock);
+        $this->assertInstanceOf(AbstractAdminListConfigurator::class, $this->abstractAdminListConfMock->addListAction($listActionInterfaceMock));
         $this->assertTrue($this->abstractAdminListConfMock->hasListActions());
         $this->assertContainsOnlyInstancesOf(ListActionInterface::class, $this->abstractAdminListConfMock->getListActions());
     }
@@ -260,7 +263,7 @@ class AbstractAdminListConfiguratorTest extends TestCase
     public function testAddHasGetBulkAction()
     {
         $bulkActionInterfaceMock = $this->createMock(BulkActionInterface::class);
-        $this->abstractAdminListConfMock->addBulkAction($bulkActionInterfaceMock);
+        $this->assertInstanceOf(AbstractAdminListConfigurator::class, $this->abstractAdminListConfMock->addBulkAction($bulkActionInterfaceMock));
         $this->assertTrue($this->abstractAdminListConfMock->hasBulkActions());
         $this->assertContainsOnlyInstancesOf(BulkActionInterface::class, $this->abstractAdminListConfMock->getBulkActions());
     }

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/ExportListTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/ExportListTest.php
@@ -26,6 +26,17 @@ class ExportListTest extends TestCase
         $this->exportList = new ExportList($configurator);
     }
 
+    public function testConstructor()
+    {
+        $configurator = $this->createMock(ExportListConfiguratorInterface::class);
+
+        $configurator->expects($this->once())->method('buildFilters');
+        $configurator->expects($this->once())->method('buildExportFields');
+        $configurator->expects($this->once())->method('buildIterator');
+
+        new ExportList($configurator);
+    }
+
     public function testGetExportColumns()
     {
         $this->assertContains('c', $this->exportList->getExportColumns());

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/FieldTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/FieldTest.php
@@ -37,6 +37,17 @@ class FieldTest extends TestCase
         $this->assertEquals('template.html.twig', $object->getTemplate());
     }
 
+    public function testConstructorDefaultValues()
+    {
+        $object = new Field('name', 'header');
+
+        $this->assertEquals('name', $object->getName());
+        $this->assertEquals('header', $object->getHeader());
+        $this->assertFalse($object->isSortable());
+        $this->assertNull($object->getTemplate());
+        $this->assertNull($object->getAlias());
+    }
+
     public function testGetName()
     {
         $this->assertEquals('name', $this->object->getName());

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/FilterBuilderTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/FilterBuilderTest.php
@@ -52,7 +52,7 @@ class FilterBuilderTest extends TestCase
         $definition = $this->object->get('columnName');
         $this->assertNotNull($definition);
 
-        $this->object->remove('columnName');
+        $this->assertInstanceOf(FilterBuilder::class, $this->object->remove('columnName'));
         $definition = $this->object->get('columnName');
         $this->assertNull($definition);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I've executed our testsuite with infection and fixed some of the issues found. These improvement harden our testsuite to catch more bugs that can possibly be introduced. The actual improvement (higher is better):

Before:
```
635 mutations were generated:
     232 mutants were killed
     235 mutants were not covered by tests
     120 covered mutants were not detected
      48 errors were encountered
       0 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 44%
         Mutation Code Coverage: 62%
         Covered Code MSI: 70%
```

After:
```
635 mutations were generated:
     258 mutants were killed
     233 mutants were not covered by tests
      96 covered mutants were not detected
      48 errors were encountered
       0 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 48%
         Mutation Code Coverage: 63%
         Covered Code MSI: 76%
```