### PR TITLE
[NodeBundle] Old version admin preview

### DIFF
--- a/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
@@ -395,7 +395,8 @@ class NodeTranslation extends AbstractEntity
      *
      * @return object|null
      */
-    public function getRefByNodeVersion(EntityManagerInterface $em, NodeVersion $nodeVersion) {
+    public function getRefByNodeVersion(EntityManagerInterface $em, NodeVersion $nodeVersion)
+    {
         return $em->getRepository($nodeVersion->getRefEntityName())->find($nodeVersion->getRefId());
     }
 

--- a/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\NodeBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
 use Kunstmaan\NodeBundle\Form\NodeTranslationAdminType;
@@ -373,19 +373,30 @@ class NodeTranslation extends AbstractEntity
     }
 
     /**
-     * @param EntityManager $em   The entity manager
-     * @param string        $type The type
+     * @param EntityManagerInterface $em   The entity manager
+     * @param string                 $type The type
      *
      * @return object|null
      */
-    public function getRef(EntityManager $em, $type = 'public')
+    public function getRef(EntityManagerInterface $em, $type = 'public')
     {
         $nodeVersion = $this->getNodeVersion($type);
-        if ($nodeVersion) {
-            return $em->getRepository($nodeVersion->getRefEntityName())->find($nodeVersion->getRefId());
+
+        if ($nodeVersion instanceof NodeVersion) {
+            return $this->getRefByNodeVersion($em, $nodeVersion);
         }
 
         return null;
+    }
+
+    /**
+     * @param EntityManagerInterface $em   The entity manager
+     * @param NodeVersion            $nodeVersion
+     *
+     * @return object|null
+     */
+    public function getRefByNodeVersion(EntityManagerInterface $em, NodeVersion $nodeVersion) {
+        return $em->getRepository($nodeVersion->getRefEntityName())->find($nodeVersion->getRefId());
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
@@ -390,7 +390,7 @@ class NodeTranslation extends AbstractEntity
     }
 
     /**
-     * @param EntityManagerInterface $em   The entity manager
+     * @param EntityManagerInterface $em          The entity manager
      * @param NodeVersion            $nodeVersion
      *
      * @return object|null

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -32,7 +32,6 @@ class SlugListener
      */
     protected $eventDispatcher;
 
-
     /**
      * SlugListener constructor.
      *

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -3,11 +3,16 @@
 namespace Kunstmaan\NodeBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 use Kunstmaan\NodeBundle\Controller\SlugActionInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Event\SlugSecurityEvent;
+use Kunstmaan\NodeBundle\Repository\NodeVersionRepository;
+use Kunstmaan\NodeBundle\Router\SlugRouter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
@@ -28,6 +33,7 @@ class SlugListener
      */
     protected $eventDispatcher;
 
+
     /**
      * SlugListener constructor.
      *
@@ -35,8 +41,11 @@ class SlugListener
      * @param ControllerResolverInterface $resolver
      * @param EventDispatcherInterface    $eventDispatcher
      */
-    public function __construct(EntityManager $em, ControllerResolverInterface $resolver, EventDispatcherInterface $eventDispatcher)
-    {
+    public function __construct(
+        EntityManager $em,
+        ControllerResolverInterface $resolver,
+        EventDispatcherInterface $eventDispatcher
+    ) {
         $this->em = $em;
         $this->resolver = $resolver;
         $this->eventDispatcher = $eventDispatcher;
@@ -60,7 +69,8 @@ class SlugListener
         if (!($nodeTranslation instanceof NodeTranslation)) {
             throw new \Exception('Invalid _nodeTranslation value found in request attributes');
         }
-        $entity = $nodeTranslation->getRef($this->em);
+
+        $entity = $this->getEntity($nodeTranslation, $request);
 
         // If the entity is an instance of the SlugActionInterface, change the controller
         if ($entity instanceof SlugActionInterface) {
@@ -80,5 +90,34 @@ class SlugListener
             $request->attributes->set('_controller', $entity->getControllerAction());
             $event->setController($this->resolver->getController($request));
         }
+    }
+
+    /**
+     * @param NodeTranslation $nodeTranslation
+     * @param Request         $request
+     *
+     * @return null|object
+     */
+    private function getEntity(NodeTranslation $nodeTranslation, Request $request)
+    {
+        $versionId = $request->query->get('version');
+
+        if ($request->attributes->get('_route') !== SlugRouter::$SLUG_PREVIEW || $versionId === null) {
+            return $nodeTranslation->getRef($this->em);
+        }
+
+        /** @var NodeVersionRepository $nodeVersionRepository */
+        $nodeVersionRepository = $this->em->getRepository(NodeVersion::class);
+
+        $nodeVersion = $nodeVersionRepository->findOneBy([
+            'nodeTranslation' => $nodeTranslation,
+            'id' => $versionId
+        ]);
+
+        if (!$nodeVersion instanceof NodeVersion) {
+            return null;
+        }
+
+        return $nodeTranslation->getRefByNodeVersion($this->em, $nodeVersion);
     }
 }

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -3,7 +3,6 @@
 namespace Kunstmaan\NodeBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
-use Kunstmaan\AdminBundle\Helper\AdminRouteHelper;
 use Kunstmaan\NodeBundle\Controller\SlugActionInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugListener.php
@@ -110,7 +110,7 @@ class SlugListener
 
         $nodeVersion = $nodeVersionRepository->findOneBy([
             'nodeTranslation' => $nodeTranslation,
-            'id' => $versionId
+            'id' => $versionId,
         ]);
 
         if (!$nodeVersion instanceof NodeVersion) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In the admin you can view older versions of your pages:
![versions](https://user-images.githubusercontent.com/37873948/73246654-710d4a00-41af-11ea-8520-a0d225581bf5.PNG)

However, the preview button always shows the latest version, since the version parameter is completely ignored.

This code will retrieve the correct NodeVersion, instead of always getting the public node version.

