### PR TITLE
[MediaBundle] Fix incompatibility with liip/imagine-bundle 2.2+

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
@@ -38,15 +38,21 @@ class WebPathResolver extends \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPath
         return parent::getFileUrl($path, $filter);
     }
 
+    protected function getFilePath($path, $filter)
+    {
+        $filterConf = $this->filterConfig->get($filter);
+        $path = $this->changeFileExtension($path, $filterConf['format']);
+        $fullPath = $this->getFullPath($path, $filter);
+
+        return $this->webRoot.'/'.$fullPath;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function resolve($path, $filter)
     {
-        return sprintf('%s/%s',
-            $this->getBaseUrl(),
-            $this->getFileUrl($path, $filter)
-        );
+        return sprintf('%s/%s', $this->getBaseUrl(), $this->getFileUrl($path, $filter));
     }
 
     /**
@@ -65,5 +71,16 @@ class WebPathResolver extends \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPath
         $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $format;
 
         return $path;
+    }
+
+    /**
+     * Copy from \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPathResolver::getFullPath
+     */
+    private function getFullPath($path, $filter)
+    {
+        // crude way of sanitizing URL scheme ("protocol") part
+        $path = str_replace('://', '---', $path);
+
+        return $this->cachePrefix.'/'.$filter.'/'.ltrim($path, '/');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Since v2.2 some overrides we do for the liip/imagine-bundle didn't work anymore. This causes issues with uploads with a different extension than the filter outputs.
