### PR TITLE
[AdminListBundle] Don't call deprecated setters in ExportService

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -6,6 +6,7 @@ AdminBundle
 
 * The composer script class `Kunstmaan\AdminBundle\Composer\ScriptHandler` is deprecated and will be removed in 6.0. 
   If you use this script handler, remove it from your composer.json scripts section.
+* We don't enable the templating component by default anymore. If you use the templating component or the `@templating` service, activate it by enabling the `framework.templating` config in your project.
 
 AdminListBundle
 ---------------

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -124,9 +124,7 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $twigConfig['paths'][] = ['value' => dirname(__DIR__).'/Resources/views', 'namespace' => 'FOSUser'];
         $container->prependExtensionConfig('twig', $twigConfig);
 
-        // NEXT_MAJOR: Remove templating config (toghether with templating dependency)
-        $frameworkConfig['templating']['engines'] = ['twig'];
-        $container->prependExtensionConfig('framework', $frameworkConfig);
+        // NEXT_MAJOR: Remove templating dependency
 
         $configs = $container->getExtensionConfig($this->getAlias());
         $this->processConfiguration(new Configuration(), $configs);

--- a/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminListBundle/Resources/config/services.yml
@@ -11,9 +11,6 @@ services:
         arguments:
             - '@twig'
             - '@translator'
-        calls:
-            -  [ setRenderer, [ '@templating' ] ]
-            -  [ setTranslator, [ '@translator' ] ]
         public: true
 
     kunstmaan_adminlist.twig.extension:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Follow up of #2556