### PR TITLE
[MediaBundle] Catch exception in DoctrineMediaListener

### DIFF
--- a/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
+++ b/src/Kunstmaan/MediaBundle/EventListener/DoctrineMediaListener.php
@@ -51,7 +51,11 @@ class DoctrineMediaListener
             return false;
         }
 
-        $this->mediaManager->prepareMedia($entity);
+        try {
+            $this->mediaManager->prepareMedia($entity);
+        } catch (\Exception $exception) {
+            return false;
+        }
 
         return true;
     }

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -136,7 +136,7 @@ class FileHandler extends AbstractMediaHandler
     {
         if ($object instanceof File ||
             ($object instanceof Media &&
-            (is_file($object->getContent()) || $object->getLocation() == 'local'))
+            (is_file($object->getUrl()) || $object->getLocation() == 'local'))
         ) {
             return true;
         }
@@ -172,12 +172,9 @@ class FileHandler extends AbstractMediaHandler
         }
 
         if (!$content instanceof File) {
-            if (!is_file($content)) {
-                throw new \RuntimeException('Invalid file');
-            }
+            $content = new File($media->getUrl());
 
-            $file = new File($content);
-            $media->setContent($file);
+            $media->setContent($content);
         }
 
         $contentType = $this->mimeTypeGuesser->guess($content->getPathname());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When using flush on a new Media with that contains a pdf as content, will throw an exception that will cause the entity manager to close. If using this in an iteration (import) there is no way to open the entity manager again.

This fix makes sure File will be created with url to the file, instead of the content and catched the exception, before being throwed during the flush.