### PR TITLE
[AdminListBundle] Display associations when using viewAction()

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -322,10 +322,10 @@ abstract class AdminListController extends Controller
             throw $this->createAccessDeniedException('You do not have sufficient rights to access this page.');
         }
 
-        $MetaData = $em->getClassMetadata($configurator->getRepositoryName());
-        $fields = array();
+        $metaData = $em->getClassMetadata($configurator->getRepositoryName());
+        $fields = [];
         $accessor = PropertyAccess::createPropertyAccessor();
-        foreach ($MetaData->fieldNames as $value) {
+        foreach ($metaData->getReflectionProperties() as $value => $reflectionProperty) {
             $fields[$value] = $accessor->getValue($helper, $value);
         }
 

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/view.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/view.html.twig
@@ -7,7 +7,7 @@
     {% for key, value in fields %}
         <tr>
             <td>
-                {{ key }}
+                {{ key | trans }}
             </td>
             <td>
                 {{ adminlistconfigurator.getStringValue(entity, key) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

`$MetaData->fieldNames` returns a list of regular property names, it does not return names of association mappings. This causes all associations not to be shown when viewing an entity in the adminlist.
`$metaData->getReflectionProperties()` returns all properties. Also added `key | trans` to be able to translate the names of the properties when viewing the data.

I'd like to add that this change could potentially cause an exception for anyone who has uses view option in an admin list, when their entity has assocations and those entities havent implemented __toString()