### PR TITLE
[NodeBundle] Fix incompatibility with framework-extra-bundle 5.5.*

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -109,6 +109,7 @@ class SlugController extends Controller
 
         $template = new Template(array());
         $template->setTemplate($view);
+        $template->setOwner([SlugController::class, 'slugAction']);
 
         $request->attributes->set('_template', $template);
 

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -98,7 +98,33 @@ class RenderContextListener
             $template = new Template(array());
             $template->setTemplate($entity->getDefaultView());
 
+            $controllerInfo = $this->getControllerInfo($request->attributes->get('_controller'));
+            $template->setOwner($controllerInfo);
+
             $request->attributes->set('_template', $template);
         }
+    }
+
+    /**
+     * BC check to return correct controller/action information.
+     *
+     * @param string $controllerString
+     *
+     * @return array
+     */
+    private function getControllerInfo($controllerString)
+    {
+        if (strpos($controllerString, '::') !== false) {
+            $controllerBits = explode('::', $controllerString);
+            $action = array_pop($controllerBits);
+
+            return [$controllerBits, $action];
+        }
+
+        // NEXT_MAJOR: Remove BC check when we drop sf 3.4 support
+        $controllerBits = explode(':', $controllerString);
+        $action = array_pop($controllerBits);
+
+        return [implode(':', $controllerBits), $action];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed incompatibility with `sensio/framework-extra-bundle ^5.5`. Follow up of #2572 