### PR TITLE
[PagepartBundle] Fixed not being able to search for translated names of PageParts

### DIFF
--- a/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/modal.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/PagePartAdminTwigExtension/modal.html.twig
@@ -1,6 +1,6 @@
 <div class="modal fade pp-chooser js-pp-chooser pp-search" id="pagePartModal{{ pagepartadmin.context }}" tabindex="-1" role="dialog" aria-labelledby="pagePartModalLabel"
      aria-hidden="true"
-     data-pp-types="{{ pagepartadmin.possiblePagePartTypes|json_encode() }}"
+     data-pp-types="{{ pagepartadmin.possiblePagePartTypes|map(pp => {'name': pp.name|trans, 'class': pp.class, 'preview': pp.preview })|json_encode(constant('JSON_UNESCAPED_UNICODE')) }}"
 >
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -20,7 +20,7 @@
             <div class="modal-body clearfix">
                 <div class="row">
                     {% for pagePartType in pagepartadmin.possiblePagePartTypes %}
-                        <div class="pp-search__item js-pp-search-item col-sm-6 col-lg-4" data-pp-name="{{ pagePartType.name }}">
+                        <div class="pp-search__item js-pp-search-item col-sm-6 col-lg-4" data-pp-name="{{ pagePartType.name|trans }}">
                             {% if pagePartType.preview is defined and pagePartType.preview is not empty %}
                                 {% set background = asset(pagePartType.preview) %}
                             {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/Kunstmaan/KunstmaanBundlesCMS/issues/2519

This commit allows to translate PageParts names in "choose PagePart" modal and search by translated names.

![image](https://user-images.githubusercontent.com/32791888/68862319-85cc5c80-06ed-11ea-8428-54cad4f130c0.png)