### PR TITLE
[AdminListBundle] Refactor extra actions

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
@@ -18,34 +18,36 @@
             <div class="app__content__header__extra-actions">
                 <div class="btn-group">
                     {% if adminlist.canAdd() %}
-                        {% if adminlist.getIndexUrl()['params'] is defined %}
-                            {% set adminaddlist = adminlist.getAddUrlFor(adminlist.getIndexUrl()['params']) %}
-                        {% else %}
-                            {% set adminaddlist = adminlist.getAddUrlFor(adminlist.getIndexUrl()) %}
-                        {% endif %}
+                        {% block add_action %}
+                            {% if adminlist.getIndexUrl()['params'] is defined %}
+                                {% set adminaddlist = adminlist.getAddUrlFor(adminlist.getIndexUrl()['params']) %}
+                            {% else %}
+                                {% set adminaddlist = adminlist.getAddUrlFor(adminlist.getIndexUrl()) %}
+                            {% endif %}
 
-                        {% if adminaddlist|length > 1 %}
-                            <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
-                                {{ 'form.add' | trans }}
-                                <i class="fa fa-caret-down btn__icon"></i>
-                            </a>
-                            <ul class="dropdown-menu dropdown-menu-right">
-                                {% for key,add in adminaddlist %}
-                                    <li>
-                                        <a href="{{ path(add["path"], add[("params")]) }}">
-                                            {{ key }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% else %}
-                            {% for key,add in adminaddlist %}
-                                <a class="btn btn-primary btn--raise-on-hover" href="{{ path(add["path"], add[("params")]) }}">
-                                    {{ 'form.add.%subject%' | trans({ '%subject%': key|trans }) }}
+                            {% if adminaddlist|length > 1 %}
+                                <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+                                    {{ 'form.add' | trans }}
+                                    <i class="fa fa-caret-down btn__icon"></i>
                                 </a>
-                            {% endfor %}
+                                <ul class="dropdown-menu dropdown-menu-right">
+                                    {% for key,add in adminaddlist %}
+                                        <li>
+                                            <a href="{{ path(add["path"], add[("params")]) }}">
+                                                {{ key }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                {% for key,add in adminaddlist %}
+                                    <a class="btn btn-primary btn--raise-on-hover" href="{{ path(add["path"], add[("params")]) }}">
+                                        {{ 'form.add.%subject%' | trans({ '%subject%': key|trans }) }}
+                                    </a>
+                                {% endfor %}
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
+                    {% endblock %}
                 </div>
 
                 {% if adminlist.canExport() %}

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Default/list.html.twig
@@ -46,8 +46,8 @@
                                     </a>
                                 {% endfor %}
                             {% endif %}
-                        {% endif %}
-                    {% endblock %}
+                        {% endblock %}
+                    {% endif %}
                 </div>
 
                 {% if adminlist.canExport() %}

--- a/src/Kunstmaan/AdminListBundle/Resources/views/Page/list.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/Page/list.html.twig
@@ -1,61 +1,16 @@
 {% extends 'KunstmaanAdminListBundle:Default:list.html.twig' %}
 
+{% block add_action %}
+    <div class="btn-group">
+        <a href='#' data-target='#add-subpage-modal' data-toggle='modal' class='btn btn-primary btn--raise-on-hover'>
+            {{ 'form.add'|trans }}
+        </a>
+    </div>
+{% endblock %}
+
 {% block extra_actions_header %}
     {% if adminlistconfigurator.overviewPage %}
-        {% if adminlist.canAdd() or adminlist.canExport() or adminlist.hasListActions() %}
-            <div class="col-sm-6 col-md-4">
-                <div class="app__content__header__extra-actions">
-                    {% if adminlist.canAdd() %}
-                        <div class="btn-group">
-                            <a href='#' data-target='#add-subpage-modal' data-toggle='modal' class='btn btn-primary btn--raise-on-hover'>
-                                {{ 'form.add'|trans }}
-                            </a>
-                        </div>
-                    {% endif %}
-
-                    {% if adminlist.canExport() %}
-                        <div class="btn-group dropdown">
-                            <a class="btn btn-default btn--raise-on-hover dropdown-toggle" data-toggle="dropdown" href="#">
-                                {{ 'kuma_admin_list.form.export_to' | trans }}
-                                <i class="fa fa-caret-down btn__icon"></i>
-                            </a>
-
-                            <ul class="dropdown-menu dropdown-menu-right">
-                                {% set exportparams = adminlist.filterbuilder.currentparameters|merge(adminlist.getExportUrl()[("params")]) %}
-                                {% for name, ext in supported_export_extensions() %}
-                                    {% set exportparams = exportparams|merge({"_format": ext}) %}
-                                    <li>
-                                        <a href="{{ path(adminlist.getExportUrl()["path"], exportparams) }}">
-                                            <i class="fa fa-file-{{ name | lower }} btn__icon"></i>
-                                            {{ name }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                    {% endif %}
-
-                    {% if adminlist.hasListActions() %}
-                        <div class="btn-group">
-                            {% for action in adminlist.getListActions() %}
-                                {% if action.template is not null %}
-                                    {% include action.template with {'action': action} %}
-                                {% else %}
-                                    <a href="{{ path(action.getUrl()["path"], action.getUrl()[("params")] ) }}" class="btn">
-                                        {% if action.getIcon() is not null %}
-                                            <i class="fa fa-{{ action.getIcon() }}"></i>
-                                            {{ action.getLabel()|trans }}
-                                        {% else %}
-                                            {{ action.getLabel()|trans }}
-                                        {% endif %}
-                                    </a>
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        {% endif %}
+        {{ parent() }}
 
         {% if adminlistconfigurator.canAdd %}
             <div id='add-subpage-modal' class='modal fade'>

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -196,9 +196,4 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
      * @return \Doctrine\ORM\EntityRepository
      */
     abstract public function getOverviewPageRepository();
-
-    public function getIterator()
-    {
-        return $this->getItems();
-    }
 }

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -196,4 +196,9 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
      * @return \Doctrine\ORM\EntityRepository
      */
     abstract public function getOverviewPageRepository();
+
+    public function getIterator()
+    {
+        return $this->getItems();
+    }
 }

--- a/src/Kunstmaan/ArticleBundle/Resources/views/AbstractArticlePageAdminList/list.html.twig
+++ b/src/Kunstmaan/ArticleBundle/Resources/views/AbstractArticlePageAdminList/list.html.twig
@@ -45,44 +45,16 @@
 {% import _self as modal %}
 
 {% block extra_actions_header %}
-
     {% if adminmenu.current %}
         {% set title = adminmenu.current.label | trans %}
     {% else %}
         {% set title = adminlist.configurator.getEntityName() %}
     {% endif %}
-    
-    {% if adminlistconfigurator.overviewPage %}
-        {% if adminlist.canAdd() %}
-            <div class="col-sm-6 col-md-4">
-                <!-- Main-actions -->
-                <div class="page-main-actions page-main-actions--no-tabs page-main-actions--inside-extra-actions-header">
-                    <div class="btn-group">
-                        {% block actions %}
-                            {% if adminlistconfigurator.overviewPages | length > 1 %}
-                                <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
-                                    {{ 'form.add' | trans }}
-                                    <i class="fa fa-caret-down"></i>
-                                </a>
-                                <ul class="dropdown-menu dropdown-menu-right">
-                                    {% for key, overviewPage in adminlistconfigurator.overviewPages %}
-                                        <li>
-                                            <a data-target="#add-subpage-modal-{{ overviewPage.id }}" data-toggle="modal" href="#">
-                                                {{ overviewPage.pageTitle }}
-                                            </a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% else %}
-                                <button type="button" data-target="#add-subpage-modal-{{ adminlistconfigurator.overviewPage.id }}" data-toggle="modal" class="btn btn-primary btn--raise-on-hover">
-                                    {{ 'form.add' | trans }}
-                                </button>
-                            {% endif %}
-                        {% endblock %}
-                    </div>
-                </div>
-            </div>
 
+    {% if adminlistconfigurator.overviewPage %}
+        {{ parent() }}
+
+        {% if adminlist.canAdd() %}
             {% if adminlistconfigurator.overviewPages | length > 1 %}
                 {% for overviewPage in adminlistconfigurator.overviewPages %}
                     {{ modal.modal(overviewPage, title, adminlist.configurator.getEntityClassName) }}
@@ -90,7 +62,6 @@
             {% else %}
                 {{ modal.modal(adminlistconfigurator.overviewPage, title, adminlist.configurator.getEntityClassName) }}
             {% endif %}
-
         {% endif %}
 
     {% else %}

--- a/src/Kunstmaan/ArticleBundle/Resources/views/AbstractArticlePageAdminList/list.html.twig
+++ b/src/Kunstmaan/ArticleBundle/Resources/views/AbstractArticlePageAdminList/list.html.twig
@@ -16,7 +16,9 @@
                     </h3>
                 </div>
 
-                <form action="{{ path('KunstmaanNodeBundle_nodes_add', { 'id': get_node_for(overviewPage).id , 'type' : type}) }}" method="post" novalidate="novalidate">
+                <form
+                    action="{{ path('KunstmaanNodeBundle_nodes_add', { 'id': get_node_for(overviewPage).id , 'type' : type}) }}"
+                    method="post" novalidate="novalidate">
                     <!-- Body -->
                     <div class="modal-body">
                         <div class="form-group">
@@ -66,10 +68,34 @@
 
     {% else %}
         <div class="alert alert-warning">
-            <strong>{{ 'form.warning' | trans }}: </strong> {{ 'article.warning.create_overview_page' | trans({ '%type%': title | lower }) }}
+            <strong>{{ 'form.warning' | trans }}
+                : </strong> {{ 'article.warning.create_overview_page' | trans({ '%type%': title | lower }) }}
             <button class="close" data-dismiss="alert">
                 <i class="fa fa-times"></i>
             </button>
         </div>
+    {% endif %}
+{% endblock %}
+
+{% block add_action %}
+    {% if adminlistconfigurator.overviewPages | length > 1 %}
+        <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+            {{ 'form.add' | trans }}
+            <i class="fa fa-caret-down"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right">
+            {% for key, overviewPage in adminlistconfigurator.overviewPages %}
+                <li>
+                    <a data-target="#add-subpage-modal-{{ overviewPage.id }}" data-toggle="modal" href="#">
+                        {{ overviewPage.pageTitle }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <button type="button" data-target="#add-subpage-modal-{{ adminlistconfigurator.overviewPage.id }}"
+                data-toggle="modal" class="btn btn-primary btn--raise-on-hover">
+            {{ 'form.add' | trans }}
+        </button>
     {% endif %}
 {% endblock %}

--- a/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/list.html.twig
+++ b/src/Kunstmaan/FormBundle/Resources/views/FormSubmissions/list.html.twig
@@ -1,31 +1,4 @@
-{% extends '@KunstmaanAdmin/Default/layout.html.twig' %}
-
-{% block extra_actions_header %}
-    {% if adminlist.canExport() %}
-        <div class="col-sm-6 col-md-4">
-            <div class="app__content__header__extra-actions">
-                <div class="btn-group">
-                    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
-                        {{ 'kuma_form.button.export_to' | trans }}
-                        <i class="fa fa-caret-down"></i>
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-right">
-                        {% set exportparams = adminlist.filterbuilder.currentparameters|merge(adminlist.getExportUrl()[("params")]) %}
-                        {% for name, ext in supported_export_extensions() %}
-                            {% set exportparams = exportparams|merge({"_format": ext}) %}
-                            <li>
-                                <a href="{{ path(adminlist.getExportUrl()["path"], exportparams) }}">
-                                    <i class="fa fa-file-{{ name|lower }}"></i>
-                                    {{ name }}
-                                </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-{% endblock %}
+{% extends '@KunstmaanAdminList/Default/list.html.twig' %}
 
 {% block content %}
     <h2>{{ nodetranslation.title }}</h2>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Turns out not all of the extra actions arent the same for every time of admin list. We couldnt add an export button to `AbstractArticlePageAdminListConfigurator`, because the template used for that adminlist is different than `AbstractDoctrineORMAdminListConfigurator`.
I've tried to merge the `list.html.twig` files as much as possible for the extra actions.
