### PR TITLE
[AdminBundle] Get correct version when using the separate packages

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/views/Toolbar/bundles_version.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Toolbar/bundles_version.html.twig
@@ -19,6 +19,15 @@
                         {% set status_color = '#9F6000' %}
                         {% set txt = 'toolbar.bundle_version.toupdate'|trans %}
                     {% endif %}
+                {% elseif bundle.name == 'kunstmaan/admin-bundle' %}
+                    {% set version = bundle.version %}
+                    {% if bundle.status == 'UP_TO_DATE' %}
+                        {% set status_color = '#4F8A10' %}
+                        {% set txt = 'toolbar.bundle_version.uptodate'|trans %}
+                    {% elseif bundle.status == 'TO_UPDATE' %}
+                        {% set status_color = '#9F6000' %}
+                        {% set txt = 'toolbar.bundle_version.toupdate'|trans %}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Backported the version fix from #2477. Currently no version info could be shown when using the cms with sf4 and the separate packages