### PR TITLE
[NodeBundle] Fix url chooser to allow # and #! urls

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\NodeBundle\Form\EventListener;
 
 use Kunstmaan\NodeBundle\Form\Type\URLChooserType;
 use Kunstmaan\NodeBundle\Validation\URLValidator;
+use Kunstmaan\NodeBundle\Validator\Constraint\ValidExternalUrl;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormEvent;
@@ -58,7 +59,7 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
             } // Else, it's an external link
             else {
                 $form->get('link_type')->setData(URLChooserType::EXTERNAL);
-                $constraints[] = new Url();
+                $constraints[] = new ValidExternalUrl();
             }
         } else {
             $choices = $form->get('link_type')->getConfig()->getOption('choices');
@@ -71,7 +72,7 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
                     break;
                 case URLChooserType::EXTERNAL:
                     $attributes['placeholder'] = 'https://';
-                    $constraints[] = new Url();
+                    $constraints[] = new ValidExternalUrl();
 
                     break;
                 case URLChooserType::EMAIL:

--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserLinkTypeSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserLinkTypeSubscriber.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeBundle\Form\EventListener;
 
 use Kunstmaan\NodeBundle\Form\Type\URLChooserType;
+use Kunstmaan\NodeBundle\Validator\Constraint\ValidExternalUrl;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormEvent;
@@ -52,7 +53,7 @@ class URLChooserLinkTypeSubscriber implements EventSubscriberInterface
                     break;
                 case URLChooserType::EXTERNAL:
                     $attributes['placeholder'] = 'https://';
-                    $constraints[] = new Url();
+                    $constraints[] = new ValidExternalUrl();
 
                     break;
                 case URLChooserType::EMAIL:

--- a/src/Kunstmaan/NodeBundle/Tests/unit/Validator/Constraint/ValidExternalUrlValidatorTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/Validator/Constraint/ValidExternalUrlValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Tests\unit\Validator\Constraint;
+
+use Kunstmaan\NodeBundle\Validator\Constraint\ValidExternalUrl;
+use Kunstmaan\NodeBundle\Validator\Constraint\ValidExternalUrlValidator;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class ValidExternalUrlValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new ValidExternalUrlValidator();
+    }
+
+    /**
+     * @dataProvider getValidUrls
+     */
+    public function testValidUrls($url)
+    {
+        $this->validator->validate($url, new ValidExternalUrl());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidUrls
+     */
+    public function testInvalidUrls($url)
+    {
+        $this->validator->validate($url, new ValidExternalUrl());
+
+        $this->buildViolation('This value is not a valid URL.')
+            ->setParameter('{{ value }}', '"'.$url.'"')
+            ->setCode(Url::INVALID_URL_ERROR)
+            ->assertRaised();
+    }
+
+    public function getValidUrls()
+    {
+        return [
+            ['http://www.example.com'],
+            ['https://example.com'],
+            ['#'],
+            ['#anchor-name'],
+            ['#!'],
+        ];
+    }
+
+    public function getInvalidUrls()
+    {
+        return [
+            ['example.com'],
+            ['www.example.com'],
+            ['!#'],
+            ['abc#anchor-name'],
+        ];
+    }
+}

--- a/src/Kunstmaan/NodeBundle/Validator/Constraint/ValidExternalUrl.php
+++ b/src/Kunstmaan/NodeBundle/Validator/Constraint/ValidExternalUrl.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+final class ValidExternalUrl extends Constraint
+{
+}

--- a/src/Kunstmaan/NodeBundle/Validator/Constraint/ValidExternalUrlValidator.php
+++ b/src/Kunstmaan/NodeBundle/Validator/Constraint/ValidExternalUrlValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\Constraints\UrlValidator;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class ValidExternalUrlValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (strpos($value, '#') === 0) {
+            return;
+        }
+
+        $urlValidator = new UrlValidator();
+        $urlValidator->initialize($this->context);
+        $urlValidator->validate($value, new Url());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

#2413 added url validation to the external url from the url chooser, but this broke the ability to link to anchors on the page (#anchor-name, # and #!)
