### PR TITLE
[NodeBundle] Fixed default page icon

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -235,7 +235,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
                         'page' => [
                             'class' => $refName,
                             'children' => $this->pagesConfiguration->getPossibleChildTypes($refName),
-                            'icon' => $this->pagesConfiguration->getIcon($refName) ?? $this->pagesConfiguration->isHomePage($refName) ? 'fa fa-home' : null,
+                            'icon' => $this->pagesConfiguration->getIcon($refName) ?? ($this->pagesConfiguration->isHomePage($refName) ? 'fa fa-home' : null),
                         ],
                     ]
                 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

Fixed issue where all page icons would fall back to 'fa fa-home' in sidebar of node module. 
