### PR TITLE
[AdminListBundle] Fix missing date and time suffixes on form fields #…

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/FilterType/dateTimeFilter.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/FilterType/dateTimeFilter.html.twig
@@ -15,7 +15,7 @@
             <input
                 type="text"
                 class="form-control form_datepicker{{ nameprefix }}{{ namesuffix }}"
-                name="{{ nameprefix }}value{{ namesuffix }}"
+                name="{{ nameprefix }}value{{ namesuffix }}[date]"
                 data-date-format="DD/MM/YYYY"
                 {% if data.value['date'] is defined %} value="{{ data.value['date'] }}"{% endif %}
                 {% if datePicker_startDate is defined %} data-startDate="{{ datePicker_startDate }}"{% endif %}
@@ -31,7 +31,7 @@
             <input
                 type="text"
                 class="form-control form_datepicker{{ nameprefix }}{{ namesuffix }}"
-                name="{{ nameprefix }}value{{ namesuffix }}"
+                name="{{ nameprefix }}value{{ namesuffix }}[time]"
                 data-date-format="HH:mm"
                 {% if data.value['time'] is defined %} value="{{ data.value['time'] }}"{% endif %}
                 {% if datePicker_startDate is defined %} data-startDate="{{ datePicker_startDate }}"{% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #2513

The date and time values weren't posted correctly because the [date] and [time] fieldname suffixes were missing.