### PR TITLE
[RedirectBundle] Fix UTF-8 issue with redirect origin

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -166,6 +166,7 @@ class RedirectRouter implements RouterInterface
         foreach ([$redirect->getOrigin(), $redirect->getTarget()] as $item) {
             if (preg_match('/[\x80-\xFF]/', $item)) {
                 $needsUtf8 = true;
+                
                 break;
             }
         }

--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -166,7 +166,7 @@ class RedirectRouter implements RouterInterface
         foreach ([$redirect->getOrigin(), $redirect->getTarget()] as $item) {
             if (preg_match('/[\x80-\xFF]/', $item)) {
                 $needsUtf8 = true;
-                
+
                 break;
             }
         }

--- a/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
+++ b/src/Kunstmaan/RedirectBundle/Router/RedirectRouter.php
@@ -162,7 +162,13 @@ class RedirectRouter implements RouterInterface
      */
     private function createRoute(Redirect $redirect)
     {
-        $needsUtf8 = preg_match('/[\x80-\xFF]/', $redirect->getTarget());
+        $needsUtf8 = false;
+        foreach ([$redirect->getOrigin(), $redirect->getTarget()] as $item) {
+            if (preg_match('/[\x80-\xFF]/', $item)) {
+                $needsUtf8 = true;
+                break;
+            }
+        }
 
         return new Route(
             $redirect->getOrigin(), [

--- a/src/Kunstmaan/RedirectBundle/Tests/unit/Router/RedirectRouterTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/unit/Router/RedirectRouterTest.php
@@ -82,6 +82,8 @@ class RedirectRouterTest extends TestCase
             $this->redirects[] = $this->getRedirect(2, 'test2', '/target2', true, null);
             $this->redirects[] = $this->getRedirect(3, 'test3', '/target3', true, 'sub.domain.com');
             $this->redirects[] = $this->getRedirect(4, 'test4', '/target4', true, 'other.domain.com');
+            $this->redirects[] = $this->getRedirect(5, 'test5', '/targét5', true, null);
+            $this->redirects[] = $this->getRedirect(6, 'tést6', '/target6', true, null);
         }
 
         return $this->redirects;
@@ -97,19 +99,19 @@ class RedirectRouterTest extends TestCase
     public function testGetRouteCollection()
     {
         $collection = $this->firstObject->getRouteCollection();
-        $this->assertEquals(3, $collection->count());
+        $this->assertEquals(5, $collection->count());
 
         $collection = $this->secondObject->getRouteCollection();
-        $this->assertEquals(3, $collection->count());
+        $this->assertEquals(5, $collection->count());
     }
 
     public function testGetRouteCollectionf()
     {
         $collection = $this->firstObject->getRouteCollection();
-        $this->assertEquals(3, $collection->count());
+        $this->assertEquals(5, $collection->count());
 
         $collection = $this->secondObject->getRouteCollection();
-        $this->assertEquals(3, $collection->count());
+        $this->assertEquals(5, $collection->count());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

If the origin of a redirect contains UTF-8 chars this will throw an Logic exception eg. Cannot use UTF-8 route patterns without setting the "utf8" option for route "fiscalité".