### PR TITLE
[GeneratorBundle] Fix doctrine fixtures error during install command

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
@@ -13,8 +13,8 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\OutputInterface;
 use Sensio\Bundle\GeneratorBundle\Command\Validators;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Process\Exception\RuntimeException;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Symfony\Component\Process\Process;
 
 /**
  * Kunstmaan installer
@@ -152,7 +152,7 @@ final class InstallCommand extends GeneratorCommand
             ->executeCommand($output, 'doctrine:database:create')
             ->executeCommand($output, 'doctrine:schema:drop', ['--force' => true])
             ->executeCommand($output, 'doctrine:schema:create')
-            ->executeCommand($output, 'doctrine:fixtures:load')
+            ->executeCommand($output, 'doctrine:fixtures:load', ['-n' => true], true)
             ->executeCommand($output, 'assets:install')
         ;
 
@@ -169,26 +169,29 @@ final class InstallCommand extends GeneratorCommand
         $this->assistant->writeSection('PRO TIP: If you like to use the default frontend setup, run the buildUI.sh script or run the commands separate to compile the frontend assets. ', 'bg=blue;fg=white');
     }
 
-    protected function executeCommand(OutputInterface $output, $command, array $options = [])
+    protected function executeCommand(OutputInterface $output, $command, array $options = [], $separateProcess = false)
     {
-        $options = array_merge(
-            [
-                '--no-debug' => true,
-            ],
-            $options
-        );
+        $options = array_merge(['--no-debug' => true], $options);
 
         ++$this->commandSteps;
 
         try {
-            $updateInput = new ArrayInput($options);
-            $updateInput->setInteractive(true);
-            $this->getApplication()->find($command)->run($updateInput, $output);
+            if ($separateProcess) {
+                $process = new Process(array_merge(['bin/console', $command], array_keys($options)));
+                $process->setTty(true);
+                $process->run();
+
+                if (!$process->isSuccessful()) {
+                    throw new \RuntimeException($process->getErrorOutput());
+                }
+            } else {
+                $updateInput = new ArrayInput($options);
+                $updateInput->setInteractive(true);
+                $this->getApplication()->find($command)->run($updateInput, $output);
+            }
             $output->writeln(sprintf('<info>Step %d: "%s" - [OK]</info>', $this->commandSteps, $command));
-        } catch (RuntimeException $exception) {
-            $output->writeln(sprintf('<error>Step %d: "%s" - [FAILED]</error>', $this->commandSteps, $command));
         } catch (\Throwable $e) {
-            $output->writeln(sprintf('<error>Step %d: "%s" - [FAILED]</error>', $this->commandSteps, $command));
+            $output->writeln(sprintf('<error>Step %d: "%s" - [FAILED] Message: %s</error>', $this->commandSteps, $command, $e->getMessage()));
         }
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Because during the install command the `security.yaml` is replaced by the new security config, this is not available during this run (current container is still loaded in the process), this will make the `doctrine:fixtures:load` command fail with the error `No encoder has been configured for ...`
