### PR TITLE
[AdminBundle] Deprecate unused composer script class

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 5.3 to 5.4
+=======================
+
+AdminBundle
+-----------
+
+* The composer script class `Kunstmaan\AdminBundle\Composer\ScriptHandler` is deprecated and will be removed in 6.0. 
+  If you use this script handler, remove it from your composer.json scripts section.  

--- a/src/Kunstmaan/AdminBundle/Composer/ScriptHandler.php
+++ b/src/Kunstmaan/AdminBundle/Composer/ScriptHandler.php
@@ -7,6 +7,11 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Parser;
 
+@trigger_error(sprintf('The composer script class "%s" is deprecated in KunstmaanAdminBundle 5.4 and will be removed in KunstmaanAdminBundle 6.0. If you use this script handler, remove it from your composer.json scripts section.', __CLASS__), E_USER_DEPRECATED);
+
+/**
+ * NEXT_MAJOR remove the symfony/filesystem and symfony/yaml as direct dependency of the admin-bundle (if unused in other classes)
+ */
 class ScriptHandler
 {
     protected static $options = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

This class was only used in the standard-edition but [was removed a long time ago](https://github.com/Kunstmaan/KunstmaanBundlesStandardEdition/commit/31c1486f48757ae2fc18dd06707dfa1147299b90#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L46). 
