### PR TITLE
[RedirectBundle] Replace deprecated RedirectableUrlMatcher

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -5,8 +5,8 @@ namespace Kunstmaan\RedirectBundle\Router;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\RedirectBundle\Entity\Redirect;
-use Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -87,7 +87,7 @@ class RedirectRouter implements RouterInterface
      */
     public function match($pathinfo)
     {
-        $urlMatcher = new RedirectableUrlMatcher($this->getRouteCollection(), $this->getContext());
+        $urlMatcher = new UrlMatcher($this->getRouteCollection(), $this->getContext());
 
         return $urlMatcher->match($pathinfo);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The `RedirectableUrlMatcher` is deprecated, but we specify the `_controller` ourself on redirects so no need for a redirectable matcher.
