### PR TITLE
[TranslatorBundle] implement changeablelimitinterface on translationadminlist

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -5,15 +5,19 @@ namespace Kunstmaan\TranslatorBundle\AdminList;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineDBALAdminListConfigurator;
+use Kunstmaan\AdminListBundle\AdminList\Configurator\ChangeableLimitInterface;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\EnumerationFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\StringFilterType;
+use Kunstmaan\AdminListBundle\Traits\ChangeableLimitTrait;
 use Kunstmaan\TranslatorBundle\Entity\Translation;
 
 /**
  * TranslationAdminListConfigurator
  */
-class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConfigurator
+class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConfigurator implements ChangeableLimitInterface
 {
+    use ChangeableLimitTrait;
+
     /**
      * @var array
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  /

Got some complaints on a project that only 10 translations  at a time were visible in the translationadminlist. Since we already have a changeablelimitinterface in the bundles I decided to implement it for the translations.
