### PR TITLE
[DashboardBundle] Update incorrect documentation url

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.de.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Ziele deaktivieren
       title: Google Analytics dashboard widget einrichten
       content: "Um mehr Informationen zur Einrichtung des Google Analytics Widgets zu erhalten, besuchen Sie"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: die Dokumentation
       redirect: "Dies ist die Umleitungs-URI:"
       refresh: "Aktualisieren Sie diese Seite sobald Sie mit der Einrichtung fertig sind."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.en.yml
@@ -22,7 +22,7 @@ dashboard:
                 disable: Disable goals
             title: Setup your Google Analytics dashboard widget
             content: "To learn how to setup the Google Analytics widget, please refer to"
-            docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+            docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
             docs: the documentation
             redirect: "This is your redirect URI:"
             refresh: "Once everything is set up, refresh this page."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.es.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Disable goals
       title: Setup your Google Analytics dashboard widget
       content: "To learn how to setup the Google Analytics widget, please refer to"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: the documentation
       redirect: "This is your redirect URI:"
       refresh: "Once everything is set up, refresh this page."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.fr.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Disable goals
       title: Setup your Google Analytics dashboard widget
       content: "To learn how to setup the Google Analytics widget, please refer to"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: the documentation
       redirect: "This is your redirect URI:"
       refresh: "Once everything is set up, refresh this page."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.hu.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Célok leállítása
       title: Állítsd be a Google Analytics  widgetet
       content: "Bővebben a Google Analytics widget beállításairól ezen a linket találhat információkat:"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: a dokumentáció
       redirect: "Ez az átirányított URI:"
       refresh: "Amennyiben mindent beállított, frissítse az oldalt"

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.it.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Disattiva obiettivi
       title: Configura il tuo widget Google Analytics in dashboard
       content: "Per imparare come configurare il widget Google Analytics , fai riferimento"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: alla documentazione
       redirect: "Questo è il tuo redirect URI:"
       refresh: "Quando tutto è stato configurato, aggiorna questa pagina."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.nl.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Doelen uitschakelen
       title: Instellen van uw Google Analytics-dashboard-widget
       content: "Om te leren hoe de Google Analytics widget werkt, verwijzen we u door naar"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: de documentatie
       redirect: "Dit is uw redirect URI:"
       refresh: "Zodra alles is ingesteld, vernieuw deze pagina."

--- a/src/Kunstmaan/DashboardBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/translations/messages.pl.yml
@@ -22,7 +22,7 @@ dashboard:
         disable: Wyłączone cele
       title: Utwórz widget panelu informacyjnego Google Analytics
       content: "Jeśli chcesz dowiedzieć się, w jaki sposób utworzyć widget Google Analytics zapoznaj się z:"
-      docs_url: "http://bundles.kunstmaan.be/getting-started/advanced/setting-up-the-google-analytics-dashboard"
+      docs_url: "https://kunstmaanbundlescms.readthedocs.io/en/stable/cookbook/google-analytics-dashboard/"
       docs: dokumentacją
       redirect: "To jest adres URL Twojego przekierowania:"
       refresh: "Jak tylko wszystko zostanie utworzone, odśwież tę stronę."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The documentation link for the setup of a google analytics dashboard was still pointed to the old documentation
