### PR TITLE
[AllBundles] Deprecate old flash "error" type

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -12,6 +12,7 @@ AdminBundle
 * The composer script class `Kunstmaan\AdminBundle\Composer\ScriptHandler` is deprecated and will be removed in 6.0. 
   If you use this script handler, remove it from your composer.json scripts section.
 * We don't enable the templating component by default anymore. If you use the templating component or the `@templating` service, activate it by enabling the `framework.templating` config in your project.
+* The `\Kunstmaan\AdminBundle\FlashMessages\FlashTypes::ERROR` constant is deprecated and will be removed in 6.0. Use `\Kunstmaan\AdminBundle\FlashMessages\FlashTypes::DANGER` instead.
 
 AdminListBundle
 ---------------

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -83,7 +83,7 @@ class PasswordCheckListener
                 if ($user->isPasswordChanged() === false) {
                     $response = new RedirectResponse($this->router->generate('fos_user_change_password'));
                     $this->session->getFlashBag()->add(
-                        FlashTypes::ERROR,
+                        FlashTypes::DANGER,
                         $this->translator->trans('kuma_admin.password_check.flash.error')
                     );
                     $event->setResponse($response);

--- a/src/Kunstmaan/AdminBundle/FlashMessages/FlashTypes.php
+++ b/src/Kunstmaan/AdminBundle/FlashMessages/FlashTypes.php
@@ -10,6 +10,9 @@ namespace Kunstmaan\AdminBundle\FlashMessages;
 class FlashTypes
 {
     const SUCCESS = 'success';
+    /**
+     * @deprecated The `FlashTypes::ERROR` constant is deprecated in KunstmaanAdminBundle 5.4 and will be removed in KunstmaanAdminBundle 6.0. Use `FlashTypes::DANGER` instead.
+     */
     const ERROR = 'error';
     const WARNING = 'warning';
 

--- a/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
+++ b/src/Kunstmaan/AdminBundle/Security/OAuthAuthenticator.php
@@ -191,7 +191,7 @@ class OAuthAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $this->session->getFlashBag()->add(FlashTypes::ERROR, $this->translator->trans('errors.oauth.invalid'));
+        $this->session->getFlashBag()->add(FlashTypes::DANGER, $this->translator->trans('errors.oauth.invalid'));
 
         return new RedirectResponse($this->router->generate('fos_user_security_login'));
     }

--- a/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
+++ b/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
@@ -175,7 +175,7 @@ class FormSubmissionsController extends Controller
         } catch (\Exception $e) {
             $this->get('logger')->error($e->getMessage());
             $this->addFlash(
-                FlashTypes::ERROR,
+                FlashTypes::DANGER,
                 $this->get('translator')->trans('formsubmissions.delete.flash.error')
             );
         }

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -116,7 +116,7 @@ class FolderController extends Controller
 
         if (\is_null($parentFolder)) {
             $this->addFlash(
-                FlashTypes::ERROR,
+                FlashTypes::DANGER,
                 $this->get('translator')->trans('media.folder.delete.failure.text', array(
                     '%folder%' => $folderName,
                 ))

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -395,7 +395,7 @@ class MediaController extends Controller
 
             if ($isInModal) {
                 $this->addFlash(
-                    FlashTypes::ERROR,
+                    FlashTypes::DANGER,
                     $this->get('translator')->trans(
                         'media.flash.not_created',
                         [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The error flashtype was a leftover of the boostrap v2 integration where an error alert was `alert-error` since v3 it is `alert-danger`. This PR deprecates the error flash type and replaces the usages in our code so that the styling of these alerts shows up correctly.

Example of the first login after an installation:

Before:
![Screenshot 2019-07-05 at 10 07 46](https://user-images.githubusercontent.com/1374857/60708213-ce893300-9f0d-11e9-927b-be783abe950c.png)

After:
![Screenshot 2019-07-05 at 10 07 24](https://user-images.githubusercontent.com/1374857/60708212-ce893300-9f0d-11e9-92ff-14c771dd9f8b.png)


