### PR TITLE
[TranslatorBundle] Tag translator to inject correct locale on sf4.3

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/config/services.yml
@@ -98,6 +98,7 @@ services:
         calls:
             - [setTranslationRepository, ['@kunstmaan_translator.repository.translation']]
             - [setResourceCacher, ['@kunstmaan_translator.service.translator.resource_cacher']]
+        tags: ['kernel.locale_aware']
 
     # TODO: needs to be refactored, should not need to be public
     kunstmaan_translator.service.migrations.migrations:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The `TranslatorListener` was deprecated and the service definition was removed in symfony/symfony#28929. Because we do an override of the translator we must tag the service ourself to "restore" the old behaviour.
