### PR TITLE
[NodeBundle] Throw a NotFoundException when the page entity is not found

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -54,6 +54,11 @@ class SlugController extends Controller
             $em,
             $nodeTranslation
         );
+
+        if (!$entity) {
+            throw $this->createNotFoundException('No page entity found for slug ' . $url);
+        }
+
         $node = $nodeTranslation->getNode();
 
         $securityEvent = new SlugSecurityEvent();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Throw a NotFoundException when the page entity is not found in SlugController.
We have a DoctrineFilter active that filters out page entities. So when the SlugController tries to find the node translation it works, but when it searches for the page entity, it gets a `null` returned. Here a NotFoundException should be thrown