### PR TITLE
[AdminBundle] Deprecate container access in adminbundle classes

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -13,6 +13,8 @@ AdminBundle
   If you use this script handler, remove it from your composer.json scripts section.
 * We don't enable the templating component by default anymore. If you use the templating component or the `@templating` service, activate it by enabling the `framework.templating` config in your project.
 * The `\Kunstmaan\AdminBundle\FlashMessages\FlashTypes::ERROR` constant is deprecated and will be removed in 6.0. Use `\Kunstmaan\AdminBundle\FlashMessages\FlashTypes::DANGER` instead.
+* Passing the container as the first argument of "Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder" is deprecated in 5.4 and will be removed in 6.0. Inject the "request_stack" service instead.
+* Passing the container as the first argument of "Kunstmaan\AdminBundle\Helper\UserProcessor" is deprecated in 5.4 and will be removed in 6.0. Inject the "security.token_storage" service instead.
 
 AdminListBundle
 ---------------

--- a/src/Kunstmaan/AdminBundle/Helper/UserProcessor.php
+++ b/src/Kunstmaan/AdminBundle/Helper/UserProcessor.php
@@ -28,12 +28,23 @@ class UserProcessor
      */
     private $record = array();
 
+    private $tokenStorage;
+
     /**
-     * @param ContainerInterface $container
+     * @param ContainerInterface|TokenStorageInterface $tokenStorage
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(/*TokenStorageInterface */ $tokenStorage)
     {
-        $this->container = $container;
+        if ($tokenStorage instanceof ContainerInterface) {
+            @trigger_error(sprintf('Passing the container as the first argument of "%s" is deprecated in KunstmaanAdminBundle 5.4 and will be removed in KunstmaanAdminBundle 6.0. Inject the "security.token_storage" service instead.', __CLASS__), E_USER_DEPRECATED);
+
+            $this->container = $tokenStorage;
+            $this->tokenStorage = $this->container->get('security.token_storage');
+
+            return;
+        }
+
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -44,10 +55,8 @@ class UserProcessor
     public function processRecord(array $record)
     {
         if (\is_null($this->user)) {
-            /* @var TokenStorageInterface $securityTokenStorage */
-            $securityTokenStorage = $this->container->get('security.token_storage');
-            if (($securityTokenStorage !== null) && ($securityTokenStorage->getToken() !== null) && ($securityTokenStorage->getToken()->getUser() instanceof \Symfony\Component\Security\Core\User\AdvancedUserInterface)) {
-                $this->user = $securityTokenStorage->getToken()->getUser();
+            if (($this->tokenStorage !== null) && ($this->tokenStorage->getToken() !== null) && ($this->tokenStorage->getToken()->getUser() instanceof \Symfony\Component\Security\Core\User\AdvancedUserInterface)) {
+                $this->user = $this->tokenStorage->getToken()->getUser();
                 $this->record['extra']['user']['username'] = $this->user->getUsername();
                 $this->record['extra']['user']['roles'] = $this->user->getRoles();
                 $this->record['extra']['user']['is_account_non_expired'] = $this->user->isAccountNonExpired();

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -23,7 +23,7 @@ parameters:
 services:
     kunstmaan_admin.menubuilder:
         class: '%kunstmaan_admin.menubuilder.class%'
-        arguments: ['@service_container']
+        arguments: ['@request_stack']
 
     kunstmaan_admin.admin_panel:
         class: '%kunstmaan_admin.admin_panel.class%'

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Menu/MenuBuilderTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Menu/MenuBuilderTest.php
@@ -16,26 +16,14 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class MenuBuilderTest extends TestCase
 {
     /**
-     * @var ContainerInterface (mock)
-     */
-    protected $container;
-
-    protected function setUp()
-    {
-        $container = $this->createMock(ContainerInterface::class);
-        $this->container = $container;
-    }
-
-    /**
-     * @param ContainerInterface $container
-     * @param array|null         $methods
+     * @param array|null $methods
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|MenuBuilder
      */
-    public function setUpMenuBuilderMock(ContainerInterface $container, ?array $methods)
+    public function setUpMenuBuilderMock(?array $methods)
     {
         $menuBuilderMock = $this->getMockBuilder(MenuBuilder::class)
-            ->setConstructorArgs([$container])
+            ->setConstructorArgs([$this->createMock(RequestStack::class)])
             ->setMethods($methods)
             ->getMock()
         ;
@@ -43,13 +31,19 @@ class MenuBuilderTest extends TestCase
         return $menuBuilderMock;
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing the container as the first argument of "Kunstmaan\AdminBundle\Helper\Menu\MenuBuilder" is deprecated in KunstmaanAdminBundle 5.4 and will be removed in KunstmaanAdminBundle 6.0. Inject the "request_stack" service instead.
+     */
+    public function testConstructorContainerDeprecation()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        new MenuBuilder($container);
+    }
+
     public function testGetChildrenAndTopChildren()
     {
-        $stack = $this->createMock(RequestStack::class);
-
-        $this->container->expects($this->any())->method('get')->willReturn($stack);
-
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, null);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(null);
 
         /** @var MenuAdaptorInterface $menuAdaptorInterfaceMock */
         $menuAdaptorInterfaceMock = $this->createMock(MenuAdaptorInterface::class);
@@ -74,7 +68,7 @@ class MenuBuilderTest extends TestCase
             ->willReturn(true)
         ;
 
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, ['getChildren']);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(['getChildren']);
         $menuBuilderMock
             ->expects($this->any())
             ->method('getChildren')
@@ -95,7 +89,7 @@ class MenuBuilderTest extends TestCase
             ->willReturn(true)
         ;
 
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, ['getChildren']);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(['getChildren']);
         $menuBuilderMock
             ->expects($this->any())
             ->method('getChildren')
@@ -119,7 +113,7 @@ class MenuBuilderTest extends TestCase
             ->willReturn($this->createMock(TopMenuItem::class))
         ;
 
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, ['getChildren']);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(['getChildren']);
         $menuBuilderMock
             ->expects($this->any())
             ->method('getChildren')
@@ -138,7 +132,7 @@ class MenuBuilderTest extends TestCase
             ->willReturn(false)
         ;
 
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, ['getChildren']);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(['getChildren']);
         $menuBuilderMock
             ->expects($this->any())
             ->method('getChildren')
@@ -150,10 +144,6 @@ class MenuBuilderTest extends TestCase
 
     public function testGetTopChildren()
     {
-        $stack = $this->createMock(RequestStack::class);
-
-        $this->container->expects($this->any())->method('get')->willReturn($stack);
-
         /** @var MenuAdaptorInterface $menuAdaptorInterfaceMock */
         $menuAdaptorInterfaceMock = $this->createMock(MenuAdaptorInterface::class);
         $menuAdaptorInterfaceMock
@@ -161,7 +151,7 @@ class MenuBuilderTest extends TestCase
             ->method('adaptChildren')
         ;
 
-        $menuBuilderMock = $this->setUpMenuBuilderMock($this->container, null);
+        $menuBuilderMock = $this->setUpMenuBuilderMock(null);
         $menuBuilderMock->addAdaptMenu($menuAdaptorInterfaceMock);
 
         $this->assertIsArray($menuBuilderMock->getTopChildren());

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/UserProcessorTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/UserProcessorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\unit\Helper;
+
+use Kunstmaan\AdminBundle\Helper\UserProcessor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class UserProcessorTest extends TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing the container as the first argument of "Kunstmaan\AdminBundle\Helper\UserProcessor" is deprecated in KunstmaanAdminBundle 5.4 and will be removed in KunstmaanAdminBundle 6.0. Inject the "security.token_storage" service instead.
+     */
+    public function testConstructorContainerDeprecation()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        new UserProcessor($container);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Inject the correct dependency instead of the full service container.