### PR TITLE
[AdminBundle] Re-enable templating component for search nodepages config

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -125,6 +125,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
         $container->prependExtensionConfig('twig', $twigConfig);
 
         // NEXT_MAJOR: Remove templating dependency
+        $frameworkConfig['templating']['engines'] = ['twig'];
+        $container->prependExtensionConfig('framework', $frameworkConfig);
 
         $configs = $container->getExtensionConfig($this->getAlias());
         $this->processConfiguration(new Configuration(), $configs);


### PR DESCRIPTION
| Q             | A
| ------------- | ----
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The templating component should still be enable, otherwise we get errors in `NodeSearchConfiguration`. Temporary re-enable the component, so we can deprecate the remaining usages.

https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/f760926cb4f626646bd19745c97ecebb7ebeed6f/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php#L577-L635
