### PR TITLE
[TranslatorBundle] use the common export logic instead of a custom export

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineDBALAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\ChangeableLimitInterface;
+use Kunstmaan\AdminListBundle\AdminList\Field;
+use Kunstmaan\AdminListBundle\AdminList\FieldAlias;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\EnumerationFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\DBAL\StringFilterType;
 use Kunstmaan\AdminListBundle\Traits\ChangeableLimitTrait;
@@ -27,6 +29,11 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
      * @var string
      */
     protected $locale;
+
+    /**
+     * @var Field[]
+     */
+    private $exportFields = [];
 
     /**
      * @param Connection $connection
@@ -64,6 +71,31 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
         $this->addField('status', 'kuma_translator.adminlist.header.status', true);
     }
 
+    public function getExportFields()
+    {
+        if (empty($this->exportFields)) {
+            $this->addExportField('domain', 'kuma_translator.adminlist.header.domain');
+            $this->addExportField('keyword', 'kuma_translator.adminlist.header.keyword');
+
+            $this->locales = array_unique($this->locales);
+            // Field building hack...
+            foreach ($this->locales as $locale) {
+                $this->addExportField($locale, strtoupper($locale));
+            }
+
+            $this->addExportField('status', 'kuma_translator.adminlist.header.status');
+        }
+
+        return $this->exportFields;
+    }
+
+    public function addExportField($name, $header, $template = null, FieldAlias $alias = null)
+    {
+        $this->exportFields[] = new Field($name, $header);
+
+        return $this;
+    }
+
     /**
      * @return bool
      */
@@ -88,6 +120,14 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
      * @return bool
      */
     public function canEditInline($item)
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canExport()
     {
         return true;
     }

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorCommandController.php
@@ -71,9 +71,12 @@ class TranslatorCommandController extends Controller
 
     /**
      * @Route("/export", name="KunstmaanTranslatorBundle_command_export")
+     * @deprecated Using the "KunstmaanTranslatorBundle_command_export" route is deprecated since KunstmaanTranslatorBundle 5.4 and will be removed in KunstmaanTranslatorBundle 6.0. Use the default adminlist bundle export functionality instead.
      */
     public function exportAction()
     {
+        // NEXT_MAJOR this route will be removed because we are now using the common export logic
+        @trigger_error('Using the "KunstmaanTranslatorBundle_command_export" route is deprecated since KunstmaanTranslatorBundle 5.4 and will be removed in KunstmaanTranslatorBundle 6.0. Use the default adminlist bundle export functionality instead.', E_USER_DEPRECATED);
         $locales = $this->getParameter('kuma_translator.managed_locales');
         $exportCommand = new ExportCommand();
         $exportCommand

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -228,6 +228,20 @@ class TranslatorController extends AdminListController
     }
 
     /**
+     * The export action
+     *
+     * @param string $_format
+     *
+     * @Route("/export.{_format}", requirements={"_format" = "csv|ods|xlsx"}, name="KunstmaanTranslatorBundle_settings_translations_export", methods={"GET", "POST"})
+     *
+     * @return array
+     */
+    public function exportAction(Request $request, $_format)
+    {
+        return parent::doExportAction($this->getAdminListConfigurator(), $_format, $request);
+    }
+
+    /**
      * @param $domain
      * @param $locale
      * @param $keyword

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.de.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importieren
     import_file: Aus Tabelle importieren
     actions: Aktionen
-    export_translations: Export nach csv
+    export_translations: Export nach
     not_live_warning: "Die Übersetzungen der Liveseite sind nicht aktuell. Bitte 'Liveseite Aktualisieren' klicken."
     choose_language: "Sprache Auswählen"
     succesful_added: "Übersetzung wurde erfolgreich angelegt"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.en.yml
@@ -17,7 +17,7 @@ settings:
         import_translations: Import
         import_file: Import from spreadsheet
         actions: Actions
-        export_translations: Export to CSV
+        export_translations: Export to
         not_live_warning: "Translations on the live website are not up-to-date, hit 'Refresh live' to update to the latest translations."
         choose_language: "Choose a language"
         succesful_added: "Translation succesfully created"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.es.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importar
     import_file: Import from spreadsheet
     actions: Actions
-    export_translations: Export to CSV
+    export_translations: Export to
     not_live_warning: "Las traducciones en el sitio en vivo no están actualizadas, haga click en 'Actualizar en vivo' para actulizar a las últimas traducciones."
     choose_language: "Elegir lenguage"
     succesful_added: "Traducción creada correctamente"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.fr.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importer des traductions
     import_file: Import from spreadsheet
     actions: Actions
-    export_translations: Exporter vers csv
+    export_translations: Exporter vers
     not_live_warning: "Les traductions sur le site live ne sont pas à jour, appuyer sur 'Rafraîchir live' pour mettre à jour."
     choose_language: "Choisir une langue"
     succesful_added: "Traduction ajoutée avec succès"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.hu.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importálás
     import_file: Importálás táblázatból
     actions: Műveletek
-    export_translations: Exportálás CSV fáljba
+    export_translations: Exportálás
     not_live_warning: "A fordítás nem azonnali idejű!"
     choose_language: "Válassz egy nyelvet"
     succesful_added: "Sikeresen hozzá lett adva."

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.it.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importa
     import_file: Import from spreadsheet
     actions: Actions
-    export_translations: Export to CSV
+    export_translations: Export to
     not_live_warning: "Le traduzioni sul sito non sono aggiornate, clicca 'Aggiorna' per avere l'ultima traduzione."
     choose_language: "Seleziona una lingua"
     succesful_added: "Traduzione creata con successo"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.nl.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importeer
     import_file: Import from spreadsheet
     actions: Acties
-    export_translations: Exporteer naar CSV
+    export_translations: Exporteer naar
     not_live_warning: "De live vertalingen zijn niet up-to-date. Klik op 'Live herladen' om deze te updaten."
     choose_language: "Kies een taal"
     succesful_added: "Vertaling met succes gemaakt"

--- a/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/TranslatorBundle/Resources/translations/messages.pl.yml
@@ -17,7 +17,7 @@ settings:
     import_translations: Importuj
     import_file: Import from spreadsheet
     actions: Akcje
-    export_translations: Eksportuj do CSV
+    export_translations: Eksportuj do
     not_live_warning: "Tłumaczenia aktywnej strony nie zostały zaktualizowane, wybierz „odśwież” aby wgrać ostatnie zmiany tłumaczeń."
     choose_language: "Wybierz język"
     succesful_added: "Tłumaczenie zostało pomyślnie utworzone"

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/inline_edit.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/inline_edit.html.twig
@@ -1,6 +1,8 @@
-{% if adminlist.configurator.canEditInline(row) %}
+{% apply spaceless %}
+{% if adminlist is defined and adminlist.configurator.canEditInline(row) %}
     {% set uid = attribute(row, columnName ~ '_id') %}
     <a href="#" class="js-editable editable editable-pre-wrapped" data-type="textarea" data-url="{{ path('KunstmaanTranslatorBundle_settings_translations_inline_edit') }}" data-title="{{ 'translator.translator.inline_edit_title'|trans }}" data-uid="{{ uid }}" data-tid="{{ row.id }}" data-locale="{{ columnName }}" data-domain="{{ row.domain }}" data-keyword="{{ row.keyword }}" data-empty-text="{{ 'translator.translator.emptytext'|trans }}">{{ object }}</a>
 {% else %}
     {{ object }}
 {% endif %}
+{% endapply %}

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
@@ -59,11 +59,24 @@
                                                 {{ 'settings.translator.import_file' | trans }}
                                             </a>
                                         </li>
-                                        <li>
-                                            <a href="{{ path('KunstmaanTranslatorBundle_command_export') }}">
-                                                {{ 'settings.translator.export_translations' | trans }}
-                                            </a>
-                                        </li>
+                                        {% if adminlist.canExport() %}
+                                            {% set exportparams = adminlist.filterbuilder.currentparameters|merge(adminlist.getExportUrl()[("params")]) %}
+                                            {% for name, ext in supported_export_extensions() %}
+                                                {% set exportparams = exportparams|merge({"_format": ext}) %}
+                                                {% if (name | lower == 'csv') %}
+                                                    {% set icon = 'fa-file-code' %}
+                                                {% elseif (name | lower == 'excel') %}
+                                                    {% set icon = 'fa-file-excel' %}
+                                                {% else %}
+                                                    {% set icon = 'fa-file' %}
+                                                {% endif %}
+                                                <li>
+                                                    <a href="{{ path(adminlist.getExportUrl()["path"], exportparams) }}">
+                                                        <i class="fa {{ icon }} btn__icon"></i> {{ 'settings.translator.export_translations'|trans }} {{ name }}
+                                                    </a>
+                                                </li>
+                                            {% endfor %}
+                                        {% endif %}
                                     </ul>
                                 </div>
                             {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

[TranslatorBundle] use the common export logic instead of a custom export but only from the settings view and not from commandline. 