### PR TITLE
[GeneratorBundle] Fix webpack output path for admin-bundle-extra js

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/config/webpack.config.admin-extra.js
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/config/webpack.config.admin-extra.js
@@ -5,7 +5,8 @@ export default function webpackConfigAdminExtra(speedupLocalDevelopment, optimiz
 
     config.entry = './{% if isV4 %}assets{% else %}src/{{ bundle.namespace|replace({'\\':'/'}) }}/Resources{% endif %}/admin/js/admin-bundle-extra.js';
     config.output = {
-        filename: './{% if isV4 %}public{% else %}web{% endif %}/frontend/js/admin-bundle-extra.js',
+        path: path.resolve(__dirname, '../../{% if isV4 %}public{% else %}web{% endif %}/frontend/js'),
+        filename: 'admin-bundle-extra.js',
     };
 
     return config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The default output path is /dist, so it will generate `./dist/public/frontend/js/admin-bundle-extra.js`. By setting the path explicitly the output is correctly generated. Follow up of #2179