### PR TITLE
[AllBundles] Switch code coverage to latest php + codecoverage speed up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-      env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-clover=coverage.clover"
     - php: 7.4
+      env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-clover=coverage.clover"
 
 before_install:
   - yes | pecl install imagick


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Switch the code coverage run to the latest php. This also include a speed improvement because travis now comes with xdebug 2.9 which the improves code coverage by 50% for us. ([Even more for others](https://xdebug.org/announcements/2019-12-09))
