### PR TITLE
[AdminBundle] Add string return typehint to be compatible with symfony 4.3

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/Role.php
+++ b/src/Kunstmaan/AdminBundle/Entity/Role.php
@@ -50,16 +50,6 @@ class Role extends BaseRole
     }
 
     /**
-     * Return the string representation of the role entity.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->role;
-    }
-
-    /**
      * Get id
      *
      * @return int
@@ -81,5 +71,15 @@ class Role extends BaseRole
         $this->role = $role;
 
         return $this;
+    }
+
+    /**
+     * Return the string representation of the role entity.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->role;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Entity/Role.php
+++ b/src/Kunstmaan/AdminBundle/Entity/Role.php
@@ -50,6 +50,16 @@ class Role extends BaseRole
     }
 
     /**
+     * Return the string representation of the role entity.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->role;
+    }
+
+    /**
      * Get id
      *
      * @return int
@@ -71,15 +81,5 @@ class Role extends BaseRole
         $this->role = $role;
 
         return $this;
-    }
-
-    /**
-     * Return the string representation of the role entity.
-     *
-     * @return string
-     */
-    public function __toString(): string
-    {
-        return (string) $this->role;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Our method conflicts with the parent method in symfony 4.3. So add the string typehint to be compatible with symfony 4.3 and keep the `__toString()` working for older versions. 
 
```
Declaration of Kunstmaan\AdminBundle\Entity\Role::__toString() must be compatible with Symfony\Component\Security\Core\Role\Role::__toString(): string
```