### PR TITLE
[NodeBundle] Updated SlugType prefix build

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
+++ b/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
@@ -54,7 +54,7 @@ class SlugType extends AbstractType
             $nodeTranslation = $parentNode->getNodeTranslation($nodeTranslation->getLang(), true);
             $slug = $nodeTranslation->getSlugPart();
             if (!empty($slug)) {
-                $slug .= '/';
+                $slug = rtrim($slug, '/') . '/';
             }
             $view->vars['prefix'] = $slug;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    |  no
| Deprecations? | no
| Fixed tickets |

Updated SlugType prefix build to avoid double slashes when using StructurePage.

Using the same method as in https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/5.0/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php#L255

This bug appears on the 'Menu' tab of a page, the prefix to render a preview url (from js) should not contain double slashes. A double slash is possible when the parent page is a structure page (without slug).
