### PR TITLE
[SitemapBundle] Allow to include other items in the sitemap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
         "ruflin/elastica": "^5.1|^6.0",
         "behat/transliterator": "~1.2",
         "defuse/php-encryption": "v2.1.0",
-        "kunstmaan/sensio-generator-bundle": "^3.2"
+        "kunstmaan/sensio-generator-bundle": "^3.2",
+        "doctrine/collections": "^1.6"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.6",

--- a/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
+++ b/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SitemapBundle\Controller;
 
+use Kunstmaan\SitemapBundle\Event\PreSitemapRenderEvent;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -30,9 +31,13 @@ class SitemapController extends Controller
         $nodeMenu->setIncludeHiddenFromNav(true);
         $nodeMenu->setCurrentNode(null);
 
+        $event = new PreSitemapRenderEvent($locale);
+        $this->get('event_dispatcher')->dispatch(PreSitemapRenderEvent::NAME, $event);
+
         return array(
             'nodemenu' => $nodeMenu,
             'locale' => $locale,
+            'extraItems' => $event->getExtraItems(),
         );
     }
 

--- a/src/Kunstmaan/SitemapBundle/Event/PreSitemapRenderEvent.php
+++ b/src/Kunstmaan/SitemapBundle/Event/PreSitemapRenderEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\Event;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Kunstmaan\SitemapBundle\Model\SitemapUrl;
+use Symfony\Component\EventDispatcher\Event;
+
+final class PreSitemapRenderEvent extends Event
+{
+    public const NAME = 'sitemap.pre_render';
+
+    /** @var ArrayCollection */
+    private $extraItems;
+
+    /** @var string */
+    private $locale;
+
+    public function __construct($locale)
+    {
+        $this->extraItems = new ArrayCollection();
+        $this->locale = $locale;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getExtraItems(): Collection
+    {
+        return $this->extraItems;
+    }
+
+    public function addExtraItem(SitemapUrl $extraItem): void
+    {
+        if (!$this->extraItems->contains($extraItem)) {
+            $this->extraItems->add($extraItem);
+        }
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/Model/SitemapUrl.php
+++ b/src/Kunstmaan/SitemapBundle/Model/SitemapUrl.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\Model;
+
+class SitemapUrl
+{
+    /** @var string */
+    private $url;
+
+    /** @var \DateTimeImmutable */
+    private $lastModified;
+
+    /** @var float */
+    private $priority;
+
+    public function __construct(string $url, \DateTimeImmutable $lastModified, float $priority = 0.9)
+    {
+        if ($priority > 1 || $priority < 0) {
+            throw new \InvalidArgumentException(sprintf('A sitemap url priority can\'t be higher than 1 or below 0. Value given "%s"', $priority));
+        }
+
+        $this->url = $url;
+        $this->lastModified = $lastModified;
+        $this->priority = $priority;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getLastModified(): \DateTimeImmutable
+    {
+        return $this->lastModified;
+    }
+
+    public function getPriority(): float
+    {
+        return $this->priority;
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/Resources/views/Sitemap/view.xml.twig
+++ b/src/Kunstmaan/SitemapBundle/Resources/views/Sitemap/view.xml.twig
@@ -14,4 +14,13 @@
             {% endfor %}
         {% endfor %}
     {% endif %}
+    {% if extraItems is defined and extraItems is not empty %}
+        {% for item in extraItems %}
+            <url>
+                <loc>{{ item.url }}</loc>
+                <lastmod>{{ item.lastModified|date('Y-m-d') }}</lastmod>
+                <priority>{{ item.priority }}</priority>
+            </url>
+        {% endfor %}
+    {% endif %}
 </urlset>

--- a/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
+++ b/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for locale in locales %}
-	<sitemap>
-	    <loc>{{ host }}/sitemap-{{ locale }}.xml</loc>
-	</sitemap>
+		<sitemap>
+			<loc>{{ url('KunstmaanSitemapBundle_sitemap', {'locale': locale, '_format': 'xml'}) }}</loc>
+		</sitemap>
     {% endfor %}
-</sitemapindex> 
+</sitemapindex>

--- a/src/Kunstmaan/SitemapBundle/Tests/unit/Model/SitemapUrlTest.php
+++ b/src/Kunstmaan/SitemapBundle/Tests/unit/Model/SitemapUrlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\Tests\unit\Model;
+
+use Kunstmaan\SitemapBundle\Model\SitemapUrl;
+use PHPUnit\Framework\TestCase;
+
+class SitemapUrlTest extends TestCase
+{
+    /**
+     * @dataProvider priorityDataProvider
+     */
+    public function testPriorityValues(float $priority, bool $expectException)
+    {
+        if ($expectException) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage(sprintf('A sitemap url priority can\'t be higher than 1 or below 0. Value given "%s"', $priority));
+        }
+
+        $obj = new SitemapUrl('example-url', new \DateTimeImmutable(), $priority);
+
+        if (!$expectException) {
+            $this->assertInstanceOf(SitemapUrl::class, $obj);
+            $this->assertSame($priority, $obj->getPriority());
+        }
+    }
+
+    public function priorityDataProvider()
+    {
+        return [
+            [0.0, false],
+            [-1.0, true],
+            [1.0, false],
+            [1.2, true],
+        ];
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/composer.json
+++ b/src/Kunstmaan/SitemapBundle/composer.json
@@ -16,7 +16,8 @@
         "php": "^7.1",
         "kunstmaan/admin-bundle": "~5.2",
         "kunstmaan/node-bundle": "~5.2",
-        "kunstmaan/pagepart-bundle": "~5.2"
+        "kunstmaan/pagepart-bundle": "~5.2",
+        "doctrine/collections": "^1.6"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Currently you have to override the controller/view for the sitemap-locale route to add additional items. This PR adds an event so you can write a listener in your application to add additional non-cms urls to the sitemap.

I've also updated the main `sitemap.xml.twig` to use the symfony route to generate the specific locale urls. So don't squash the commits here to keep the history
