### PR TITLE
[TranslatorBundle] Restored missing service alias for translator datacollector

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
@@ -51,5 +51,9 @@ class KunstmaanTranslatorCompilerPass implements CompilerPassInterface
         if ($container->hasDefinition('kunstmaan_translator.service.exporter.exporter')) {
             $container->getDefinition('kunstmaan_translator.service.exporter.exporter')->addMethodCall('setExporters', array($exporterRefs));
         }
+
+        if ($container->has('translator.data_collector')) {
+            $container->setAlias('translator.data_collector', 'kunstmaan_translator.datacollector');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

With all the previous deprecation fix in 5.x we forgot to add an alias for the symfony translation datacollector. With this fix the symfony translation toolbar item will work again.
