### PR TITLE
[AllBundles] Commands should return an integer exitcode

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
@@ -82,10 +82,12 @@ class ApplyAclCommand extends ContainerAwareCommand
 
         // Check if another ACL apply process is currently running & do nothing if it is
         if ($this->isRunning()) {
-            return;
+            return 0;
         }
 
         $this->aclManager->applyAclChangesets();
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/AdminBundle/Command/CreateGroupCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateGroupCommand.php
@@ -106,5 +106,7 @@ EOT
         $this->em->flush();
 
         $output->writeln(sprintf('Created group <comment>%s</comment>', $groupName));
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Command/CreateRoleCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateRoleCommand.php
@@ -89,5 +89,7 @@ EOT
         $this->em->flush();
 
         $output->writeln(sprintf('Created role <comment>%s</comment>', $roleName));
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/CreateUserCommand.php
@@ -165,9 +165,7 @@ EOT
                 $groupOutput[] = $group->getName();
                 $user->getGroups()->add($group);
             } else {
-                throw new \RuntimeException(
-                    'The selected group(s) can\'t be found.'
-                );
+                throw new \RuntimeException('The selected group(s) can\'t be found.');
             }
         }
 
@@ -180,6 +178,8 @@ EOT
         $this->em->flush();
 
         $output->writeln(sprintf('Added user <comment>%s</comment> to groups <comment>%s</comment>', $input->getArgument('username'), implode(',', $groupOutput)));
+
+        return 0;
     }
 
     /**
@@ -274,9 +274,7 @@ EOT
                 }
 
                 if ($groupsInput === '') {
-                    throw new \RuntimeException(
-                        'Group(s) must be of type integer and can not be empty'
-                    );
+                    throw new \RuntimeException('Group(s) must be of type integer and can not be empty');
                 }
 
                 return $groupsInput;

--- a/src/Kunstmaan/AdminBundle/Command/ExceptionCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ExceptionCommand.php
@@ -82,5 +82,7 @@ class ExceptionCommand extends ContainerAwareCommand
         }
 
         $output->writeln(sprintf('Removed exceptions <comment>%s</comment>', $cp));
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/AdminBundle/Command/UpdateAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/UpdateAclCommand.php
@@ -101,5 +101,7 @@ class UpdateAclCommand extends ContainerAwareCommand
         $this->aclManager->updateNodesAclToRole($nodes, $role, $mask);
 
         $output->writeln(count($nodes) . ' nodes processed.');
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Command/DashboardCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/DashboardCommand.php
@@ -58,5 +58,7 @@ class DashboardCommand extends ContainerAwareCommand
             /* @var DashboardWidget $widget */
             $widget->getCommand()->execute($input, $output);
         }
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigFlushCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigFlushCommand.php
@@ -79,8 +79,12 @@ class GoogleAnalyticsConfigFlushCommand extends ContainerAwareCommand
             }
             $this->em->flush();
             $output->writeln('<fg=green>Config flushed</fg=green>');
+
+            return 0;
         } catch (\Exception $e) {
             $output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
+
+            return 1;
         }
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigsListCommand.php
@@ -69,6 +69,8 @@ class GoogleAnalyticsConfigsListCommand extends ContainerAwareCommand
         } else {
             $output->writeln('No configs found');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataCollectCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataCollectCommand.php
@@ -106,7 +106,7 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
         if (!$configHelper->tokenIsSet()) {
             $this->output->writeln('You haven\'t configured a Google account yet');
 
-            return;
+            return 0;
         }
 
         // get params
@@ -140,8 +140,12 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
             $result = '<fg=green>Google Analytics data updated with <fg=red>'.$this->errors.'</fg=red> error';
             $result .= $this->errors != 1 ? 's</fg=green>' : '</fg=green>';
             $this->output->writeln($result); // done
+
+            return 0;
         } catch (\Exception $e) {
             $this->output->writeln($e->getMessage());
+
+            return 1;
         }
     }
 

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataFlushCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataFlushCommand.php
@@ -66,8 +66,12 @@ class GoogleAnalyticsDataFlushCommand extends ContainerAwareCommand
         try {
             $configRepository->flushConfig($configId);
             $output->writeln('<fg=green>Data flushed</fg=green>');
+
+            return 0;
         } catch (\Exception $e) {
             $output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
+
+            return 1;
         }
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsGenerateCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsGenerateCommand.php
@@ -89,8 +89,12 @@ class GoogleAnalyticsOverviewsGenerateCommand extends ContainerAwareCommand
             }
 
             $output->writeln('<fg=green>Overviews succesfully generated</fg=green>');
+
+            return 0;
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<fg=red>' . $e->getMessage() . '</fg=red>');
+
+            return 1;
         }
     }
 

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsListCommand.php
@@ -99,8 +99,12 @@ class GoogleAnalyticsOverviewsListCommand extends ContainerAwareCommand
             } else {
                 $output->writeln('No overviews found');
             }
+
+            return 0;
         } catch (\Exception $e) {
             $output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
+
+            return 1;
         }
     }
 

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsSegmentsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsSegmentsListCommand.php
@@ -84,8 +84,12 @@ class GoogleAnalyticsSegmentsListCommand extends ContainerAwareCommand
             } else {
                 $output->writeln('No segments found');
             }
+
+            return 0;
         } catch (\Exception $e) {
             $output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
+
+            return 1;
         }
     }
 

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminListCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminListCommand.php
@@ -99,6 +99,8 @@ EOT
         $entityClass = array_pop($parts);
 
         $this->updateRouting($questionHelper, $input, $output, $bundle, $entityClass);
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
@@ -62,6 +62,8 @@ EOT
 
         $generator = $this->getGenerator($this->getApplication()->getKernel()->getBundle('KunstmaanGeneratorBundle'));
         $generator->generate($bundle, $output);
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
@@ -220,6 +220,8 @@ EOT
             '    Directly update your database:          <comment>bin/console doctrine:schema:update --force</comment>',
             '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
         ));
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
@@ -114,6 +114,8 @@ EOT
         $runner($this->updateRouting($questionHelper, $input, $output, $bundle, $format));
 
         $questionHelper->writeGeneratorSummary($output, $errors);
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateConfigCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateConfigCommand.php
@@ -92,6 +92,8 @@ class GenerateConfigCommand extends KunstmaanGenerateCommand
         );
 
         $this->assistant->writeSection('Config successfully created', 'bg=green;fg=black');
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
@@ -90,6 +90,8 @@ EOT
                 '    Directly update your database:          <comment>bin/console doctrine:schema:update --force</comment>',
                 '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>', )
         );
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -138,6 +138,8 @@ EOT
         }
 
         $this->assistant->writeSection('Site successfully created', 'bg=green;fg=black');
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateEntityCommand.php
@@ -99,6 +99,8 @@ EOT
             '    Directly update your database:          <comment>bin/console doctrine:schema:update --force</comment>',
             '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && app/console doctrine:migrations:migrate</comment>',
         ));
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPageCommand.php
@@ -123,6 +123,8 @@ EOT
             '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
             '',
         ));
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
@@ -76,6 +76,8 @@ EOT
                 '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
             ]
         );
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateLayoutCommand.php
@@ -67,6 +67,8 @@ EOT
         if (!$this->isSubCommand()) {
             $this->assistant->writeSection('Layout successfully created', 'bg=green;fg=black');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePageCommand.php
@@ -98,6 +98,8 @@ EOT
             '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
             '',
         ));
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GeneratePagePartCommand.php
@@ -80,6 +80,8 @@ EOT
             '    Create a Doctrine migration and run it: <comment>bin/console doctrine:migrations:diff && bin/console doctrine:migrations:migrate</comment>',
             ($this->behatTest ? 'A new behat test is created, to run it: <comment>bin/behat --tags \'@'.$this->pagepartName.'\' @'.$this->bundle->getName().'</comment>' : ''),
         ));
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
@@ -91,6 +91,8 @@ EOT
         }
 
         $output->writeln('');
+
+        return 0;
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)

--- a/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
@@ -167,6 +167,8 @@ final class InstallCommand extends GeneratorCommand
 
         $this->assistant->writeSection('Installation done. Enjoy your KunstmaanCMS', 'bg=green;fg=black');
         $this->assistant->writeSection('PRO TIP: If you like to use the default frontend setup, run the buildUI.sh script or run the commands separate to compile the frontend assets. ', 'bg=blue;fg=white');
+
+        return 0;
     }
 
     protected function executeCommand(OutputInterface $output, $command, array $options = [])

--- a/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
@@ -77,7 +77,7 @@ class CleanDeletedMediaCommand extends ContainerAwareCommand
             $question = new ConfirmationQuestion('<question>Are you sure you want to remove all deleted Media from the file system?</question> ', false);
 
             if (!$helper->ask($input, $output, $question)) {
-                return;
+                return 0;
             }
         }
 
@@ -93,10 +93,14 @@ class CleanDeletedMediaCommand extends ContainerAwareCommand
             $this->em->flush();
             $this->em->commit();
             $output->writeln('<info>All Media flagged as deleted, have now been removed from the file system.<info>');
+
+            return 0;
         } catch (\Exception $e) {
             $this->em->rollback();
             $output->writeln('An error occured while trying to delete Media from the file system:');
             $output->writeln('<error>'. $e->getMessage() . '</error>');
+
+            return 1;
         }
     }
 }

--- a/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
@@ -98,6 +98,8 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>PDF preview images have been created.</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Command/RebuildFolderTreeCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RebuildFolderTreeCommand.php
@@ -60,5 +60,7 @@ class RebuildFolderTreeCommand extends ContainerAwareCommand
 
         $this->em->getRepository('KunstmaanMediaBundle:Folder')->rebuildTree();
         $output->writeln('Updated all folders');
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -111,5 +111,7 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>' . $updates . ' soft-deleted media files have been renamed.</info>');
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
+++ b/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
@@ -112,5 +112,7 @@ class CronUpdateNodeCommand extends ContainerAwareCommand
         } else {
             $output->writeln('No queued jobs');
         }
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/NodeBundle/Command/InitAclCommand.php
+++ b/src/Kunstmaan/NodeBundle/Command/InitAclCommand.php
@@ -109,5 +109,7 @@ class InitAclCommand extends ContainerAwareCommand
             $this->aclProvider->updateAcl($acl);
         }
         $output->writeln("{$count} nodes processed.");
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/SearchBundle/Command/DeleteIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/DeleteIndexCommand.php
@@ -64,5 +64,7 @@ class DeleteIndexCommand extends ContainerAwareCommand
             $searchConfiguration->deleteIndex();
             $output->writeln('Index deleted : ' . $alias);
         }
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/SearchBundle/Command/PopulateIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/PopulateIndexCommand.php
@@ -79,5 +79,7 @@ class PopulateIndexCommand extends ContainerAwareCommand
             $searchConfiguration->populateIndex();
             $output->writeln('Index populated : ' . $alias);
         }
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
+++ b/src/Kunstmaan/SearchBundle/Command/SetupIndexCommand.php
@@ -79,5 +79,7 @@ class SetupIndexCommand extends ContainerAwareCommand
             $searchConfiguration->createIndex();
             $output->writeln('Index created : ' . $alias);
         }
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
@@ -71,5 +71,7 @@ class ExportTranslationsCommand extends ContainerAwareCommand
             ->setLocales($locales === null ? false : $locales);
 
         $this->exportCommandHandler->executeExportCommand($exportCommand);
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
@@ -119,5 +119,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         $imported = $this->importCommandHandler->executeImportCommand($importCommand);
 
         $output->writeln(sprintf('Translation imported: %d', $imported));
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
@@ -71,5 +71,7 @@ final class ImportTranslationsFromFileCommand extends Command
             $confirmation = $this->translator->trans('kuma_translator.command.import.flash.success');
         }
         $output->writeln($confirmation);
+
+        return 0;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/MigrationsDiffCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/MigrationsDiffCommand.php
@@ -35,6 +35,8 @@ class MigrationsDiffCommand extends DiffCommand
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
 
-        parent::execute($input, $output);
+        $exitCode = parent::execute($input, $output);
+
+        return is_numeric($exitCode) ? (int) $exitCode : 0;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
@@ -56,6 +56,8 @@ class TranslationFlagCommand extends ContainerAwareCommand
             $this->resetAllTranslationFlags();
             $output->writeln('<info>All translation and translation domain flags are reset.</info>');
         }
+
+        return 0;
     }
 
     /**

--- a/src/Kunstmaan/TranslatorBundle/Service/Command/DiffCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Command/DiffCommand.php
@@ -30,13 +30,15 @@ class DiffCommand extends GenerateCommand
         if (!$up && !$down) {
             $output->writeln('No changes detected in your mapping information.', 'ERROR');
 
-            return;
+            return 0;
         }
 
         $version = date('YmdHis');
         $path = $this->generateMigration($configuration, $input, $version, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
+
+        return 0;
     }
 
     private function buildCodeFromSql(Configuration $configuration, array $sql)

--- a/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
+++ b/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
@@ -135,5 +135,7 @@ class CipherCommand extends ContainerAwareCommand
 
                 break;
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Since symfony 4.4 all commands should return an integer exit code, not returning it will throw exceptions in symfony 5.
