### PR TITLE
[MediaBundle] Fixed imagine ignoring EXIF orientation data

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/config/imagine_filters.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/imagine_filters.yml
@@ -9,14 +9,17 @@ liip_imagine:
         media_list_thumbnail:
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail: { size: [210, 150], mode: outbound }
                 relative_resize: { widen: 210 }
         media_list_thumbnail_retina:
             quality: 85
             filters:
+                auto_rotate: ~
                 thumbnail: { size: [420, 300], mode: outbound }
                 relative_resize: { widen: 420 }
         media_detail_thumbnail:
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail: { size: [700, 500], mode: inset }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When uploading any image with exif rotation/orientation data, imagine ignores these informations, so images are being processed with wrong rotation.

Here's a sample image with orientation exif data: https://github.com/ianare/exif-samples/blob/master/jpg/orientation/portrait_2.jpg
If you upload this image via MediaBundle you'll get a mirrored image with wrong orientation.

Adding `auto_rotate: ~` to liip_imagine configuration fixes this issue.