### PR TITLE
[NodeBundle] missing form error translations

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.nl.yml
@@ -47,6 +47,9 @@ kuma_node:
     online_public.raw: Online / Publieke versie
     offline.raw: Offline
     "go_to_draft_version.%url%.raw": (Ga naar <a href="%url%">draft versie</a>)
+  error:
+    title: 'Error'
+    validation: 'Het formulier is niet opgeslagen, omdat er validatie errors zijn'
   admin:
     publish:
       flash:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Translation exists in messages.en.yml, missing in messages.nl.yml