### PR TITLE
[AdminListBundle] Deprecate setter injection and usage of symfony templating

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -5,7 +5,14 @@ AdminBundle
 -----------
 
 * The composer script class `Kunstmaan\AdminBundle\Composer\ScriptHandler` is deprecated and will be removed in 6.0. 
-  If you use this script handler, remove it from your composer.json scripts section.  
+  If you use this script handler, remove it from your composer.json scripts section.
+
+AdminListBundle
+---------------
+
+* Not passing the Twig service as the first argument of "Kunstmaan\AdminListBundle\Service\ExportService::__construct" is deprecated and will be required in 6.0. Injected the required services in the constructor instead.
+* Injecting the template renderer with "Kunstmaan\AdminListBundle\Service\ExportService::setRenderer" is deprecated and will be removed in 6.0. Inject Twig with constructor injection instead.
+* Injecting the translator with "Kunstmaan\AdminListBundle\Service\ExportService::setTranslator" is deprecated and will be removed in 6.0. Inject the Translator with constructor injection instead.
 
 ConfigBundle
 ------------

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -8,6 +8,9 @@ services:
 
     kunstmaan_adminlist.service.export:
         class:  '%kunstmaan_adminlist.service.export.class%'
+        arguments:
+            - '@twig'
+            - '@translator'
         calls:
             -  [ setRenderer, [ '@templating' ] ]
             -  [ setTranslator, [ '@translator' ] ]

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/Service/ExportServiceTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/Service/ExportServiceTest.php
@@ -6,6 +6,10 @@ use Box\Spout\Common\Type;
 use Kunstmaan\AdminListBundle\AdminList\ExportableInterface;
 use Kunstmaan\AdminListBundle\Service\ExportService;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Environment;
 
 class ExportServiceTest extends TestCase
 {
@@ -14,13 +18,39 @@ class ExportServiceTest extends TestCase
      */
     protected $object;
 
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     */
     protected function setUp()
     {
-        $this->object = new ExportService();
+        $this->object = new ExportService($this->createMock(Environment::class), new Translator('nl'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not passing the Twig service as the first argument of "Kunstmaan\AdminListBundle\Service\ExportService::__construct" is deprecated since KunstmaanAdminListBundle 5.4 and will be required in KunstmaanAdminListBundle 6.0. Injected the required services in the constructor instead.
+     */
+    public function testWithoutConstructorInjection()
+    {
+        new ExportService();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Not passing the Twig service as the first argument of "Kunstmaan\AdminListBundle\Service\ExportService::__construct" is deprecated since KunstmaanAdminListBundle 5.4 and will be required in KunstmaanAdminListBundle 6.0. Injected the required services in the constructor instead.
+     * @expectedDeprecation Injecting the template renderer with "Kunstmaan\AdminListBundle\Service\ExportService::setRenderer" is deprecated since KunstmaanAdminListBundle 5.4 and will be removed in KunstmaanAdminListBundle 6.0. Inject Twig with constructor injection instead.
+     * @expectedDeprecation Injecting the translator with "Kunstmaan\AdminListBundle\Service\ExportService::setTranslator" is deprecated since KunstmaanAdminListBundle 5.4 and will be removed in KunstmaanAdminListBundle 6.0. Inject the Translator with constructor injection instead.
+     */
+    public function testDeprecatedSetters()
+    {
+        $obj = new ExportService();
+        $obj->setRenderer($this->createMock(EngineInterface::class));
+        $obj->setTranslator($this->createMock(TranslatorInterface::class));
+    }
+
+    public function testConstructorInvalidTranslatorlass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument 2 passed to "Kunstmaan\AdminListBundle\Service\ExportService::__construct" must be of the type "Symfony\Component\Translation\TranslatorInterface" or "Symfony\Contracts\Translation\TranslatorInterface", "stdClass" given');
+
+        new ExportService($this->createMock(Environment::class), new \stdClass());
     }
 
     public function testGetSupportedExtensions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Deprecate the `@templating` injection and replace it by `@twig`. Also deprecate setter injection and move it to the constructor.
