### PR TITLE
[GeneratorBundle] Add missing parameter in article adminlist controller

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
@@ -44,7 +44,7 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
      */
     public function addAction(Request $request)
     {
-        return parent::doAddAction($this->getAdminListConfigurator($request), $request);
+        return parent::doAddAction($this->getAdminListConfigurator($request), null, $request);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The second parameter `$type` was missing