### PR TITLE
[AllBundles] Add configuration option to disable permission module/checking

### DIFF
--- a/docs/bundles/config-reference.md
+++ b/docs/bundles/config-reference.md
@@ -125,6 +125,7 @@ kunstmaan_node:
         enabled:              false
         check_interval:       15
         threshold:            35
+    enable_permissions: true # Enable/disable permission checking on nodes (frontend and admin view)
 ```
 
 ## NodeSearchBundle

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/EnablePermissionsPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/EnablePermissionsPass.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class EnablePermissionsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasParameter('kunstmaan_node.permissions.enabled')) {
+            $permissionsEnabledParameter = $container->getParameter('kunstmaan_node.permissions.enabled');
+
+            $container->getDefinition('kunstmaan_admin.acl.helper')->setArgument('$permissionsEnabled', $permissionsEnabledParameter);
+            $container->getDefinition('kunstmaan_admin.acl.native.helper')->setArgument('$permissionsEnabled', $permissionsEnabledParameter);
+            $aclVoterDefinition = $container->getDefinition('kunstmaan_admin.security.acl.voter');
+
+            $aclVoterDefinition->setArgument('$logger', null);
+            $aclVoterDefinition->setArgument('$allowIfObjectIdentityUnavailable', true);
+            $aclVoterDefinition->setArgument('$permissionsEnabled', $permissionsEnabledParameter);
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
@@ -33,17 +33,23 @@ class AclNativeHelper
     private $roleHierarchy = null;
 
     /**
+     * @var bool
+     */
+    private $permissionsEnabled;
+
+    /**
      * Constructor.
      *
      * @param EntityManager          $em           The entity manager
      * @param TokenStorageInterface  $tokenStorage The security context
      * @param RoleHierarchyInterface $rh           The role hierarchies
      */
-    public function __construct(EntityManager $em, TokenStorageInterface $tokenStorage, RoleHierarchyInterface $rh)
+    public function __construct(EntityManager $em, TokenStorageInterface $tokenStorage, RoleHierarchyInterface $rh, $permissionsEnabled = true)
     {
         $this->em = $em;
         $this->tokenStorage = $tokenStorage;
         $this->roleHierarchy = $rh;
+        $this->permissionsEnabled = $permissionsEnabled;
     }
 
     /**
@@ -56,6 +62,10 @@ class AclNativeHelper
      */
     public function apply(QueryBuilder $queryBuilder, PermissionDefinition $permissionDef)
     {
+        if (!$this->permissionsEnabled) {
+            return $queryBuilder;
+        }
+
         $aclConnection = $this->em->getConnection();
 
         $databasePrefix = is_file($aclConnection->getDatabase()) ? '' : $aclConnection->getDatabase().'.';
@@ -108,10 +118,10 @@ class AclNativeHelper
 
         if (\is_object($user)) {
             $inString .= ' OR s.identifier = "' . str_replace(
-                    '\\',
-                    '\\\\',
-                    \get_class($user)
-                ) . '-' . $user->getUserName() . '"';
+                '\\',
+                '\\\\',
+                \get_class($user)
+            ) . '-' . $user->getUserName() . '"';
         }
 
         $joinTableQuery = <<<SELECTQUERY

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterfac
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
 use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
 use Symfony\Component\Security\Acl\Voter\AclVoter as BaseAclVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * This voter can be used as a base class for implementing your own permissions.
@@ -25,8 +26,21 @@ use Symfony\Component\Security\Acl\Voter\AclVoter as BaseAclVoter;
  */
 class AclVoter extends BaseAclVoter
 {
-    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true)
+    /** @var bool */
+    private $permissionsEnabled;
+
+    public function __construct(AclProviderInterface $aclProvider, ObjectIdentityRetrievalStrategyInterface $oidRetrievalStrategy, SecurityIdentityRetrievalStrategyInterface $sidRetrievalStrategy, PermissionMapInterface $permissionMap, LoggerInterface $logger = null, $allowIfObjectIdentityUnavailable = true, $permissionsEnabled = true)
     {
         parent::__construct($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap, $logger, $allowIfObjectIdentityUnavailable);
+        $this->permissionsEnabled = $permissionsEnabled;
+    }
+
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        if (!$this->permissionsEnabled) {
+            return self::ACCESS_GRANTED;
+        }
+
+        return parent::vote($token, $object, $attributes);
     }
 }

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -8,6 +8,7 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\ConsoleCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DataCollectorPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DeprecateClassParametersPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\EnablePermissionsPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\InjectUntrackedTokenStorageCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
@@ -33,6 +34,7 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new DomainConfigurationPass());
         $container->addCompilerPass(new ConsoleCompilerPass());
         $container->addCompilerPass(new InjectUntrackedTokenStorageCompilerPass());
+        $container->addCompilerPass(new EnablePermissionsPass());
 
         $container->addCompilerPass(new DeprecateClassParametersPass());
 

--- a/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
@@ -18,7 +18,7 @@ class KunstmaanAdminBundleTest extends TestCase
         $resources = $containerBuilder->getResources();
         $extensions = $containerBuilder->getExtensions();
 
-        $this->assertCount(9, $resources);
+        $this->assertCount(10, $resources);
         $this->assertCount(1, $extensions);
         $this->assertArrayHasKey('kunstmaan_admin', $extensions);
         $this->assertInstanceOf(KunstmaanAdminExtension::class, $extensions['kunstmaan_admin']);

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('enable_permissions')->defaultTrue()->end()
                 ->scalarNode('publish_later_stepping')->defaultValue('15')->end()
                 ->scalarNode('unpublish_later_stepping')->defaultValue('15')->end()
                 ->booleanNode('show_add_homepage')->defaultTrue()->end()

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -35,6 +35,7 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
         $nodePagesDefinition->setPublic(true);
         $container->setDefinition('kunstmaan_node.pages_configuration', $nodePagesDefinition);
 
+        $container->setParameter('kunstmaan_node.permissions.enabled', $config['enable_permissions']);
         $container->setParameter('kunstmaan_node.show_add_homepage', $config['show_add_homepage']);
         $container->setParameter('kunstmaan_node.enable_export_page_template', $config['enable_export_page_template']);
         $container->setParameter('kunstmaan_node.lock_check_interval', $config['lock']['check_interval']);

--- a/src/Kunstmaan/NodeBundle/EventListener/NodeListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeListener.php
@@ -28,15 +28,21 @@ class NodeListener
     protected $permissionMap;
 
     /**
+     * @var bool
+     */
+    private $permissionsEnabled;
+
+    /**
      * @param AuthorizationCheckerInterface $authorizationChecker The security context
      * @param PermissionAdmin               $permissionAdmin      The permission admin
      * @param PermissionMapInterface        $permissionMap        The permission map
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, PermissionAdmin $permissionAdmin, PermissionMapInterface $permissionMap)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, PermissionAdmin $permissionAdmin, PermissionMapInterface $permissionMap, $permissionsEnabled = true)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->permissionAdmin = $permissionAdmin;
         $this->permissionMap = $permissionMap;
+        $this->permissionsEnabled = $permissionsEnabled;
     }
 
     /**
@@ -44,7 +50,7 @@ class NodeListener
      */
     public function adaptForm(AdaptFormEvent $event)
     {
-        if ($event->getPage() instanceof HasNodeInterface && !$event->getPage()->isStructureNode() && $this->authorizationChecker->isGranted('ROLE_PERMISSIONMANAGER')) {
+        if ($this->permissionsEnabled && $event->getPage() instanceof HasNodeInterface && !$event->getPage()->isStructureNode() && $this->authorizationChecker->isGranted('ROLE_PERMISSIONMANAGER')) {
             $tabPane = $event->getTabPane();
             $tabPane->addTab(new Tab('kuma_node.tab.permissions.title', new PermissionsFormWidget($event->getPage(), $event->getNode(), $this->permissionAdmin, $this->permissionMap)));
         }

--- a/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/SlugSecurityListener.php
@@ -28,6 +28,11 @@ class SlugSecurityListener
     protected $nodeMenu;
 
     /**
+     * @var bool
+     */
+    private $permissionsEnabled;
+
+    /**
      * @param EntityManager                 $entityManager
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param NodeMenu                      $nodeMenu
@@ -35,11 +40,13 @@ class SlugSecurityListener
     public function __construct(
         EntityManager $entityManager,
         AuthorizationCheckerInterface $authorizationChecker,
-        NodeMenu $nodeMenu
+        NodeMenu $nodeMenu,
+        $permissionsEnabled = true
     ) {
         $this->em = $entityManager;
         $this->authorizationChecker = $authorizationChecker;
         $this->nodeMenu = $nodeMenu;
+        $this->permissionsEnabled = $permissionsEnabled;
     }
 
     /**
@@ -56,7 +63,7 @@ class SlugSecurityListener
         $nodeTranslation = $event->getNodeTranslation();
         $request = $event->getRequest();
 
-        if (false === $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_VIEW, $node)) {
+        if ($this->permissionsEnabled && false === $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_VIEW, $node)) {
             throw new AccessDeniedException('You do not have sufficient rights to access this page.');
         }
 

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -109,7 +109,11 @@ services:
 
     kunstmaan_node.edit_node.listener:
         class: Kunstmaan\NodeBundle\EventListener\NodeListener
-        arguments: ['@security.authorization_checker', '@kunstmaan_admin.permissionadmin', '@kunstmaan_admin.security.acl.permission.map']
+        arguments:
+            - '@security.authorization_checker'
+            - '@kunstmaan_admin.permissionadmin'
+            - '@kunstmaan_admin.security.acl.permission.map'
+            - '%kunstmaan_node.permissions.enabled%'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.adaptForm, method: adaptForm }
 
@@ -172,7 +176,11 @@ services:
 
     kunstmaan_node.slug.security.listener:
         class: Kunstmaan\NodeBundle\EventListener\SlugSecurityListener
-        arguments: ['@doctrine.orm.entity_manager', '@security.authorization_checker', '@kunstmaan_node.node_menu']
+        arguments:
+            - '@doctrine.orm.entity_manager'
+            - '@security.authorization_checker'
+            - '@kunstmaan_node.node_menu'
+            - '%kunstmaan_node.permissions.enabled%'
         tags:
             - { name: kernel.event_listener, event: kunstmaan_node.slug.security, method: onSlugSecurityEvent }
 

--- a/src/Kunstmaan/NodeBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/DependencyInjection/ConfigurationTest.php
@@ -34,6 +34,7 @@ class ConfigurationTest extends TestCase
                 'check_interval' => 15,
                 'threshold' => 35,
             ],
+            'enable_permissions' => true,
         ];
 
         $this->assertProcessedConfigurationEquals([$array], $array);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This will allow a project to disable the permission module. This will disable the permission checking on frontend pages (VIEW) and in the admin (VIEW, EDIT, (UN)PUBLISH, ...) and will hide the permissions tab in the page admin.
