### PR TITLE
[AdminBundle] Fix phpunit test warnings

### DIFF
--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/AclHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/AclHelperTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 class AclHelperTest extends TestCase
@@ -140,7 +141,8 @@ class AclHelperTest extends TestCase
             ->method('getToken')
             ->will($this->returnValue($this->token));
 
-        $this->rh = $this->getMockBuilder('Symfony\Component\Security\Core\Role\RoleHierarchyInterface')
+        $this->rh = $this->getMockBuilder(RoleHierarchy::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->object = new AclHelper($this->em, $this->tokenStorage, $this->rh);

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/AclNativeHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/AclNativeHelperTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 class AclNativeHelperTest extends TestCase
@@ -101,7 +102,8 @@ class AclNativeHelperTest extends TestCase
             ->method('getToken')
             ->will($this->returnValue($this->token));
 
-        $this->rh = $this->getMockBuilder('Symfony\Component\Security\Core\Role\RoleHierarchyInterface')
+        $this->rh = $this->getMockBuilder(RoleHierarchy::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->object = new AclNativeHelper($this->em, $this->tokenStorage, $this->rh);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Symfony deprecated and removed a method on the `RoleHierarchyInterface`. After that change our unittest triggers warning because we can't mock non-existing methods. I think technically this is a bc break from their side, but this will only break in tests. If we move our mock to the actual class everything works correctly and we get the correct deprecation warnings.

See: https://github.com/symfony/symfony/pull/30388
