### PR TITLE
[NodeBundle] Be able to set the target of the preview of a page

### DIFF
--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('publish_later_stepping')->defaultValue('15')->end()
                 ->scalarNode('unpublish_later_stepping')->defaultValue('15')->end()
                 ->booleanNode('show_add_homepage')->defaultTrue()->end()
+                ->scalarNode('preview_target_window')->defaultValue('_blank')->end()
                 ->booleanNode('enable_export_page_template')->defaultFalse()->end()
                 ->arrayNode('lock')
                     ->addDefaultsIfNotSet()

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -37,6 +37,7 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
 
         $container->setParameter('kunstmaan_node.show_add_homepage', $config['show_add_homepage']);
         $container->setParameter('kunstmaan_node.enable_export_page_template', $config['enable_export_page_template']);
+        $container->setParameter('kunstmaan_node.preview_target_window', $config['preview_target_window']);
         $container->setParameter('kunstmaan_node.lock_check_interval', $config['lock']['check_interval']);
         $container->setParameter('kunstmaan_node.lock_threshold', $config['lock']['threshold']);
         $container->setParameter('kunstmaan_node.lock_enabled', $config['lock']['enabled']);

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -75,8 +75,8 @@ class ActionsMenuBuilder
      * @param EventDispatcherInterface      $dispatcher               The event dispatcher
      * @param AuthorizationCheckerInterface $authorizationChecker     The security authorization checker
      * @param PagesConfiguration            $pagesConfiguration
-     * @param string                        $previewTargetName
      * @param bool                          $enableExportPageTemplate
+     * @param string                        $previewTargetName
      */
     public function __construct(
         FactoryInterface $factory,
@@ -85,8 +85,8 @@ class ActionsMenuBuilder
         EventDispatcherInterface $dispatcher,
         AuthorizationCheckerInterface $authorizationChecker,
         PagesConfiguration $pagesConfiguration,
-        $previewTargetName,
-        $enableExportPageTemplate = true
+        $enableExportPageTemplate,
+        $previewTargetName
     ) {
         $this->factory = $factory;
         $this->em = $em;
@@ -94,8 +94,8 @@ class ActionsMenuBuilder
         $this->dispatcher = $dispatcher;
         $this->authorizationChecker = $authorizationChecker;
         $this->pagesConfiguration = $pagesConfiguration;
-        $this->previewTargetName = $previewTargetName;
         $this->enableExportPageTemplate = $enableExportPageTemplate;
+        $this->previewTargetName = $previewTargetName;
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -59,6 +59,11 @@ class ActionsMenuBuilder
     private $isEditableNode = true;
 
     /**
+     * @var string
+     */
+    private $previewTargetName;
+
+    /**
      * @var bool
      */
     private $enableExportPageTemplate = true;
@@ -70,6 +75,7 @@ class ActionsMenuBuilder
      * @param EventDispatcherInterface      $dispatcher               The event dispatcher
      * @param AuthorizationCheckerInterface $authorizationChecker     The security authorization checker
      * @param PagesConfiguration            $pagesConfiguration
+     * @param string                        $previewTargetName
      * @param bool                          $enableExportPageTemplate
      */
     public function __construct(
@@ -79,6 +85,7 @@ class ActionsMenuBuilder
         EventDispatcherInterface $dispatcher,
         AuthorizationCheckerInterface $authorizationChecker,
         PagesConfiguration $pagesConfiguration,
+        $previewTargetName,
         $enableExportPageTemplate = true
     ) {
         $this->factory = $factory;
@@ -87,6 +94,7 @@ class ActionsMenuBuilder
         $this->dispatcher = $dispatcher;
         $this->authorizationChecker = $authorizationChecker;
         $this->pagesConfiguration = $pagesConfiguration;
+        $this->previewTargetName = $previewTargetName;
         $this->enableExportPageTemplate = $enableExportPageTemplate;
     }
 
@@ -227,7 +235,7 @@ class ActionsMenuBuilder
                         ]
                     ),
                     'linkAttributes' => [
-                        'target' => '_blank',
+                        'target' => $this->previewTargetName,
                         'class' => 'btn btn-default btn--raise-on-hover',
                     ],
                 ]
@@ -271,7 +279,7 @@ class ActionsMenuBuilder
                             ['url' => $activeNodeTranslation->getUrl()]
                         ),
                         'linkAttributes' => [
-                            'target' => '_blank',
+                            'target' => $this->previewTargetName,
                             'class' => 'btn btn-default btn--raise-on-hover',
                         ],
                     ]

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -77,7 +77,7 @@ services:
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration', '%kunstmaan_node.enable_export_page_template%', '%kunstmaan_node.preview_target_window%' ]
+        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration', '%kunstmaan_node.preview_target_window%', '%kunstmaan_node.enable_export_page_template%' ]
         public: true
 
     kunstmaan_node.menu.sub_actions:

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -77,7 +77,7 @@ services:
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration', '%kunstmaan_node.enable_export_page_template%' ]
+        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration', '%kunstmaan_node.enable_export_page_template%', '%kunstmaan_node.preview_target_window%' ]
         public: true
 
     kunstmaan_node.menu.sub_actions:

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -77,7 +77,15 @@ services:
 
     kunstmaan_node.actions_menu_builder:
         class: Kunstmaan\NodeBundle\Helper\Menu\ActionsMenuBuilder
-        arguments: ['@knp_menu.factory', '@doctrine.orm.entity_manager', '@router', '@event_dispatcher', '@security.authorization_checker', '@kunstmaan_node.pages_configuration', '%kunstmaan_node.preview_target_window%', '%kunstmaan_node.enable_export_page_template%' ]
+        arguments:
+            - '@knp_menu.factory'
+            - '@doctrine.orm.entity_manager'
+            - '@router'
+            - '@event_dispatcher'
+            - '@security.authorization_checker'
+            - '@kunstmaan_node.pages_configuration'
+            - '%kunstmaan_node.enable_export_page_template%'
+            - '%kunstmaan_node.preview_target_window%'
         public: true
 
     kunstmaan_node.menu.sub_actions:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | none


Currently Kuma opens a new window/tab when the users presses 'preview'. This is because the target is '_blank'. When using a target as 'kuma-preview' (for example) pressing preview refreshes the window/tab with a new request. Less preview windows and easier debugging (dev-tools can stay open for the preview window).