### PR TITLE
[RedirectBundle] Fix target column length for long urls

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
@@ -45,7 +45,7 @@ class Redirect extends AbstractEntity
     /**
      * @var string
      *
-     * @ORM\Column(name="target", type="string", length=255)
+     * @ORM\Column(name="target", type="text")
      * @Assert\NotBlank()
      */
     private $target;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Target urls could potentially be long and 255 chars could be too few.