### PR TITLE
[AdminListBundle] Fixed undefined entity when creating entity having itemActions

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -175,6 +175,7 @@ abstract class AdminListController extends Controller
             'form' => $form->createView(),
             'adminlistconfigurator' => $configurator,
             'entityVersionLockCheck' => false,
+            'entity' => $helper,
         ];
 
         if ($tabPane) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When an admin list has custom item actions (by defining `getItemActions()` in admin list configurator), you can not add an entity anymore. This is because both add and edit actions use the same template (`Kunstmaan/AdminListBundle/Resources/views/Default/add_or_edit.html.twig`).
However, only the edit action passes the `entity` variable. So when using the add action, it causes an error
