### PR TITLE
[NodeBundle] Restore NodeMenuItem::getLang method to fix BC break

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenuItem.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenuItem.php
@@ -288,4 +288,12 @@ class NodeMenuItem
     {
         return $this->menu->getActive($this->getSlug());
     }
+
+    /**
+     * @return string
+     */
+    public function getLang()
+    {
+        return $this->menu->getLocale();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #1888 

The `NodeMenuItem::getLang` method was incorrectly removed in #1255, the `NodeMenu::getLang` method was deprecated and removed but this method should have been reworked to use the new `getLocale` method.