### PR TITLE
[AllBundles] Upgrade jquery to fix security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1469,7 +1469,7 @@
       "integrity": "sha512-xDVuG5ZLDKLoYdBodnrKo417eqFlNwpk6gNbv1mAFdFno0p0xnkYm9KQTiUqR4kva9t+hlJJc2UURZnD6fvn+Q==",
       "requires": {
         "bootstrap": "4.2.1",
-        "jquery": "3.3.1"
+        "jquery": "3.4.1"
       }
     },
     "bootstrap-sass": {
@@ -1863,9 +1863,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz",
       "integrity": "sha512-1Y2uJ5y56qDt3jsDTdBHL1OqiImzjoQcBG6Yl3Qizq8mcc2SgCFpi+ZwLLqkztYnk9l87IYqRlNBnPSOTbFkXQ==",
       "dev": true
-    },
-    "cargobay": {
-      "version": "github:Kunstmaan/cargobay#d4ab90f51b1d4e395ebee02924ebeefb5068fa60"
     },
     "caseless": {
       "version": "0.12.0",
@@ -3222,7 +3219,7 @@
       "integrity": "sha1-ekmXAEQGUnbnll79Fvgic1IZ5zU=",
       "requires": {
         "bootstrap": "3.4.0",
-        "jquery": "3.3.1",
+        "jquery": "3.4.1",
         "moment": "2.24.0",
         "moment-timezone": "0.4.1"
       },
@@ -6213,9 +6210,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jquery-mousewheel": {
       "version": "3.1.13",
@@ -6414,7 +6411,7 @@
       "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.7.tgz",
       "integrity": "sha512-yzzalO1TbZ4HdPezO43LesGI4Wv2sB0Nl+4GfwO0YYvehGws5qtTAhlBISxfur9phMLwCtf9GjHlRx2ZLXyRnw==",
       "requires": {
-        "jquery": "3.3.1"
+        "jquery": "3.4.1"
       }
     },
     "just-debounce": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cargobay": "Kunstmaan/cargobay#0.8.6-support",
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "fuse.js": "^3.1.0",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.1",
     "jquery.typewatch": "^3.0.0",
     "jstree": "^3.3.3",
     "picturefill": "^3.0.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Fix for jquery security warning (CVE-201911385)
![image](https://user-images.githubusercontent.com/1374857/58634110-c0cb0700-82ea-11e9-90a9-c444e67a3cfa.png)

