### PR TITLE
[NodeBundle] added translations for  URL-chooser  and  Choose

### DIFF
--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.de.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Seitenvorlage exportieren
+  widget:
+      choose: Auswählen
+      url_chooser: URL-Auswahl

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.en.yml
@@ -177,3 +177,6 @@ kuma_node:
         export_pagetemplate:
             button:
                 title:   Export pagetemplate
+    widget:
+        choose: Choose
+        url_chooser: URL-chooser

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.es.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Export pagetemplate
+  widget:
+    choose: Choose
+    url_chooser: URL-chooser

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.fr.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Export pagetemplate
+  widget:
+    choose: Choisir
+    url_chooser: sélecteur d'URL

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.hu.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: A pagetemplate exportálása
+  widget:
+    choose: Válassz
+    url_chooser: URL választó

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.it.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Export pagetemplate
+  widget:
+    choose: Scegli
+    url_chooser: URL-chooser

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.nl.yml
@@ -172,3 +172,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Exporteer pagina template
+  widget:
+    choose: Kies
+    url_chooser: URL-keuze

--- a/src/Kunstmaan/NodeBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/translations/messages.pl.yml
@@ -169,3 +169,6 @@ kuma_node:
     export_pagetemplate:
       button:
         title: Eksportuj szablon strony
+  widget:
+    choose: Wybierz
+    url_chooser: Wybierz URL

--- a/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
@@ -14,7 +14,7 @@
                                 <i class="fa fa-times"></i>
                             </button>
                             <h3 class="modal-title">
-                                URL-Chooser
+                                {{ 'kuma_node.widget.url_chooser' | trans }}
                             </h3>
                         </div>
 
@@ -58,7 +58,7 @@
                             <input type="text" disabled="disabled" class="form-control js-urlchooser-value" value="{{ linkUrl.value ? linkUrl.value|replace_url : '' }}">
                             <span class="input-group-btn">
                         <button type="button" class="btn btn-default btn--raise-on-hover" data-toggle="modal" data-target="#{{ linkUrl.id }}-urlChooserModal" data-link="{{ path('KunstmaanNodeBundle_selecturl') }}">
-                            Choose
+                            {{ 'kuma_node.widget.choose' | trans }}
                         </button>
                     </span>
                         {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

"URL-chooser" and "Choose" are now translatable in urlchooser_widget of NodeBundle. 