### PR TITLE
[AllBundles] Fixed remaining template path using the old notation

### DIFF
--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -179,7 +179,7 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
      */
     public function getListTemplate()
     {
-        return 'KunstmaanArticleBundle:AbstractArticlePageAdminList:list.html.twig';
+        return '@KunstmaanArticle/AbstractArticlePageAdminList/list.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/ArticleBundle/Entity/AbstractArticleOverviewPage.php
+++ b/src/Kunstmaan/ArticleBundle/Entity/AbstractArticleOverviewPage.php
@@ -43,7 +43,7 @@ abstract class AbstractArticleOverviewPage extends AbstractPage implements HasPa
      */
     public function getDefaultView()
     {
-        return 'KunstmaanArticleBundle:AbstractArticleOverviewPage:view.html.twig';
+        return '@KunstmaanArticle/AbstractArticleOverviewPage/view.html.twig';
     }
 
     public function getControllerAction()

--- a/src/Kunstmaan/ArticleBundle/Tests/unit/AdminList/AbstractArticlePageAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/unit/AdminList/AbstractArticlePageAdminListConfiguratorTest.php
@@ -78,7 +78,7 @@ class AbstractArticlePageAdminListConfiguratorTest extends TestCase
     {
         $this->assertEquals('KunstmaanArticleBundle', $this->object->getBundleName());
         $this->assertEquals('AbstractArticlePage', $this->object->getEntityName());
-        $this->assertEquals('KunstmaanArticleBundle:AbstractArticlePageAdminList:list.html.twig', $this->object->getListTemplate());
+        $this->assertEquals('@KunstmaanArticle/AbstractArticlePageAdminList/list.html.twig', $this->object->getListTemplate());
         $this->assertEquals('KunstmaanArticleBundle:AbstractArticlePage', $this->object->getRepositoryName());
     }
 

--- a/src/Kunstmaan/ArticleBundle/Tests/unit/Entity/AbstractArticleOverviewPageTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/unit/Entity/AbstractArticleOverviewPageTest.php
@@ -22,7 +22,7 @@ class AbstractArticleOverviewPageTest extends TestCase
     {
         $entity = new ArticleOverViewPage();
         $this->assertEquals('KunstmaanArticleBundle:AbstractArticleOverviewPage:service', $entity->getControllerAction());
-        $this->assertEquals('KunstmaanArticleBundle:AbstractArticleOverviewPage:view.html.twig', $entity->getDefaultView());
+        $this->assertEquals('@KunstmaanArticle/AbstractArticleOverviewPage/view.html.twig', $entity->getDefaultView());
         $this->assertInternalType('array', $entity->getPossibleChildTypes());
         $this->assertInternalType('array', $entity->getPagePartAdminConfigurations());
     }

--- a/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/DashboardController.php
@@ -27,6 +27,6 @@ class DashboardController extends Controller
         $widgets = $widgetManager->getWidgets();
         $segmentId = $request->query->get('segment');
 
-        return $this->render('KunstmaanDashboardBundle:Dashboard:index.html.twig', array('widgets' => $widgets, 'id' => $segmentId));
+        return $this->render('@KunstmaanDashboard/Dashboard/index.html.twig', array('widgets' => $widgets, 'id' => $segmentId));
     }
 }

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
@@ -33,7 +33,7 @@ class GoogleAnalyticsController extends Controller
                 $params['authUrl'] = $configHelper->getAuthUrl();
             }
 
-            return $this->render('KunstmaanDashboardBundle:GoogleAnalytics:connect.html.twig', $params);
+            return $this->render('@KunstmaanDashboard/GoogleAnalytics/connect.html.twig', $params);
         }
 
         // if propertyId not set
@@ -153,7 +153,7 @@ class GoogleAnalyticsController extends Controller
         $params['profileSegments'] = $configHelper->getProfileSegments();
 
         return $this->render(
-            'KunstmaanDashboardBundle:GoogleAnalytics:setupcontainer.html.twig',
+            '@KunstmaanDashboard/GoogleAnalytics/setupcontainer.html.twig',
             $params
         );
     }

--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/FileFormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/FileFormSubmissionField.php
@@ -219,7 +219,7 @@ class FileFormSubmissionField extends FormSubmissionField
      */
     public function getSubmissionTemplate()
     {
-        return 'KunstmaanFormBundle:FileUploadPagePart:submission.html.twig';
+        return '@KunstmaanForm/FileUploadPagePart/submission.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/AbstractFormPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/AbstractFormPagePart.php
@@ -62,6 +62,6 @@ abstract class AbstractFormPagePart extends AbstractPagePart implements FormAdap
      */
     public function getAdminView()
     {
-        return 'KunstmaanFormBundle:AbstractFormPagePart:admin-view.html.twig';
+        return '@KunstmaanForm/AbstractFormPagePart/admin-view.html.twig';
     }
 }

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
@@ -87,7 +87,7 @@ class CheckboxPagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:CheckboxPagePart:view.html.twig';
+        return '@KunstmaanForm/CheckboxPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
@@ -73,7 +73,7 @@ class ChoicePagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:ChoicePagePart:view.html.twig';
+        return '@KunstmaanForm/ChoicePagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
@@ -119,7 +119,7 @@ class EmailPagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:EmailPagePart:view.html.twig';
+        return '@KunstmaanForm/EmailPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
@@ -128,7 +128,7 @@ class FileUploadPagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:FileUploadPagePart:view.html.twig';
+        return '@KunstmaanForm/FileUploadPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
@@ -102,7 +102,7 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:MultiLineTextPagePart:view.html.twig';
+        return '@KunstmaanForm/MultiLineTextPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
@@ -150,7 +150,7 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:SingleLineTextPagePart:view.html.twig';
+        return '@KunstmaanForm/SingleLineTextPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SubmitButtonPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SubmitButtonPagePart.php
@@ -62,7 +62,7 @@ class SubmitButtonPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanFormBundle:SubmitButtonPagePart:view.html.twig';
+        return '@KunstmaanForm/SubmitButtonPagePart/view.html.twig';
     }
 
     /**
@@ -72,7 +72,7 @@ class SubmitButtonPagePart extends AbstractPagePart
      */
     public function getAdminView()
     {
-        return 'KunstmaanFormBundle:SubmitButtonPagePart:view-admin.html.twig';
+        return '@KunstmaanForm/SubmitButtonPagePart/view-admin.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/app/KunstmaanSitemapBundle/views/SitemapPage/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/app/KunstmaanSitemapBundle/views/SitemapPage/view.html.twig
@@ -7,7 +7,7 @@
             {% if nodemenu is defined %}
                 {% for topNode in nodemenu.getTopNodes() %}
                     {% for node in topNode.getChildren() %}
-                        {% include 'KunstmaanSitemapBundle:SitemapPage:entry.html.twig' with {'entry' : node} %}
+                        {% include '@KunstmaanSitemap/SitemapPage/entry.html.twig' with {'entry' : node} %}
                     {% endfor %}
                 {% endfor %}
             {% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/AudioPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/AudioPagePart/view.html.twig
@@ -1,3 +1,3 @@
 {% if resource.media is defined and resource.media != "" %}
-    {% include 'KunstmaanMediaBundle:Media\\RemoteAudio:preview.html.twig' with {'media': resource.media} %}
+    {% include '@KunstmaanMedia/Media/RemoteAudio/preview.html.twig' with {'media': resource.media} %}
 {% endif %}

--- a/src/Kunstmaan/LeadGenerationBundle/AdminList/PopupAdminListConfigurator.php
+++ b/src/Kunstmaan/LeadGenerationBundle/AdminList/PopupAdminListConfigurator.php
@@ -17,9 +17,9 @@ class PopupAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
     {
         parent::__construct($em, $aclHelper);
 
-        $this->setListTemplate('KunstmaanLeadGenerationBundle:AdminList:popup-list.html.twig');
-        $this->setEditTemplate('KunstmaanLeadGenerationBundle:AdminList:popup-edit.html.twig');
-        $this->setAddTemplate('KunstmaanLeadGenerationBundle:AdminList:popup-edit.html.twig');
+        $this->setListTemplate('@KunstmaanLeadGeneration/AdminList/popup-list.html.twig');
+        $this->setEditTemplate('@KunstmaanLeadGeneration/AdminList/popup-edit.html.twig');
+        $this->setAddTemplate('@KunstmaanLeadGeneration/AdminList/popup-edit.html.twig');
     }
 
     /**

--- a/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
+++ b/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
@@ -26,9 +26,9 @@ class RulesAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
         parent::__construct($em, $aclHelper);
 
         $this->setPopupId($id);
-        $this->setListTemplate('KunstmaanLeadGenerationBundle:AdminList:rules-list.html.twig');
-        $this->setEditTemplate('KunstmaanLeadGenerationBundle:AdminList:rules-edit.html.twig');
-        $this->setAddTemplate('KunstmaanLeadGenerationBundle:AdminList:rules-edit.html.twig');
+        $this->setListTemplate('@KunstmaanLeadGeneration/AdminList/rules-list.html.twig');
+        $this->setEditTemplate('@KunstmaanLeadGeneration/AdminList/rules-edit.html.twig');
+        $this->setAddTemplate('@KunstmaanLeadGeneration/AdminList/rules-edit.html.twig');
     }
 
     /**

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
@@ -77,17 +77,17 @@ abstract class AbstractNewsletterController extends Controller
 
     protected function getIndexTemplate()
     {
-        return 'KunstmaanLeadGenerationBundle:Newsletter:index.html.twig';
+        return '@KunstmaanLeadGeneration/Newsletter/index.html.twig';
     }
 
     protected function getFormTemplate()
     {
-        return 'KunstmaanLeadGenerationBundle:Newsletter:form.html.twig';
+        return '@KunstmaanLeadGeneration/Newsletter/form.html.twig';
     }
 
     protected function getThanksTemplate()
     {
-        return 'KunstmaanLeadGenerationBundle:Newsletter:thanks.html.twig';
+        return '@KunstmaanLeadGeneration/Newsletter/thanks.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
@@ -22,6 +22,6 @@ abstract class AbstractRedirectController extends Controller
 
     protected function getIndexTemplate()
     {
-        return 'KunstmaanLeadGenerationBundle:Redirect:index.html.twig';
+        return '@KunstmaanLeadGeneration/Redirect/index.html.twig';
     }
 }

--- a/src/Kunstmaan/LeadGenerationBundle/Resources/views/Newsletter/index.html.twig
+++ b/src/Kunstmaan/LeadGenerationBundle/Resources/views/Newsletter/index.html.twig
@@ -9,7 +9,7 @@
 
 <div id="{{ popup.htmlId }}" class="popup--hide">
     <div id="{{ popup.htmlId }}--content">
-        {% include 'KunstmaanLeadGenerationBundle:Newsletter:form.html.twig' %}
+        {% include '@KunstmaanLeadGeneration/Newsletter/form.html.twig' %}
     </div>
 </div>
 

--- a/src/Kunstmaan/LeadGenerationBundle/Twig/PopupTwigExtension.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Twig/PopupTwigExtension.php
@@ -74,7 +74,7 @@ class PopupTwigExtension extends AbstractExtension
     {
         $files = $this->popupManager->getUniqueJsIncludes();
 
-        return $environment->render('KunstmaanLeadGenerationBundle::js-includes.html.twig', array('files' => $files));
+        return $environment->render('@KunstmaanLeadGeneration/js-includes.html.twig', array('files' => $files));
     }
 
     /**
@@ -84,7 +84,7 @@ class PopupTwigExtension extends AbstractExtension
     {
         $popups = $this->popupManager->getPopups();
 
-        return $environment->render('KunstmaanLeadGenerationBundle::popups-html.html.twig', array('popups' => $popups));
+        return $environment->render('@KunstmaanLeadGeneration/popups-html.html.twig', array('popups' => $popups));
     }
 
     /**
@@ -94,7 +94,7 @@ class PopupTwigExtension extends AbstractExtension
     {
         $popups = $this->popupManager->getPopups();
 
-        return $environment->render('KunstmaanLeadGenerationBundle::initialize-js.html.twig', array('popups' => $popups, 'debug' => $this->debug));
+        return $environment->render('@KunstmaanLeadGeneration/initialize-js.html.twig', array('popups' => $popups, 'debug' => $this->debug));
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/AudioPagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/AudioPagePart.php
@@ -62,7 +62,7 @@ class AudioPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanMediaPagePartBundle:AudioPagePart:view.html.twig';
+        return '@KunstmaanMediaPagePart/AudioPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/DownloadPagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/DownloadPagePart.php
@@ -62,7 +62,7 @@ class DownloadPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanMediaPagePartBundle:DownloadPagePart:view.html.twig';
+        return '@KunstmaanMediaPagePart/DownloadPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/ImagePagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/ImagePagePart.php
@@ -149,7 +149,7 @@ class ImagePagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanMediaPagePartBundle:ImagePagePart:view.html.twig';
+        return '@KunstmaanMediaPagePart/ImagePagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/SlidePagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/SlidePagePart.php
@@ -62,7 +62,7 @@ class SlidePagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanMediaPagePartBundle:SlidePagePart:view.html.twig';
+        return '@KunstmaanMediaPagePart/SlidePagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/VideoPagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/VideoPagePart.php
@@ -62,7 +62,7 @@ class VideoPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanMediaPagePartBundle:VideoPagePart:view.html.twig';
+        return '@KunstmaanMediaPagePart/VideoPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/AudioPagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/AudioPagePartTest.php
@@ -39,7 +39,7 @@ class AudioPagePartTest extends TestCase
     public function testGetDefaultView()
     {
         $defaultView = $this->object->getDefaultView();
-        $this->assertEquals('KunstmaanMediaPagePartBundle:AudioPagePart:view.html.twig', $defaultView);
+        $this->assertEquals('@KunstmaanMediaPagePart/AudioPagePart/view.html.twig', $defaultView);
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/DownloadPagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/DownloadPagePartTest.php
@@ -39,7 +39,7 @@ class DownloadPagePartTest extends TestCase
     public function testGetDefaultView()
     {
         $defaultView = $this->object->getDefaultView();
-        $this->assertEquals('KunstmaanMediaPagePartBundle:DownloadPagePart:view.html.twig', $defaultView);
+        $this->assertEquals('@KunstmaanMediaPagePart/DownloadPagePart/view.html.twig', $defaultView);
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/ImagePagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/ImagePagePartTest.php
@@ -59,7 +59,7 @@ class ImagePagePartTest extends TestCase
     public function testGetDefaultView()
     {
         $defaultView = $this->object->getDefaultView();
-        $this->assertEquals('KunstmaanMediaPagePartBundle:ImagePagePart:view.html.twig', $defaultView);
+        $this->assertEquals('@KunstmaanMediaPagePart/ImagePagePart/view.html.twig', $defaultView);
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/SlidePagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/SlidePagePartTest.php
@@ -34,7 +34,7 @@ class SlidePagePartTest extends TestCase
     public function testGetDefaultView()
     {
         $defaultView = $this->object->getDefaultView();
-        $this->assertEquals('KunstmaanMediaPagePartBundle:SlidePagePart:view.html.twig', $defaultView);
+        $this->assertEquals('@KunstmaanMediaPagePart/SlidePagePart/view.html.twig', $defaultView);
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/VideoPagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/unit/Entity/VideoPagePartTest.php
@@ -38,7 +38,7 @@ class VideoPagePartTest extends TestCase
     public function testGetDefaultView()
     {
         $defaultView = $this->object->getDefaultView();
-        $this->assertEquals('KunstmaanMediaPagePartBundle:VideoPagePart:view.html.twig', $defaultView);
+        $this->assertEquals('@KunstmaanMediaPagePart/VideoPagePart/view.html.twig', $defaultView);
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
+++ b/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
@@ -25,9 +25,9 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     {
         parent::__construct($em, $aclHelper);
 
-        $this->setListTemplate('KunstmaanMenuBundle:AdminList:list-menu-item.html.twig');
-        $this->setAddTemplate('KunstmaanMenuBundle:AdminList:edit-menu-item.html.twig');
-        $this->setEditTemplate('KunstmaanMenuBundle:AdminList:edit-menu-item.html.twig');
+        $this->setListTemplate('@KunstmaanMenu/AdminList/list-menu-item.html.twig');
+        $this->setAddTemplate('@KunstmaanMenu/AdminList/edit-menu-item.html.twig');
+        $this->setEditTemplate('@KunstmaanMenu/AdminList/edit-menu-item.html.twig');
         $this->menu = $menu;
     }
 
@@ -36,10 +36,10 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function buildFields()
     {
-        $this->addField('title', 'kuma_menu.menu_item.adminlist.field.title', false, 'KunstmaanMenuBundle:AdminList:menu-item-title.html.twig');
-        $this->addField('online', 'kuma_menu.menu_item.adminlist.field.online', false, 'KunstmaanMenuBundle:AdminList:menu-item-online.html.twig');
+        $this->addField('title', 'kuma_menu.menu_item.adminlist.field.title', false, '@KunstmaanMenu/AdminList/menu-item-title.html.twig');
+        $this->addField('online', 'kuma_menu.menu_item.adminlist.field.online', false, '@KunstmaanMenu/AdminList/menu-item-online.html.twig');
         $this->addField('type', 'kuma_menu.menu_item.adminlist.field.type', false);
-        $this->addField('url', 'kuma_menu.menu_item.adminlist.field.url', false, 'KunstmaanMenuBundle:AdminList:menu-item-url.html.twig');
+        $this->addField('url', 'kuma_menu.menu_item.adminlist.field.url', false, '@KunstmaanMenu/AdminList/menu-item-url.html.twig');
         $this->addField('newWindow', 'kuma_menu.menu_item.adminlist.field.new_window', false);
     }
 

--- a/src/Kunstmaan/MenuBundle/Service/RenderService.php
+++ b/src/Kunstmaan/MenuBundle/Service/RenderService.php
@@ -32,7 +32,7 @@ class RenderService
     {
         $template = isset($options['template']) ? $options['template'] : false;
         if ($template === false) {
-            $template = 'KunstmaanMenuBundle::menu-item.html.twig';
+            $template = '@KunstmaanMenu/menu-item.html.twig';
         }
 
         $hasActiveChild = false;

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -21,7 +21,7 @@ class WidgetsController extends Controller
 {
     /**
      * @Route("/ckselecturl", name="KunstmaanNodeBundle_ckselecturl")
-     * @Template("KunstmaanNodeBundle:Widgets:selectLink.html.twig")
+     * @Template("@KunstmaanNode/Widgets/selectLink.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
@@ -40,7 +40,7 @@ class WidgetsController extends Controller
      * Select a link
      *
      * @Route("/selecturl", name="KunstmaanNodeBundle_selecturl")
-     * @Template("KunstmaanNodeBundle:Widgets:selectLink.html.twig")
+     * @Template("@KunstmaanNode/Widgets/selectLink.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -618,7 +618,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
         EngineInterface $renderer
     ) {
         $pageparts = $this->indexablePagePartsService->getIndexablePageParts($page);
-        $view = 'KunstmaanNodeSearchBundle:PagePart:view.html.twig';
+        $view = '@KunstmaanNodeSearch/PagePart/view.html.twig';
         $content = $this->removeHtml(
             $renderer->render(
                 $view,

--- a/src/Kunstmaan/NodeSearchBundle/Entity/AbstractSearchPage.php
+++ b/src/Kunstmaan/NodeSearchBundle/Entity/AbstractSearchPage.php
@@ -32,7 +32,7 @@ class AbstractSearchPage extends AbstractPage implements IndexableInterface, Slu
      */
     public function getDefaultView()
     {
-        return 'KunstmaanNodeSearchBundle:AbstractSearchPage:view.html.twig';
+        return '@KunstmaanNodeSearch/AbstractSearchPage/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/NodeSearchBundle/Tests/unit/Entity/AbstractSearchPageTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/unit/Entity/AbstractSearchPageTest.php
@@ -14,7 +14,7 @@ class AbstractSearchPageTest extends TestCase
     {
         $page = new AbstractSearchPage();
         $this->assertEquals('KunstmaanNodeSearchBundle:AbstractSearchPage:service', $page->getControllerAction());
-        $this->assertEquals('KunstmaanNodeSearchBundle:AbstractSearchPage:view.html.twig', $page->getDefaultView());
+        $this->assertEquals('@KunstmaanNodeSearch/AbstractSearchPage/view.html.twig', $page->getDefaultView());
         $this->assertEquals('kunstmaan_node_search.search.node', $page->getSearcher());
         $this->assertFalse($page->isIndexable());
         $this->assertInternalType('array', $page->getPossibleChildTypes());

--- a/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
@@ -81,7 +81,7 @@ class KunstmaanNodeSearchTwigExtension extends AbstractExtension
         $contextName = 'main',
         array $parameters = array()
     ) {
-        $template = $env->load('KunstmaanNodeSearchBundle:PagePart:view.html.twig');
+        $template = $env->load('@KunstmaanNodeSearch/PagePart/view.html.twig');
         $pageparts = $this->indexablePagePartsService->getIndexablePageParts($page, $contextName);
         $newTwigContext = array_merge(
             $parameters,

--- a/src/Kunstmaan/PagePartBundle/Entity/HeaderPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/HeaderPagePart.php
@@ -91,7 +91,7 @@ class HeaderPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:HeaderPagePart:view.html.twig';
+        return '@KunstmaanPagePart/HeaderPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/LinePagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/LinePagePart.php
@@ -26,7 +26,7 @@ class LinePagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:LinePagePart:view.html.twig';
+        return '@KunstmaanPagePart/LinePagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/LinkPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/LinkPagePart.php
@@ -101,7 +101,7 @@ class LinkPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:LinkPagePart:view.html.twig';
+        return '@KunstmaanPagePart/LinkPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/RawHTMLPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/RawHTMLPagePart.php
@@ -51,7 +51,7 @@ class RawHTMLPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:RawHTMLPagePart:view.html.twig';
+        return '@KunstmaanPagePart/RawHTMLPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/TextPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/TextPagePart.php
@@ -51,7 +51,7 @@ class TextPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:TextPagePart:view.html.twig';
+        return '@KunstmaanPagePart/TextPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/ToTopPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/ToTopPagePart.php
@@ -26,7 +26,7 @@ class ToTopPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:ToTopPagePart:view.html.twig';
+        return '@KunstmaanPagePart/ToTopPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Entity/TocPagePart.php
+++ b/src/Kunstmaan/PagePartBundle/Entity/TocPagePart.php
@@ -26,7 +26,7 @@ class TocPagePart extends AbstractPagePart
      */
     public function getDefaultView()
     {
-        return 'KunstmaanPagePartBundle:TocPagePart:view.html.twig';
+        return '@KunstmaanPagePart/TocPagePart/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/PagePartBundle/Resources/views/TocPagePart/view.html.twig
+++ b/src/Kunstmaan/PagePartBundle/Resources/views/TocPagePart/view.html.twig
@@ -1,7 +1,7 @@
 {% set tocContent = '' %}
 {% if page is defined %}
     {% for pagepart in getpageparts(page, "main") %}
-        {% if pagepart.getDefaultView == "KunstmaanPagePartBundle:HeaderPagePart:view.html.twig" %}
+        {% if pagepart.getDefaultView == "@KunstmaanPagePart/HeaderPagePart/view.html.twig" %}
             {% if pagepart.getNiv() == 2 %}
                 {% set tocContent = tocContent~'<li><a href="#'~pagepart.getTitle|slugify~'">'~pagepart.getTitle~'</a></li>' %}
             {% endif %}

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/HeaderPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/HeaderPagePartTest.php
@@ -57,7 +57,7 @@ class HeaderPagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:HeaderPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/HeaderPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/LinePagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/LinePagePartTest.php
@@ -31,7 +31,7 @@ class LinePagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:LinePagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/LinePagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/LinkPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/LinkPagePartTest.php
@@ -52,7 +52,7 @@ class LinkPagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:LinkPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/LinkPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/RawHTMLPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/RawHTMLPagePartTest.php
@@ -31,7 +31,7 @@ class RawHTMLPagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:RawHTMLPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/RawHTMLPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testSetGetContent()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/TextPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/TextPagePartTest.php
@@ -34,7 +34,7 @@ class TextPagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:TextPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/TextPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/ToTopPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/ToTopPagePartTest.php
@@ -45,7 +45,7 @@ class ToTopPagePartTest extends TestCase
      */
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:ToTopPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/ToTopPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/TocPagePartTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/Entity/TocPagePartTest.php
@@ -28,7 +28,7 @@ class TocPagePartTest extends TestCase
 
     public function testGetDefaultView()
     {
-        $this->assertEquals('KunstmaanPagePartBundle:TocPagePart:view.html.twig', $this->object->getDefaultView());
+        $this->assertEquals('@KunstmaanPagePart/TocPagePart/view.html.twig', $this->object->getDefaultView());
     }
 
     public function testGetDefaultAdminType()

--- a/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
+++ b/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
@@ -17,7 +17,7 @@ class SitemapController extends Controller
      *
      * @Route("/sitemap-{locale}.{_format}", name="KunstmaanSitemapBundle_sitemap",
      *                                       requirements={"_format" = "xml"})
-     * @Template("KunstmaanSitemapBundle:Sitemap:view.xml.twig")
+     * @Template("@KunstmaanSitemap/Sitemap/view.xml.twig")
      *
      * @param $locale
      *
@@ -50,7 +50,7 @@ class SitemapController extends Controller
      *
      * @Route("/sitemap.{_format}", name="KunstmaanSitemapBundle_sitemapindex",
      *                              requirements={"_format" = "xml"})
-     * @Template("KunstmaanSitemapBundle:SitemapIndex:view.xml.twig")
+     * @Template("@KunstmaanSitemap/SitemapIndex/view.xml.twig")
      *
      * @param Request $request
      *

--- a/src/Kunstmaan/SitemapBundle/Entity/SitemapPage.php
+++ b/src/Kunstmaan/SitemapBundle/Entity/SitemapPage.php
@@ -29,7 +29,7 @@ class SitemapPage extends AbstractPage implements HiddenFromSitemapInterface, Ha
      */
     public function getDefaultView()
     {
-        return 'KunstmaanSitemapBundle:SitemapPage:view.html.twig';
+        return '@KunstmaanSitemap/SitemapPage/view.html.twig';
     }
 
     /**

--- a/src/Kunstmaan/SitemapBundle/Resources/views/Sitemap/entry.xml.twig
+++ b/src/Kunstmaan/SitemapBundle/Resources/views/Sitemap/entry.xml.twig
@@ -7,6 +7,6 @@
 {% endif %}
 {% if not hide_children_from_sitemap(entry) %}
     {% for subNode in entry.getChildren() %}
-        {% include 'KunstmaanSitemapBundle:Sitemap:entry.xml.twig' with {'entry' : subNode, 'priority' : (priority - 1) } %}
+        {% include '@KunstmaanSitemap/Sitemap/entry.xml.twig' with {'entry' : subNode, 'priority' : (priority - 1) } %}
     {% endfor %}
 {% endif %}

--- a/src/Kunstmaan/SitemapBundle/Tests/unit/Entity/SiteMapPageTest.php
+++ b/src/Kunstmaan/SitemapBundle/Tests/unit/Entity/SiteMapPageTest.php
@@ -14,7 +14,7 @@ class SiteMapPageTest extends TestCase
     {
         $object = new SitemapPage();
 
-        $this->assertEquals('KunstmaanSitemapBundle:SitemapPage:view.html.twig', $object->getDefaultView());
+        $this->assertEquals('@KunstmaanSitemap/SitemapPage/view.html.twig', $object->getDefaultView());
         $this->assertTrue($object->isHiddenFromSitemap());
         $this->assertTrue($object->isChildrenHiddenFromSitemap());
         $this->assertTrue(is_array($object->getPossibleChildTypes()));

--- a/src/Kunstmaan/VotingBundle/Controller/VotingController.php
+++ b/src/Kunstmaan/VotingBundle/Controller/VotingController.php
@@ -17,7 +17,7 @@ class VotingController extends Controller
 {
     /**
      * @Route("/voting-upvote", name="voting_upvote")
-     * @Template("KunstmaanVotingBundle:UpDown:voted.html.twig")
+     * @Template("@KunstmaanVoting/UpDown/voted.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      */
@@ -30,7 +30,7 @@ class VotingController extends Controller
 
     /**
      * @Route("/voting-downvote", name="voting_downvote")
-     * @Template("KunstmaanVotingBundle:UpDown:voted.html.twig")
+     * @Template("@KunstmaanVoting/UpDown/voted.html.twig")
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixed remaining twig template strings that were missed in #2553. This currently throws errors on 5.4 installs
