### PR TITLE
[GeneratorBundle] Added missing import in admin js task

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/config/webpack.config.admin-extra.js
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/bin/config/webpack.config.admin-extra.js
@@ -1,4 +1,5 @@
 import defaultConfig from './webpack.config.default';
+import path from 'path';
 
 export default function webpackConfigAdminExtra(speedupLocalDevelopment, optimize = false) {
     const config = defaultConfig(speedupLocalDevelopment, optimize);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

#2462 was missing an import for the path var
