### PR TITLE
[AdminBundle] Fix SF 4.3 error in Role class

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/Role.php
+++ b/src/Kunstmaan/AdminBundle/Entity/Role.php
@@ -54,7 +54,7 @@ class Role extends BaseRole
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->role;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Make sure the __toString function is matching the format of the parent class. This is needed to prevent errors when running symfony 4.3. This is backwards compatible with older symfony versions.
