### PR TITLE
[AdminBundle] Aclvoter should only grant access for supported attributes with disabled permissions 

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
@@ -37,8 +37,21 @@ class AclVoter extends BaseAclVoter
 
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->permissionsEnabled) {
+        $attributeIsSupported = false;
+        foreach ($attributes as $attribute) {
+            if ($this->supportsAttribute($attribute)) {
+                $attributeIsSupported = true;
+
+                break;
+            }
+        }
+
+        if (!$this->permissionsEnabled && $attributeIsSupported) {
             return self::ACCESS_GRANTED;
+        }
+
+        if (!$this->permissionsEnabled) {
+            return self::ACCESS_ABSTAIN;
         }
 
         return parent::vote($token, $object, $attributes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
