### PR TITLE
[AllBundles] Replace internal loadTemplate twig method

### DIFF
--- a/src/Kunstmaan/AdminBundle/Twig/AdminPermissionsTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/AdminPermissionsTwigExtension.php
@@ -37,7 +37,7 @@ class AdminPermissionsTwigExtension extends AbstractExtension
      */
     public function renderWidget(Environment $env, PermissionAdmin $permissionAdmin, FormView $form, array $parameters = array())
     {
-        $template = $env->loadTemplate('@KunstmaanAdmin/PermissionsAdminTwigExtension/widget.html.twig');
+        $template = $env->load('@KunstmaanAdmin/PermissionsAdminTwigExtension/widget.html.twig');
 
         return $template->render(array_merge(array(
             'form' => $form,

--- a/src/Kunstmaan/AdminBundle/Twig/LocaleSwitcherTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/LocaleSwitcherTwigExtension.php
@@ -51,7 +51,7 @@ class LocaleSwitcherTwigExtension extends AbstractExtension
      */
     public function renderWidget(Environment $env, $locales, $route, array $parameters = array())
     {
-        $template = $env->loadTemplate(
+        $template = $env->load(
             '@KunstmaanAdmin/LocaleSwitcherTwigExtension/widget.html.twig'
         );
 

--- a/src/Kunstmaan/AdminBundle/Twig/MultiDomainAdminTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/MultiDomainAdminTwigExtension.php
@@ -45,7 +45,7 @@ class MultiDomainAdminTwigExtension extends AbstractExtension
      */
     public function renderWidget(Environment $env, $route, array $parameters = [])
     {
-        $template = $env->loadTemplate(
+        $template = $env->load(
             '@KunstmaanAdmin/MultiDomainAdminTwigExtension/widget.html.twig'
         );
 

--- a/src/Kunstmaan/AdminBundle/Twig/TabsTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/TabsTwigExtension.php
@@ -34,7 +34,7 @@ class TabsTwigExtension extends AbstractExtension
      */
     public function renderWidget(Environment $env, TabPane $tabPane, $options = array(), $template = '@KunstmaanAdmin/TabsTwigExtension/widget.html.twig')
     {
-        $template = $env->loadTemplate($template);
+        $template = $env->load($template);
 
         return $template->render(array_merge($options, array(
             'tabPane' => $tabPane,

--- a/src/Kunstmaan/AdminBundle/Twig/ToolbarTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/ToolbarTwigExtension.php
@@ -33,7 +33,7 @@ class ToolbarTwigExtension extends AbstractExtension
      */
     public function renderBlock(Environment $env, $template, $block, $context)
     {
-        $template = $env->loadTemplate($template);
+        $template = $env->load($template);
         $context = $env->mergeGlobals($context);
 
         return $template->renderBlock($block, $context);

--- a/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
@@ -78,7 +78,7 @@ class KunstmaanNodeSearchTwigExtension extends AbstractExtension
         $contextName = 'main',
         array $parameters = array()
     ) {
-        $template = $env->loadTemplate('KunstmaanNodeSearchBundle:PagePart:view.html.twig');
+        $template = $env->load('KunstmaanNodeSearchBundle:PagePart:view.html.twig');
         $pageparts = $this->indexablePagePartsService->getIndexablePageParts($page, $contextName);
         $newTwigContext = array_merge(
             $parameters,

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartAdminTwigExtension.php
@@ -51,7 +51,7 @@ class PagePartAdminTwigExtension extends AbstractExtension
             $templateName = '@KunstmaanPagePart/PagePartAdminTwigExtension/widget.html.twig';
         }
 
-        $template = $env->loadTemplate($templateName);
+        $template = $env->load($templateName);
 
         return $template->render(array_merge($parameters, [
             'pagepartadmin' => $ppAdmin,

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -52,7 +52,7 @@ class PagePartTwigExtension extends AbstractExtension
      */
     public function renderPageParts(Environment $env, array $twigContext, HasPagePartsInterface $page, $contextName = 'main', array $parameters = array())
     {
-        $template = $env->loadTemplate('@KunstmaanPagePart/PagePartTwigExtension/widget.html.twig');
+        $template = $env->load('@KunstmaanPagePart/PagePartTwigExtension/widget.html.twig');
         /* @var $entityRepository PagePartRefRepository */
         $pageparts = $this->getPageParts($page, $contextName);
         $newTwigContext = array_merge($parameters, array(

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PageTemplateTwigExtension.php
@@ -49,7 +49,7 @@ class PageTemplateTwigExtension extends AbstractExtension
 
         $pageTemplate = $pageTemplates[$this->getPageTemplate($page)];
 
-        $template = $env->loadTemplate($pageTemplate->getTemplate());
+        $template = $env->load($pageTemplate->getTemplate());
 
         return $template->render(array_merge($parameters, $twigContext));
     }
@@ -78,7 +78,7 @@ class PageTemplateTwigExtension extends AbstractExtension
 
         $pageTemplate = $pageTemplates[$this->getPageTemplate($page)];
 
-        $template = $env->loadTemplate($parameters['template']);
+        $template = $env->load($parameters['template']);
 
         return $template->render(array_merge(['pageTemplate' => $pageTemplate], $twigContext));
     }

--- a/src/Kunstmaan/SeoBundle/Twig/GoogleAnalyticsTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/GoogleAnalyticsTwigExtension.php
@@ -100,7 +100,7 @@ class GoogleAnalyticsTwigExtension extends AbstractExtension
             throw new RuntimeError("The google_analytics_initialize function depends on a Google Analytics account ID. You can either pass this along in the initialize_google_analytics function ($this->accountVarName), provide a variable under 'parameters.google.analytics.account_id'.");
         }
 
-        $template = $environment->loadTemplate('@KunstmaanSeo/GoogleAnalyticsTwigExtension/init.html.twig');
+        $template = $environment->load('@KunstmaanSeo/GoogleAnalyticsTwigExtension/init.html.twig');
 
         return $template->render($options);
     }
@@ -115,7 +115,7 @@ class GoogleAnalyticsTwigExtension extends AbstractExtension
     {
         $order = $this->orderPreparer->prepare($order);
         $options = $this->orderConverter->convert($order);
-        $template = $environment->loadTemplate(
+        $template = $environment->load(
             '@KunstmaanSeo/GoogleAnalyticsTwigExtension/ecommerce_tracking.html.twig'
         );
 

--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -162,7 +162,7 @@ class SeoTwigExtension extends AbstractExtension
     public function renderSeoMetadataFor(Environment $environment, AbstractEntity $entity, $currentNode = null, $template = '@KunstmaanSeo/SeoTwigExtension/metadata.html.twig')
     {
         $seo = $this->getSeoFor($entity);
-        $template = $environment->loadTemplate($template);
+        $template = $environment->load($template);
 
         return $template->render(
             array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Replace the internal `loadTemplate` method call by the new public api method `load`. See twigphp/twig#2236