### PR TITLE
[GeneratorBundle] getParameter should be called on the controller class

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
@@ -32,7 +32,7 @@ class DefaultController extends AbstractController
     private function getLocale(Request $request)
     {
         $locales = array_filter(
-            explode('|', $this->container->getParameter('requiredlocales'))
+            explode('|', $this->getParameter('requiredlocales'))
         );
         return $request->getPreferredLanguage($locales);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
