### PR TITLE
[AdminBundle] Avoid accessing user token when it is not needed

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/InjectUntrackedTokenStorageCompilerPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/InjectUntrackedTokenStorageCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+final class InjectUntrackedTokenStorageCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('security.untracked_token_storage')) {
+            return;
+        }
+
+        // NEXT_MAJOR: this compilerpass can be removed when we drop symfony <4.4 support + replace service argument in yaml config
+        if ($container->has('kunstmaan_admin.logger.processor.user')) {
+            $container->getDefinition('kunstmaan_admin.logger.processor.user')->setArgument(0, new Reference('security.untracked_token_storage'));
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -69,9 +69,12 @@ class AdminLocaleListener implements EventSubscriberInterface
         }
 
         $url = $event->getRequest()->getRequestUri();
-        $token = $this->tokenStorage->getToken();
+        if (!$this->adminRouteHelper->isAdminRoute($url)) {
+            return;
+        }
 
-        if ($token && $this->isAdminToken($this->providerKey, $token) && $this->adminRouteHelper->isAdminRoute($url)) {
+        $token = $this->tokenStorage->getToken();
+        if ($token && $this->isAdminToken($this->providerKey, $token)) {
             $locale = $token->getUser()->getAdminLocale();
 
             if (!$locale) {

--- a/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/PasswordCheckListener.php
@@ -76,7 +76,11 @@ class PasswordCheckListener
         }
 
         $url = $event->getRequest()->getRequestUri();
-        if ($this->tokenStorage->getToken() && $this->adminRouteHelper->isAdminRoute($url)) {
+        if (!$this->adminRouteHelper->isAdminRoute($url)) {
+            return;
+        }
+
+        if ($this->tokenStorage->getToken()) {
             $route = $event->getRequest()->get('_route');
             if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') && $route != 'fos_user_change_password') {
                 $user = $this->tokenStorage->getToken()->getUser();

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -8,6 +8,7 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\ConsoleCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\InjectUntrackedTokenStorageCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,6 +32,7 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new DataCollectorPass());
         $container->addCompilerPass(new DomainConfigurationPass());
         $container->addCompilerPass(new ConsoleCompilerPass());
+        $container->addCompilerPass(new InjectUntrackedTokenStorageCompilerPass());
 
         $container->addCompilerPass(new DeprecateClassParametersPass());
 

--- a/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
@@ -18,7 +18,7 @@ class KunstmaanAdminBundleTest extends TestCase
         $resources = $containerBuilder->getResources();
         $extensions = $containerBuilder->getExtensions();
 
-        $this->assertCount(8, $resources);
+        $this->assertCount(9, $resources);
         $this->assertCount(1, $extensions);
         $this->assertArrayHasKey('kunstmaan_admin', $extensions);
         $this->assertInstanceOf(KunstmaanAdminExtension::class, $extensions['kunstmaan_admin']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Symfony changed the default behavior of the tokenstorage service in symfony 4.4, to track and increase the session usage index. This will trigger the response to be private. 

By changing a few checks we can avoid triggering this meganism when is it not necessary.
