### PR TITLE
[NodeBundle] Explicitly require expression language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/dom-crawler": "^3.4|^4.0",
         "symfony/event-dispatcher": "^3.4|^4.0",
+        "symfony/expression-language": "^3.4|^4.0",
         "symfony/filesystem": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4|^4.0",

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -17,6 +17,7 @@
         "gedmo/doctrine-extensions": "^2.4.34",
         "kunstmaan/adminlist-bundle": "~5.2",
         "stof/doctrine-extensions-bundle": "~1.1",
+        "symfony/expression-language": "^3.4|^4.0",
         "symfony-cmf/routing-bundle": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The urlchooser route uses a condition to check the request.

https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/481373eea1afffadbe908204c099aa39f23c3352/src/Kunstmaan/NodeBundle/Controller/UrlReplaceController.php#L28-L33

This option needs the symfony/expression-language component, so explicitly require it.