### PR TITLE
[NodeBundle] Replace numeric regex check

### DIFF
--- a/src/Kunstmaan/NodeBundle/Tests/unit/Helper/Validation/UrlValidatorTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/Helper/Validation/UrlValidatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Tests\Helper;
+
+use Kunstmaan\NodeBundle\Validation\URLValidator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UrlValidatorTest extends TestCase
+{
+    /**
+     * @var URLValidator|MockObject
+     */
+    private $validatorMock;
+
+    protected function setUp()
+    {
+        $this->validatorMock = $this->getMockForTrait(URLValidator::class);
+    }
+
+    /**
+     * @dataProvider emailAddressProvider
+     */
+    public function testIsEmailAddress($email, $result)
+    {
+        $this->assertSame($result, $this->validatorMock->isEmailAddress($email));
+    }
+
+    /**
+     * @dataProvider internalLinkProvider
+     */
+    public function testIsInternalLink($link, $result)
+    {
+        $this->assertSame($result, $this->validatorMock->isInternalLink($link));
+    }
+
+    /**
+     * @dataProvider internalMediaLinkProvider
+     */
+    public function testIsInternalMediaLink($link, $result)
+    {
+        $this->assertSame($result, $this->validatorMock->isInternalMediaLink($link));
+    }
+
+    public function emailAddressProvider()
+    {
+        return [
+            ['abc', false],
+            ['test@example.com', 'test@example.com'],
+            ['test@local', false],
+        ];
+    }
+
+    public function internalLinkProvider()
+    {
+        return [
+            ['[NT:123]', false],
+            ['[NT123]', true],
+            ['[NTABC]', false],
+            ['[NT123ABC]', false],
+            ['[host_a:NT123]', true],
+            ['http://www.google.com', false],
+            ['[NT123][M20]', true],
+        ];
+    }
+
+    public function internalMediaLinkProvider()
+    {
+        return [
+            ['[M:123]', false],
+            ['[M123]', true],
+            ['[MABC]', false],
+            ['[M123ABC]', false],
+            ['[host_a:M23]', true],
+            ['http://www.google.com', false],
+            ['[M123][NT20]', true],
+        ];
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Validation/URLValidator.php
+++ b/src/Kunstmaan/NodeBundle/Validation/URLValidator.php
@@ -17,7 +17,7 @@ trait URLValidator
      */
     public function isInternalLink($link)
     {
-        preg_match_all("/\[(([a-z_A-Z\.]+):)?NT([0-9]+)\]/", $link, $matches, PREG_SET_ORDER);
+        preg_match_all("/\[(([a-z_A-Z\.]+):)?NT(\d+)\]/", $link, $matches, PREG_SET_ORDER);
 
         return count($matches) > 0;
     }
@@ -27,7 +27,7 @@ trait URLValidator
      */
     public function isInternalMediaLink($link)
     {
-        preg_match_all("/\[(([a-z_A-Z]+):)?M([0-9]+)\]/", $link, $matches, PREG_SET_ORDER);
+        preg_match_all("/\[(([a-z_A-Z]+):)?M(\d+)\]/", $link, $matches, PREG_SET_ORDER);
 
         return count($matches) > 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Applied the `'[0-9]' can be replaced with '\d' (safe in non-unicode mode)` suggestion of php inspections ea. I've added a test to check the behavior.