### PR TITLE
[MediaBundle] Replace incorrect mobile icons

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Chooser/chooserShowFolder.html.twig
@@ -143,11 +143,11 @@
                 </div>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#addsub-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.addsub.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.addsub.action_short' |trans }} <i class="fa fa-folder-o btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.addsub.action_short' |trans }} <i class="fa fa-plus-circle btn__icon-folder"></i></span>
                 </button>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#delete-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.delete.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.delete.action_short' |trans }} <i class="fa fa-folder-o btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.delete.action_short' |trans }} <i class="fa fa-minus-circle btn__icon-folder"></i></span>
                 </button>
             {% endblock %}
         </div>

--- a/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
@@ -94,19 +94,19 @@
                 </div>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#addsub-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.addsub.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.addsub.action_short' |trans }} <i class="fa fa-folder btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.addsub.action_short' |trans }} <i class="fa fa-plus-circle btn__icon-folder"></i></span>
                 </button>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#delete-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.delete.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.delete.action_short' |trans }} <i class="fa fa-folder btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.delete.action_short' |trans }} <i class="fa fa-minus-circle btn__icon-folder"></i></span>
                 </button>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#empty-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.empty.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.empty.action_short' |trans }} <i class="fa fa-folder btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.empty.action_short' |trans }} <i class="fa fa-trash btn__icon-folder"></i></span>
                 </button>
                 <button class="btn btn-default btn--raise-on-hover" data-target="#bulk-move-modal" data-toggle="modal" type="button">
                     <span class="large-screen">{{ 'media.folder.bulk_move.action' |trans }}</span>
-                    <span class="small-screen">{{ 'media.folder.bulk_move.action_short' |trans }} <i class="fa fa-folder btn__icon-folder"></i></span>
+                    <span class="small-screen">{{ 'media.folder.bulk_move.action_short' |trans }} <i class="fa fa-arrow-circle-right btn__icon-folder"></i></span>
                 </button>
             {% endblock %}
         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

On the mobile view of the media bundle there were some incorrect icons

Before:
![Screenshot 2020-03-06 at 12 55 58](https://user-images.githubusercontent.com/1374857/76082036-bbea6080-5faa-11ea-9e0e-75e3b4205799.png)


After:
![Screenshot 2020-03-06 at 12 55 37](https://user-images.githubusercontent.com/1374857/76082044-c0167e00-5faa-11ea-8f96-b3cc0d5a310d.png)
