### PR TITLE
[NodeBundle] Fix undefined offset error caused by no owner being set for Template

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -109,6 +109,7 @@ class SlugController extends Controller
 
         $template = new Template(array());
         $template->setTemplate($view);
+        $template->setOwner([SlugController::class, 'slugAction']);
 
         $request->attributes->set('_template', $template);
 

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -95,8 +95,12 @@ class RenderContextListener
             //the SensioFrameworkExtraBundle kernel.view will handle everything else
             $event->setControllerResult((array) $parameters);
 
-            $template = new Template(array());
+            $template = new Template([]);
             $template->setTemplate($entity->getDefaultView());
+
+            $controllerBits = explode(':', $request->attributes->get('_controller'));
+            $action = array_pop($controllerBits);
+            $template->setOwner([join(':', $controllerBits), $action]);
 
             $request->attributes->set('_template', $template);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

In the `onKernelView` method of [`Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener`](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/EventListener/TemplateListener.php#L87) there is a `list()` call to pull out the controller and action used by the template.

The owner for the template is normally set automatically within the `onKernelController` event. Because in the node bundle's `SlugController` the Template is being created manually, the owner for the template has not been set as `onKernelController` has already been called. This causes an error `Notice: Undefined offset: 0` when the TemplateListener attempts to pull out the owner.

This PR sets the template owner manually to `[SlugController::class, 'slugAction']` which prevents this error.

Similiarly, in `Kunstmaan\NodeBundle\EventListener\RenderContextListener` the Template is being created manually. Here we are able to pull the current controller and action from the request context and again set the template owner manually.
