### PR TITLE
[MultiDomainBundle] Use Twig namespace syntax instead of bundle refer…

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/Helper/AdminPanel/SitesAdminPanelAdaptor.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/AdminPanel/SitesAdminPanelAdaptor.php
@@ -26,7 +26,7 @@ class SitesAdminPanelAdaptor implements AdminPanelAdaptorInterface
             ),
             '',
             '',
-            'KunstmaanMultiDomainBundle:AdminPanel:_site_switch_action.html.twig'
+            '@KunstmaanMultiDomain/AdminPanel/_site_switch_action.html.twig'
         );
     }
 }


### PR DESCRIPTION
We've overwritten the view for this bundle using bundle inheritance.
But bundle inheritance is deprecated. When removing the bundle inheritance it is no longer possible for us to override the views for this bundle.

When using the newer twig syntax using namespaces it becomes possible to override the view again by setting the namespace to a different view folder. (By setting `twig.paths` configuration.)

This PR changes the twig paths to the namespace syntax, allowing the view to be overwritten again.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

CC @dannyvw 
