### PR TITLE
[GeneratorBundle] Update DefaultSiteGenerator to support symfony 4

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -456,6 +456,7 @@ class DefaultSiteGenerator extends KunstmaanGenerator
         if ($this->isSymfony4()) {
             return file_get_contents($this->rootDir . 'config/routes.yaml');
         }
+
         return file_get_contents($this->rootDir . '/app/config/routing.yml');
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -446,10 +446,16 @@ class DefaultSiteGenerator extends KunstmaanGenerator
             return $this->container->getParameter('kunstmaan_admin.multi_language');
         }
 
+        return preg_match('/_locale:/i', $this->getRoutingFile());
+    }
+
+    private function getRoutingFile()
+    {
         // This is a pretty silly implementation.
         // It just checks if it can find _locale in the routing.yml
-        $routingFile = file_get_contents($this->rootDir.'/app/config/routing.yml');
-
-        return preg_match('/_locale:/i', $routingFile);
+        if ($this->isSymfony4()) {
+            return file_get_contents($this->rootDir . 'config/routes.yaml');
+        }
+        return file_get_contents($this->rootDir . '/app/config/routing.yml');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets |

Added check for the new routes.yaml file in symfony 4. If not symfony 4, it will return regular symfony 3 path