### PR TITLE
[AllBundles] Replace deprecated doctrine string entity alias to fqcn

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
@@ -97,7 +97,7 @@ class ApplyAclCommand extends ContainerAwareCommand
     {
         // Check if we have records in running state, if so read PID & check if process is active
         /* @var AclChangeset $runningAclChangeset */
-        $runningAclChangeset = $this->em->getRepository('KunstmaanAdminBundle:AclChangeset')->findRunningChangeset();
+        $runningAclChangeset = $this->em->getRepository(AclChangeset::class)->findRunningChangeset();
         // Found running process, check if PID is still running
         if (!\is_null($runningAclChangeset) && !$this->shellHelper->isRunning($runningAclChangeset->getPid())) {
             // PID not running, process probably failed...

--- a/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
+++ b/src/Kunstmaan/AdminBundle/Controller/DefaultController.php
@@ -34,7 +34,7 @@ class DefaultController extends Controller
         /* @var DashboardConfiguration $dashboardConfiguration */
         $dashboardConfiguration = $this->getDoctrine()
             ->getManager()
-            ->getRepository('KunstmaanAdminBundle:DashboardConfiguration')
+            ->getRepository(DashboardConfiguration::class)
             ->findOneBy(array());
 
         return array('dashboardConfiguration' => $dashboardConfiguration);
@@ -57,7 +57,7 @@ class DefaultController extends Controller
 
         /* @var DashboardConfiguration $dashboardConfiguration */
         $dashboardConfiguration = $em
-            ->getRepository('KunstmaanAdminBundle:DashboardConfiguration')
+            ->getRepository(DashboardConfiguration::class)
             ->findOneBy(array());
 
         if (\is_null($dashboardConfiguration)) {

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Permission/PermissionAdmin.php
@@ -175,7 +175,7 @@ class PermissionAdmin
      */
     public function getAllRoles()
     {
-        return $this->em->getRepository('KunstmaanAdminBundle:Role')->findAll();
+        return $this->em->getRepository(Role::class)->findAll();
     }
 
     /**
@@ -185,7 +185,7 @@ class PermissionAdmin
      */
     public function getManageableRolesForPages()
     {
-        $roles = $this->em->getRepository('KunstmaanAdminBundle:Role')->findAll();
+        $roles = $this->em->getRepository(Role::class)->findAll();
 
         if (($token = $this->tokenStorage->getToken()) && ($user = $token->getUser())) {
             if ($user && !$user->isSuperAdmin() && ($superAdminRole = array_keys($roles, 'ROLE_SUPER_ADMIN'))) {

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle\Helper\Security\OAuth;
 
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Model\GroupInterface;
+use Kunstmaan\AdminBundle\Entity\Group;
 use Kunstmaan\AdminBundle\Entity\User;
 
 class OAuthUserCreator implements OAuthUserCreatorInterface
@@ -58,7 +59,7 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
 
             foreach ($this->getAccessLevels($email) as $accessLevel) {
                 /** @var GroupInterface $group */
-                $group = $this->em->getRepository('KunstmaanAdminBundle:Group')->findOneBy(['name' => $accessLevel]);
+                $group = $this->em->getRepository(Group::class)->findOneBy(['name' => $accessLevel]);
                 if (null !== $group) {
                     $user->addGroup($group);
                 }

--- a/src/Kunstmaan/AdminBundle/Service/AclManager.php
+++ b/src/Kunstmaan/AdminBundle/Service/AclManager.php
@@ -88,7 +88,7 @@ class AclManager
     public function applyAclChangesets()
     {
         /* @var AclChangesetRepository $aclRepo */
-        $aclRepo = $this->em->getRepository('KunstmaanAdminBundle:AclChangeset');
+        $aclRepo = $this->em->getRepository(AclChangeset::class);
         do {
             /* @var AclChangeset $changeset */
             $changeset = $aclRepo->findNewChangeset();

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/Permission/PermissionAdminTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/Security/Acl/Permission/PermissionAdminTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
+use Kunstmaan\AdminBundle\Entity\Role;
 use Kunstmaan\AdminBundle\Entity\User;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\MaskBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionAdmin;
@@ -78,7 +79,7 @@ class PermissionAdminTest extends TestCase
         $em = $this->getEntityManager();
         $em->expects($this->once())
             ->method('getRepository')
-            ->with('KunstmaanAdminBundle:Role')
+            ->with(Role::class)
             ->will($this->returnValue($roleRepo));
         $context = $this->getTokenStorage();
         $aclProvider = $this->getAclProvider();

--- a/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
+++ b/src/Kunstmaan/AdminListBundle/Service/EntityVersionLockService.php
@@ -93,7 +93,7 @@ class EntityVersionLockService
     protected function createEntityVersionLock(User $user, LockableEntity $entity)
     {
         /** @var EntityVersionLock $lock */
-        $lock = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock')->findOneBy([
+        $lock = $this->objectManager->getRepository(EntityVersionLock::class)->findOneBy([
             'owner' => $user->getUsername(),
             'lockableEntity' => $entity,
         ]);
@@ -134,7 +134,7 @@ class EntityVersionLockService
      */
     protected function removeExpiredLocks(LockableEntity $entity)
     {
-        $locks = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock')->getExpiredLocks($entity, $this->threshold);
+        $locks = $this->objectManager->getRepository(EntityVersionLock::class)->getExpiredLocks($entity, $this->threshold);
         foreach ($locks as $lock) {
             $this->objectManager->remove($lock);
         }
@@ -151,7 +151,7 @@ class EntityVersionLockService
     protected function getEntityVersionLocksByLockableEntity(LockableEntity $entity, User $userToExclude = null)
     {
         /** @var EntityVersionLockRepository $objectRepository */
-        $objectRepository = $this->objectManager->getRepository('KunstmaanAdminListBundle:EntityVersionLock');
+        $objectRepository = $this->objectManager->getRepository(EntityVersionLock::class);
 
         return $objectRepository->getLocksForLockableEntity($entity, $this->threshold, $userToExclude);
     }
@@ -166,7 +166,7 @@ class EntityVersionLockService
     protected function getLockableEntity(LockableEntityInterface $entity, $create = true)
     {
         /** @var LockableEntity $lockable */
-        $lockable = $this->objectManager->getRepository('KunstmaanAdminListBundle:LockableEntity')->getOrCreate($entity->getId(), \get_class($entity));
+        $lockable = $this->objectManager->getRepository(LockableEntity::class)->getOrCreate($entity->getId(), \get_class($entity));
 
         if ($create === true && $lockable->getId() === null) {
             $this->objectManager->persist($lockable);

--- a/src/Kunstmaan/AdminListBundle/Tests/unit/Service/EntityVersionLockServiceTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/Service/EntityVersionLockServiceTest.php
@@ -123,8 +123,8 @@ class EntityVersionLockServiceTest extends TestCase
             ->will($this->returnValueMap($lockableMap));
 
         $repositoryMap = [
-            ['KunstmaanAdminListBundle:EntityVersionLock', $mockLockRepository],
-            ['KunstmaanAdminListBundle:LockableEntity', $mockLockableRepository],
+            [EntityVersionLock::class, $mockLockRepository],
+            [LockableEntity::class, $mockLockableRepository],
         ];
         $mockObjectManager = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
             ->disableOriginalConstructor()

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -12,6 +12,7 @@ use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\DateFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
 use Kunstmaan\ArticleBundle\Entity\AbstractArticleOverviewPage;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
 /**
  * The AdminList configurator for the AbstractArticlePage
@@ -91,7 +92,7 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
     protected function getQueryBuilder()
     {
         $queryBuilder = $this->em
-            ->getRepository('KunstmaanNodeBundle:NodeTranslation')
+            ->getRepository(NodeTranslation::class)
             ->createQueryBuilder('b');
 
         return $queryBuilder;

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsConfigsListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\DashboardBundle\Command;
 
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -81,7 +82,7 @@ class GoogleAnalyticsConfigsListCommand extends ContainerAwareCommand
     private function getconfigs()
     {
         // get all segments
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
 
         return $configRepository->findAll();
     }

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataCollectCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsDataCollectCommand.php
@@ -6,7 +6,9 @@ use Kunstmaan\DashboardBundle\Command\Helper\Analytics\ChartDataCommandHelper;
 use Kunstmaan\DashboardBundle\Command\Helper\Analytics\GoalCommandHelper;
 use Kunstmaan\DashboardBundle\Command\Helper\Analytics\MetricsCommandHelper;
 use Kunstmaan\DashboardBundle\Command\Helper\Analytics\UsersCommandHelper;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -159,7 +161,7 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
     private function getSingleOverview($overviewId)
     {
         // get specified overview
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
         $overview = $overviewRepository->find($overviewId);
 
         if (!$overview) {
@@ -179,7 +181,7 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
     private function getOverviewsOfSegment($segmentId)
     {
         // get specified segment
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
         $segment = $segmentRepository->find($segmentId);
 
         if (!$segment) {
@@ -202,9 +204,9 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
      */
     private function getOverviewsOfConfig($configId)
     {
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
         // get specified config
         $config = $configRepository->find($configId);
 
@@ -234,9 +236,9 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
      */
     private function getAllOverviews()
     {
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
         $configs = $configRepository->findAll();
 
         foreach ($configs as $config) {
@@ -299,7 +301,7 @@ class GoogleAnalyticsDataCollectCommand extends ContainerAwareCommand
                 $this->em->persist($overview);
                 $this->em->flush();
 
-                $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->setUpdated($overview->getConfig()->getId());
+                $this->em->getRepository(AnalyticsConfig::class)->setUpdated($overview->getConfig()->getId());
             } catch (\Google_ServiceException $e) {
                 $error = explode(')', $e->getMessage());
                 $error = $error[1];

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsGenerateCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsGenerateCommand.php
@@ -3,6 +3,9 @@
 namespace Kunstmaan\DashboardBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Kunstmaan\DashboardBundle\Repository\AnalyticsSegmentRepository;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -110,7 +113,7 @@ class GoogleAnalyticsOverviewsGenerateCommand extends ContainerAwareCommand
     private function generateOverviewsOfSegment($segmentId)
     {
         /** @var AnalyticsSegmentRepository $segmentRepository */
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
         $segment = $segmentRepository->find($segmentId);
 
         if (!$segment) {
@@ -132,9 +135,9 @@ class GoogleAnalyticsOverviewsGenerateCommand extends ContainerAwareCommand
      */
     private function generateOverviewsOfConfig($configId)
     {
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
         // get specified config
         $config = $configRepository->find($configId);
 
@@ -161,9 +164,9 @@ class GoogleAnalyticsOverviewsGenerateCommand extends ContainerAwareCommand
      */
     private function generateAllOverviews()
     {
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
         $configs = $configRepository->findAll();
 
         foreach ($configs as $config) {

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsOverviewsListCommand.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\DashboardBundle\Command;
 
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -118,7 +121,7 @@ class GoogleAnalyticsOverviewsListCommand extends ContainerAwareCommand
     private function getOverviewsOfSegment($segmentId)
     {
         // get specified segment
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
         $segment = $segmentRepository->find($segmentId);
 
         if (!$segment) {
@@ -139,7 +142,7 @@ class GoogleAnalyticsOverviewsListCommand extends ContainerAwareCommand
     private function getOverviewsOfConfig($configId)
     {
         // get specified config
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
         $config = $configRepository->find($configId);
 
         if (!$config) {
@@ -158,7 +161,7 @@ class GoogleAnalyticsOverviewsListCommand extends ContainerAwareCommand
     private function getAllOverviews()
     {
         // get all overviews
-        $overviewRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+        $overviewRepository = $this->em->getRepository(AnalyticsOverview::class);
 
         return $overviewRepository->findAll();
     }

--- a/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsSegmentsListCommand.php
+++ b/src/Kunstmaan/DashboardBundle/Command/GoogleAnalyticsSegmentsListCommand.php
@@ -2,6 +2,8 @@
 
 namespace Kunstmaan\DashboardBundle\Command;
 
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -103,7 +105,7 @@ class GoogleAnalyticsSegmentsListCommand extends ContainerAwareCommand
     private function getSegmentsOfConfig($configId)
     {
         // get specified config
-        $configRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+        $configRepository = $this->em->getRepository(AnalyticsConfig::class);
         $config = $configRepository->find($configId);
 
         if (!$config) {
@@ -122,7 +124,7 @@ class GoogleAnalyticsSegmentsListCommand extends ContainerAwareCommand
     private function getAllSegments()
     {
         // get all segments
-        $segmentRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment');
+        $segmentRepository = $this->em->getRepository(AnalyticsSegment::class);
 
         return $segmentRepository->findAll();
     }

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsAJAXController.php
@@ -4,7 +4,9 @@ namespace Kunstmaan\DashboardBundle\Controller;
 
 use Kunstmaan\AdminBundle\FlashMessages\FlashTypes;
 use Kunstmaan\DashboardBundle\Command\GoogleAnalyticsDataCollectCommand;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsGoal;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Kunstmaan\DashboardBundle\Repository\AnalyticsOverviewRepository;
 use Symfony\Component\Routing\Annotation\Route;
@@ -42,7 +44,7 @@ class GoogleAnalyticsAJAXController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
         /** @var AnalyticsOverviewRepository $analyticsOverviewRepository */
-        $analyticsOverviewRepository = $em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+        $analyticsOverviewRepository = $em->getRepository(AnalyticsOverview::class);
         $overview = $analyticsOverviewRepository->find($id);
 
         // goals data
@@ -194,7 +196,7 @@ class GoogleAnalyticsAJAXController extends Controller
 
         // edit the config
         $em = $this->getDoctrine()->getManager();
-        $config = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->find($configId);
+        $config = $em->getRepository(AnalyticsConfig::class)->find($configId);
         if ($accountId && $propertyId && $profileId) {
             $config->setAccountId($accountId);
             $config->setPropertyId($propertyId);
@@ -232,7 +234,7 @@ class GoogleAnalyticsAJAXController extends Controller
 
         // edit the config
         $em = $this->getDoctrine()->getManager();
-        $config = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->find($configId);
+        $config = $em->getRepository(AnalyticsConfig::class)->find($configId);
         $em->remove($config);
         $em->flush();
 
@@ -245,7 +247,7 @@ class GoogleAnalyticsAJAXController extends Controller
     public function getConfigAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
-        $config = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->findFirst();
+        $config = $em->getRepository(AnalyticsConfig::class)->findFirst();
         $accountId = $config->getAccountId();
 
         if (!$accountId) {
@@ -276,7 +278,7 @@ class GoogleAnalyticsAJAXController extends Controller
         $segment->setName($name);
 
         // add the segment to the config
-        $config = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->find($configId);
+        $config = $em->getRepository(AnalyticsConfig::class)->find($configId);
         $segment->setConfig($config);
         $segments = $config->getSegments();
         $segments[] = $segment;
@@ -296,7 +298,7 @@ class GoogleAnalyticsAJAXController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $id = $request->query->get('id');
-        $em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment')->deleteSegment($id);
+        $em->getRepository(AnalyticsSegment::class)->deleteSegment($id);
 
         return new JsonResponse();
     }
@@ -311,7 +313,7 @@ class GoogleAnalyticsAJAXController extends Controller
         $id = $request->query->get('id');
         $query = $request->query->get('query');
         $name = $request->query->get('name');
-        $segment = $em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment')->find($id);
+        $segment = $em->getRepository(AnalyticsSegment::class)->find($id);
         $segment->setName($name);
         $segment->setQuery($query);
         $em->persist($segment);

--- a/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
+++ b/src/Kunstmaan/DashboardBundle/Controller/GoogleAnalyticsController.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\DashboardBundle\Controller;
 
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsSegment;
 use Kunstmaan\DashboardBundle\Repository\AnalyticsConfigRepository;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -55,21 +58,21 @@ class GoogleAnalyticsController extends Controller
 
         // get the segment id
         $segmentId = $request->query->get('id');
-        $params['segments'] = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->findFirst()->getSegments();
+        $params['segments'] = $em->getRepository(AnalyticsConfig::class)->findFirst()->getSegments();
         $params['segmentId'] = $segmentId;
 
         // set the overviews param
         $params['token'] = true;
         if ($segmentId) {
-            $overviews = $em->getRepository('KunstmaanDashboardBundle:AnalyticsSegment')->find($segmentId)->getOverviews();
+            $overviews = $em->getRepository(AnalyticsSegment::class)->find($segmentId)->getOverviews();
         } else {
-            $overviews = $em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview')->getDefaultOverviews();
+            $overviews = $em->getRepository(AnalyticsOverview::class)->getDefaultOverviews();
         }
 
-        $params['disableGoals'] = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->findFirst()->getDisableGoals();
+        $params['disableGoals'] = $em->getRepository(AnalyticsConfig::class)->findFirst()->getDisableGoals();
         $params['overviews'] = $overviews;
         /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-        $analyticsConfigRepository = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+        $analyticsConfigRepository = $em->getRepository(AnalyticsConfig::class);
         $date = $analyticsConfigRepository->findFirst()->getLastUpdate();
         if ($date) {
             $params['last_update'] = $date->format('d-m-Y H:i');
@@ -129,7 +132,7 @@ class GoogleAnalyticsController extends Controller
         }
 
         $em = $this->getDoctrine()->getManager();
-        $config = $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->findFirst();
+        $config = $em->getRepository(AnalyticsConfig::class)->findFirst();
 
         $params['accountId'] = $config->getAccountId();
         $params['propertyId'] = 0;
@@ -168,7 +171,7 @@ class GoogleAnalyticsController extends Controller
         $this->denyAccessUnlessGranted('ROLE_SUPER_ADMIN');
 
         $em = $this->getDoctrine()->getManager();
-        $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->resetProfileId();
+        $em->getRepository(AnalyticsConfig::class)->resetProfileId();
 
         return $this->redirect($this->generateUrl('KunstmaanDashboardBundle_ProfileSelection'));
     }
@@ -183,7 +186,7 @@ class GoogleAnalyticsController extends Controller
         $this->denyAccessUnlessGranted('ROLE_SUPER_ADMIN');
 
         $em = $this->getDoctrine()->getManager();
-        $em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->resetPropertyId();
+        $em->getRepository(AnalyticsConfig::class)->resetPropertyId();
 
         return $this->redirect($this->generateUrl('KunstmaanDashboardBundle_Config'));
     }

--- a/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
+++ b/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\DashboardBundle\Helper\Google\Analytics;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
 
 class ConfigHelper
 {
@@ -71,7 +72,7 @@ class ConfigHelper
     {
         if (!$this->token || $configId) {
             /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            $analyticsConfigRepository = $this->em->getRepository(AnalyticsConfig::class);
             if ($configId) {
                 $this->token = $analyticsConfigRepository->find($configId)->getToken();
             } else {
@@ -88,7 +89,7 @@ class ConfigHelper
     public function saveToken($token, $configId = false)
     {
         $this->token = $token;
-        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveToken($token, $configId);
+        $this->em->getRepository(AnalyticsConfig::class)->saveToken($token, $configId);
     }
 
     /**
@@ -133,7 +134,7 @@ class ConfigHelper
     {
         if (!$this->accountId || $configId) {
             /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            $analyticsConfigRepository = $this->em->getRepository(AnalyticsConfig::class);
             if ($configId) {
                 $this->accountId = $analyticsConfigRepository->find($configId)->getAccountId();
             } else {
@@ -150,7 +151,7 @@ class ConfigHelper
     public function saveAccountId($accountId, $configId = false)
     {
         $this->accountId = $accountId;
-        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveAccountId($accountId, $configId);
+        $this->em->getRepository(AnalyticsConfig::class)->saveAccountId($accountId, $configId);
     }
 
     /**
@@ -206,7 +207,7 @@ class ConfigHelper
     {
         if (!$this->propertyId || $configId) {
             /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            $analyticsConfigRepository = $this->em->getRepository(AnalyticsConfig::class);
             if ($configId) {
                 $this->propertyId = $analyticsConfigRepository->find($configId)->getPropertyId();
             } else {
@@ -223,7 +224,7 @@ class ConfigHelper
     public function savePropertyId($propertyId, $configId = false)
     {
         $this->propertyId = $propertyId;
-        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->savePropertyId($propertyId, $configId);
+        $this->em->getRepository(AnalyticsConfig::class)->savePropertyId($propertyId, $configId);
     }
 
     /**
@@ -286,7 +287,7 @@ class ConfigHelper
     {
         if (!$this->profileId || $configId) {
             /** @var AnalyticsConfigRepository $analyticsConfigRepository */
-            $analyticsConfigRepository = $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig');
+            $analyticsConfigRepository = $this->em->getRepository(AnalyticsConfig::class);
             if ($configId) {
                 $this->profileId = $analyticsConfigRepository->find($configId)->getProfileId();
             } else {
@@ -303,7 +304,7 @@ class ConfigHelper
     public function saveProfileId($profileId, $configId = false)
     {
         $this->profileId = $profileId;
-        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveProfileId($profileId, $configId);
+        $this->em->getRepository(AnalyticsConfig::class)->saveProfileId($profileId, $configId);
     }
 
     /**
@@ -379,7 +380,7 @@ class ConfigHelper
      */
     public function saveConfigName($configName, $configId = false)
     {
-        $this->em->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->saveConfigName($configName, $configId);
+        $this->em->getRepository(AnalyticsConfig::class)->saveConfigName($configName, $configId);
     }
 
     /* =============================== AUTH URL =============================== */

--- a/src/Kunstmaan/DashboardBundle/Repository/AnalyticsConfigRepository.php
+++ b/src/Kunstmaan/DashboardBundle/Repository/AnalyticsConfigRepository.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\DashboardBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsOverview;
 
 /**
  * AnalyticsConfigRepository
@@ -45,7 +46,7 @@ class AnalyticsConfigRepository extends EntityRepository
     {
         $em = $this->getEntityManager();
 
-        return $em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview')
+        return $em->getRepository(AnalyticsOverview::class)
             ->findBy(array(
                     'config' => $config,
                     'segment' => null,
@@ -65,7 +66,7 @@ class AnalyticsConfigRepository extends EntityRepository
         $em->persist($config);
         $em->flush();
 
-        $this->getEntityManager()->getRepository('KunstmaanDashboardBundle:AnalyticsOverview')->addOverviews($config);
+        $this->getEntityManager()->getRepository(AnalyticsOverview::class)->addOverviews($config);
 
         return $config;
     }
@@ -81,7 +82,7 @@ class AnalyticsConfigRepository extends EntityRepository
 
         // Backward compatibilty to flush overviews without a config set
         if (!$id) {
-            $overviewRepository = $em->getRepository('KunstmaanDashboardBundle:AnalyticsOverview');
+            $overviewRepository = $em->getRepository(AnalyticsOverview::class);
             foreach ($overviewRepository->findAll() as $overview) {
                 $em->remove($overview);
             }

--- a/src/Kunstmaan/DashboardBundle/Repository/AnalyticsSegmentRepository.php
+++ b/src/Kunstmaan/DashboardBundle/Repository/AnalyticsSegmentRepository.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\DashboardBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Kunstmaan\DashboardBundle\Entity\AnalyticsConfig;
 
 /**
  * AnalyticsSegmentRepository
@@ -45,11 +46,11 @@ class AnalyticsSegmentRepository extends EntityRepository
     {
         if (!\count($segment->getOverviews()->toArray())) {
             if ($configId) {
-                $config = $this->getEntityManager()->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->find($configId);
+                $config = $this->getEntityManager()->getRepository(AnalyticsConfig::class)->find($configId);
             } else {
-                $config = $this->getEntityManager()->getRepository('KunstmaanDashboardBundle:AnalyticsConfig')->findFirst();
+                $config = $this->getEntityManager()->getRepository(AnalyticsConfig::class)->findFirst();
             }
-            $this->getEntityManager()->getRepository('KunstmaanDashboardBundle:AnalyticsOverview')->addOverviews($config, $segment);
+            $this->getEntityManager()->getRepository(AnalyticsOverview::class)->addOverviews($config, $segment);
         }
     }
 }

--- a/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/MediaBuilder.php
@@ -47,10 +47,10 @@ class MediaBuilder implements BuilderInterface
             throw new \Exception('There is no folder specified for media fixture ' . $fixture->getName());
         }
 
-        $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('rel' => $properties['folder']));
+        $this->folder = $this->em->getRepository(Folder::class)->findOneBy(array('rel' => $properties['folder']));
 
         if (!$this->folder instanceof Folder) {
-            $this->folder = $this->em->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('internalName' => $properties['folder']));
+            $this->folder = $this->em->getRepository(Folder::class)->findOneBy(array('internalName' => $properties['folder']));
         }
 
         if (!$this->folder instanceof Folder) {

--- a/src/Kunstmaan/FixturesBundle/Builder/PageBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/PageBuilder.php
@@ -46,8 +46,8 @@ class PageBuilder implements BuilderInterface
         string $userClass
     ) {
         $this->manager = $em;
-        $this->nodeRepo = $em->getRepository('KunstmaanNodeBundle:Node');
-        $this->nodeTranslationRepo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
+        $this->nodeRepo = $em->getRepository(Node::class);
+        $this->nodeTranslationRepo = $em->getRepository(NodeTranslation::class);
         $this->userRepo = $em->getRepository($userClass);
         $this->aclPermissionCreatorService = $aclPermissionCreatorService;
         $this->populator = $populator;

--- a/src/Kunstmaan/FixturesBundle/Builder/PagePartBuilder.php
+++ b/src/Kunstmaan/FixturesBundle/Builder/PagePartBuilder.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\FixturesBundle\Builder;
 use Doctrine\ORM\EntityManager;
 use Kunstmaan\FixturesBundle\Loader\Fixture;
 use Kunstmaan\FixturesBundle\Populator\Populator;
+use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 
 class PagePartBuilder implements BuilderInterface
@@ -21,7 +22,7 @@ class PagePartBuilder implements BuilderInterface
     public function __construct(EntityManager $em, Populator $populator)
     {
         $this->em = $em;
-        $this->pagePartRepo = $em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        $this->pagePartRepo = $em->getRepository(PagePartRef::class);
         $this->populator = $populator;
     }
 

--- a/src/Kunstmaan/FixturesBundle/Provider/NodeTranslation.php
+++ b/src/Kunstmaan/FixturesBundle/Provider/NodeTranslation.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\FixturesBundle\Provider;
 
 use Doctrine\ORM\EntityManager;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation as NodeBundleNodeTranslation;
 
 class NodeTranslation
 {
@@ -10,7 +11,7 @@ class NodeTranslation
 
     public function __construct(EntityManager $em)
     {
-        $this->nodeTransRepo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
+        $this->nodeTransRepo = $em->getRepository(NodeBundleNodeTranslation::class);
     }
 
     public function getTranslationByTitle($title, $lang)

--- a/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
+++ b/src/Kunstmaan/FormBundle/Controller/FormSubmissionsController.php
@@ -9,6 +9,9 @@ use Kunstmaan\AdminListBundle\AdminList\ExportList;
 use Kunstmaan\FormBundle\AdminList\FormPageAdminListConfigurator;
 use Kunstmaan\FormBundle\AdminList\FormSubmissionAdminListConfigurator;
 use Kunstmaan\FormBundle\AdminList\FormSubmissionExportListConfigurator;
+use Kunstmaan\FormBundle\Entity\FormSubmission;
+use Kunstmaan\FormBundle\Entity\FormSubmissionField;
+use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -60,7 +63,7 @@ class FormSubmissionsController extends Controller
     public function listAction(Request $request, $nodeTranslationId)
     {
         $em = $this->getDoctrine()->getManager();
-        $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->find($nodeTranslationId);
+        $nodeTranslation = $em->getRepository(NodeTranslation::class)->find($nodeTranslationId);
 
         /** @var AdminList $adminList */
         $adminList = $this->get('kunstmaan_adminlist.factory')->createList(
@@ -86,8 +89,8 @@ class FormSubmissionsController extends Controller
     public function editAction($nodeTranslationId, $submissionId)
     {
         $em = $this->getDoctrine()->getManager();
-        $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->find($nodeTranslationId);
-        $formSubmission = $em->getRepository('KunstmaanFormBundle:FormSubmission')->find($submissionId);
+        $nodeTranslation = $em->getRepository(NodeTranslation::class)->find($nodeTranslationId);
+        $formSubmission = $em->getRepository(FormSubmission::class)->find($submissionId);
         $request = $this->container->get('request_stack')->getCurrentRequest();
         $deletableFormsubmission = $this->getParameter('kunstmaan_form.deletable_formsubmissions');
 
@@ -118,7 +121,7 @@ class FormSubmissionsController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
         /** @var NodeTranslation $nodeTranslation */
-        $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->find($nodeTranslationId);
+        $nodeTranslation = $em->getRepository(NodeTranslation::class)->find($nodeTranslationId);
         $translator = $this->get('translator');
 
         /** @var ExportList $exportList */
@@ -146,9 +149,9 @@ class FormSubmissionsController extends Controller
     public function deleteAction(Request $request, $id)
     {
         $em = $this->getDoctrine()->getManager();
-        $submission = $em->getRepository('KunstmaanFormBundle:FormSubmission')->find($id);
+        $submission = $em->getRepository(FormSubmission::class)->find($id);
 
-        $node = $em->getRepository('KunstmaanNodeBundle:Node')->find($submission->getNode());
+        $node = $em->getRepository(Node::class)->find($submission->getNode());
         $nt = $node->getNodeTranslation($request->getLocale());
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_DELETE, $node);
@@ -158,7 +161,7 @@ class FormSubmissionsController extends Controller
             ['nodeTranslationId' => $nt->getId()]
         );
 
-        $fields = $em->getRepository('KunstmaanFormBundle:FormSubmissionField')->findBy(['formSubmission' => $submission]);
+        $fields = $em->getRepository(FormSubmissionField::class)->findBy(['formSubmission' => $submission]);
 
         try {
             foreach ($fields as $field) {

--- a/src/Kunstmaan/GeneratorBundle/Generator/PagePartGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/PagePartGenerator.php
@@ -5,6 +5,8 @@ namespace Kunstmaan\GeneratorBundle\Generator;
 use Faker\Provider\Base;
 use Faker\Provider\DateTime;
 use Faker\Provider\Lorem;
+use Kunstmaan\MediaBundle\Entity\Folder;
+use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -82,7 +84,7 @@ class PagePartGenerator extends KunstmaanGenerator
             $abstractClass = 'Kunstmaan\PagePartBundle\Entity\AbstractPagePart';
         }
 
-        list($entityCode, $entityPath) = $this->generateEntity(
+        [$entityCode, $entityPath] = $this->generateEntity(
             $this->bundle,
             $this->entity,
             $this->fields,
@@ -286,8 +288,8 @@ class PagePartGenerator extends KunstmaanGenerator
             )
         */
 
-        $folder = $this->registry->getRepository('KunstmaanMediaBundle:Folder')->findOneBy(array('rel' => 'image'));
-        $images = $this->registry->getRepository('KunstmaanMediaBundle:Media')->findBy(
+        $folder = $this->registry->getRepository(Folder::class)->findOneBy(array('rel' => 'image'));
+        $images = $this->registry->getRepository(Media::class)->findBy(
             array('folder' => $folder, 'deleted' => false),
             array(),
             2

--- a/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
+++ b/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
@@ -203,6 +203,6 @@ class RulesAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getPopup()
     {
-        return $this->em->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->find($this->getPopupId());
+        return $this->em->getRepository(AbstractPopup::class)->find($this->getPopupId());
     }
 }

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractNewsletterController.php
@@ -17,8 +17,8 @@ abstract class AbstractNewsletterController extends Controller
      */
     public function indexAction($popup)
     {
-        /** @var \Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup $thePopup */
-        $thePopup = $this->getDoctrine()->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->find($popup);
+        /** @var AbstractPopup $thePopup */
+        $thePopup = $this->getDoctrine()->getRepository(AbstractPopup::class)->find($popup);
         $form = $this->createSubscriptionForm($thePopup);
 
         return $this->render($this->getIndexTemplate(), array(
@@ -33,8 +33,8 @@ abstract class AbstractNewsletterController extends Controller
      */
     public function subscribeAction(Request $request, $popup)
     {
-        /** @var \Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup $thePopup */
-        $thePopup = $this->getDoctrine()->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->find($popup);
+        /** @var AbstractPopup $thePopup */
+        $thePopup = $this->getDoctrine()->getRepository(AbstractPopup::class)->find($popup);
         $form = $this->createSubscriptionForm($thePopup);
 
         $form->handleRequest($request);

--- a/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Controller/AbstractRedirectController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\LeadGenerationBundle\Controller;
 
+use Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -12,8 +13,8 @@ abstract class AbstractRedirectController extends Controller
      */
     public function indexAction($popup)
     {
-        /** @var \Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup $thePopup */
-        $thePopup = $this->getDoctrine()->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->find($popup);
+        /** @var AbstractPopup $thePopup */
+        $thePopup = $this->getDoctrine()->getRepository(AbstractPopup::class)->find($popup);
 
         return $this->render($this->getIndexTemplate(), array(
             'popup' => $thePopup,

--- a/src/Kunstmaan/LeadGenerationBundle/Service/PopupManager.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Service/PopupManager.php
@@ -40,7 +40,7 @@ class PopupManager
     public function getPopups()
     {
         if (\is_null($this->popups)) {
-            $this->popups = $this->em->getRepository('KunstmaanLeadGenerationBundle:Popup\AbstractPopup')->findAll();
+            $this->popups = $this->em->getRepository(AbstractPopup::class)->findAll();
         }
 
         return $this->popups;

--- a/src/Kunstmaan/MediaBundle/Controller/AviaryController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/AviaryController.php
@@ -29,9 +29,9 @@ class AviaryController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
         /* @var Media $media */
-        $media = $em->getRepository('KunstmaanMediaBundle:Media')->getMedia($mediaId);
+        $media = $em->getRepository(Media::class)->getMedia($mediaId);
         /* @var MediaManager $mediaManager */
         $mediaManager = $this->get('kunstmaan_media.media_manager');
 

--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -40,7 +40,7 @@ class ChooserController extends Controller
         // Go to the last visited folder
         if ($session->get('last-media-folder')) {
             try {
-                $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($session->get('last-media-folder'));
+                $em->getRepository(Folder::class)->getFolder($session->get('last-media-folder'));
                 $folderId = $session->get('last-media-folder');
             } catch (EntityNotFoundException $e) {
                 $folderId = false;
@@ -50,7 +50,7 @@ class ChooserController extends Controller
         if (!$folderId) {
             // Redirect to the first top folder
             /* @var Folder $firstFolder */
-            $firstFolder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFirstTopFolder();
+            $firstFolder = $em->getRepository(Folder::class)->getFirstTopFolder();
             $folderId = $firstFolder->getId();
         }
 
@@ -97,7 +97,7 @@ class ChooserController extends Controller
         $mediaHandler = $this->get('kunstmaan_media.media_manager');
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         /** @var AbstractMediaHandler $handler */
         $handler = null;

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -49,7 +49,7 @@ class FolderController extends Controller
         $mediaManager = $this->get('kunstmaan_media.media_manager');
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         $adminListConfigurator = new MediaAdminListConfigurator($em, $mediaManager, $folder, $request);
         $adminList = $this->get('kunstmaan_adminlist.factory')->createList($adminListConfigurator);
@@ -66,7 +66,7 @@ class FolderController extends Controller
         if ($request->isMethod('POST')) {
             $editForm->handleRequest($request);
             if ($editForm->isValid()) {
-                $em->getRepository('KunstmaanMediaBundle:Folder')->save($folder);
+                $em->getRepository(Folder::class)->save($folder);
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
@@ -110,7 +110,7 @@ class FolderController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
         $folderName = $folder->getName();
         $parentFolder = $folder->getParent();
 
@@ -122,7 +122,7 @@ class FolderController extends Controller
                 ))
             );
         } else {
-            $em->getRepository('KunstmaanMediaBundle:Folder')->delete($folder);
+            $em->getRepository(Folder::class)->delete($folder);
             $this->addFlash(
                 FlashTypes::SUCCESS,
                 $this->get('translator')->trans('media.folder.delete.success.text', array(
@@ -163,14 +163,14 @@ class FolderController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $parent */
-        $parent = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $parent = $em->getRepository(Folder::class)->getFolder($folderId);
         $folder = new Folder();
         $folder->setParent($parent);
         $form = $this->createForm(FolderType::class, $folder);
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
-                $em->getRepository('KunstmaanMediaBundle:Folder')->save($folder);
+                $em->getRepository(Folder::class)->save($folder);
                 $this->addFlash(
                     FlashTypes::SUCCESS,
                     $this->get('translator')->trans('media.folder.addsub.success.text', array(
@@ -196,7 +196,7 @@ class FolderController extends Controller
             }
         }
 
-        $galleries = $em->getRepository('KunstmaanMediaBundle:Folder')->getAllFolders();
+        $galleries = $em->getRepository(Folder::class)->getAllFolders();
 
         return $this->render(
             '@KunstmaanMedia/Folder/addsub-modal.html.twig',
@@ -223,7 +223,7 @@ class FolderController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         $form = $this->createEmptyForm();
 
@@ -233,7 +233,7 @@ class FolderController extends Controller
                 $data = $form->getData();
                 $alsoDeleteFolders = $data['checked'];
 
-                $em->getRepository('KunstmaanMediaBundle:Folder')->emptyFolder($folder, $alsoDeleteFolders);
+                $em->getRepository(Folder::class)->emptyFolder($folder, $alsoDeleteFolders);
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
@@ -279,7 +279,7 @@ class FolderController extends Controller
         $nodeIds = $request->get('nodes');
 
         $em = $this->getDoctrine()->getManager();
-        $repository = $em->getRepository('KunstmaanMediaBundle:Folder');
+        $repository = $em->getRepository(Folder::class);
 
         foreach ($nodeIds as $id) {
             /* @var Folder $folder */

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -35,7 +35,7 @@ class MediaController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Media $media */
-        $media = $em->getRepository('KunstmaanMediaBundle:Media')->getMedia($mediaId);
+        $media = $em->getRepository(Media::class)->getMedia($mediaId);
         $folder = $media->getFolder();
 
         /* @var MediaManager $mediaManager */
@@ -49,7 +49,7 @@ class MediaController extends Controller
             $form->handleRequest($request);
             if ($form->isSubmitted() && $form->isValid()) {
                 $media = $helper->getMedia();
-                $em->getRepository('KunstmaanMediaBundle:Media')->save($media);
+                $em->getRepository(Media::class)->save($media);
 
                 return new RedirectResponse(
                     $this->generateUrl(
@@ -88,11 +88,11 @@ class MediaController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Media $media */
-        $media = $em->getRepository('KunstmaanMediaBundle:Media')->getMedia($mediaId);
+        $media = $em->getRepository(Media::class)->getMedia($mediaId);
         $medianame = $media->getName();
         $folder = $media->getFolder();
 
-        $em->getRepository('KunstmaanMediaBundle:Media')->delete($media);
+        $em->getRepository(Media::class)->delete($media);
 
         $this->addFlash(
             FlashTypes::SUCCESS,
@@ -129,7 +129,7 @@ class MediaController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         return ['folder' => $folder];
     }
@@ -240,7 +240,7 @@ class MediaController extends Controller
 
         $em = $this->getDoctrine()->getManager();
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
         $file = new File($filePath);
 
         try {
@@ -301,7 +301,7 @@ class MediaController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         $drop = null;
 
@@ -317,7 +317,7 @@ class MediaController extends Controller
         $media = $this->get('kunstmaan_media.media_manager')->createNew($drop);
         if ($media) {
             $media->setFolder($folder);
-            $em->getRepository('KunstmaanMediaBundle:Media')->save($media);
+            $em->getRepository(Media::class)->save($media);
 
             return new JsonResponse(['status' => $this->get('translator')->trans('kuma_admin.media.flash.drop_success')]);
         }
@@ -359,7 +359,7 @@ class MediaController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         /* @var Folder $folder */
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         /* @var MediaManager $mediaManager */
         $mediaManager = $this->get('kunstmaan_media.media_manager');
@@ -378,7 +378,7 @@ class MediaController extends Controller
             if ($form->isSubmitted() && $form->isValid()) {
                 $media = $helper->getMedia();
                 $media->setFolder($folder);
-                $em->getRepository('KunstmaanMediaBundle:Media')->save($media);
+                $em->getRepository(Media::class)->save($media);
 
                 $this->addFlash(
                     FlashTypes::SUCCESS,
@@ -466,10 +466,10 @@ class MediaController extends Controller
         }
 
         $em = $this->getDoctrine()->getManager();
-        $mediaRepo = $em->getRepository('KunstmaanMediaBundle:Media');
+        $mediaRepo = $em->getRepository(Media::class);
 
         $media = $mediaRepo->getMedia($mediaId);
-        $folder = $em->getRepository('KunstmaanMediaBundle:Folder')->getFolder($folderId);
+        $folder = $em->getRepository(Folder::class)->getFolder($folderId);
 
         $media->setFolder($folder);
         $mediaRepo->save($media);
@@ -489,7 +489,7 @@ class MediaController extends Controller
     public function bulkMoveAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
-        $mediaRepo = $em->getRepository('KunstmaanMediaBundle:Media');
+        $mediaRepo = $em->getRepository(Media::class);
         $form = $this->createForm(BulkMoveMediaType::class);
 
         $form->handleRequest($request);

--- a/src/Kunstmaan/MediaBundle/Form/Type/IdToMediaTransformer.php
+++ b/src/Kunstmaan/MediaBundle/Form/Type/IdToMediaTransformer.php
@@ -77,7 +77,7 @@ class IdToMediaTransformer implements DataTransformerInterface
         if (!is_numeric($key)) {
             throw new UnexpectedTypeException($key, 'numeric');
         }
-        if (!($entity = $this->objectManager->getRepository('KunstmaanMediaBundle:Media')->find($key))) {
+        if (!($entity = $this->objectManager->getRepository(Media::class)->find($key))) {
             throw new TransformationFailedException(sprintf('The entity with key "%s" could not be found', $key));
         }
         $this->currentValueContainer->setCurrentValue($entity);

--- a/src/Kunstmaan/MediaBundle/Repository/MediaRepository.php
+++ b/src/Kunstmaan/MediaBundle/Repository/MediaRepository.php
@@ -60,7 +60,7 @@ class MediaRepository extends EntityRepository
     {
         $em = $this->getEntityManager();
 
-        $picture = $em->getRepository('KunstmaanMediaBundle:Image')->find($pictureId);
+        $picture = $em->getRepository(\Kunstmaan\MediaBundle\Entity\Image::class)->find($pictureId);
         if (!$picture) {
             throw new EntityNotFoundException();
         }

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -177,7 +177,7 @@ class DomainConfiguration extends BaseDomainConfiguration
             $host = $this->getRealHost($host);
 
             $internalName = $this->hosts[$host]['root'];
-            $nodeRepo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+            $nodeRepo = $this->em->getRepository(Node::class);
             $this->rootNode = $nodeRepo->getNodeByInternalName($internalName);
         }
 

--- a/src/Kunstmaan/MultiDomainBundle/Tests/unit/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/unit/Helper/DomainConfigurationTest.php
@@ -279,7 +279,7 @@ class DomainConfigurationTest extends TestCase
         $em = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $em
             ->method('getRepository')
-            ->with($this->equalTo('KunstmaanNodeBundle:Node'))
+            ->with($this->equalTo(Node::class))
             ->willReturn($this->getNodeRepository());
 
         return $em;

--- a/src/Kunstmaan/MultiDomainBundle/Tests/unit/Router/DomainBasedLocaleRouterTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/unit/Router/DomainBasedLocaleRouterTest.php
@@ -197,7 +197,7 @@ class DomainBasedLocaleRouterTest extends TestCase
         $em = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $em
             ->method('getRepository')
-            ->with($this->equalTo('KunstmaanNodeBundle:NodeTranslation'))
+            ->with($this->equalTo(NodeTranslation::class))
             ->willReturn($this->getNodeTranslationRepository($nodeTranslation));
 
         return $em;

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -21,6 +21,7 @@ use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
+use Kunstmaan\NodeBundle\Entity\QueuedNodeTranslationAction;
 use Kunstmaan\NodeBundle\Event\AdaptFormEvent;
 use Kunstmaan\NodeBundle\Event\CopyPageTranslationNodeEvent;
 use Kunstmaan\NodeBundle\Event\Events;
@@ -167,7 +168,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
@@ -179,7 +180,7 @@ class NodeAdminController extends Controller
             ->deepCloneAndSave($otherLanguagePage);
 
         /* @var NodeTranslation $nodeTranslation */
-        $nodeTranslation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $nodeTranslation = $this->em->getRepository(NodeTranslation::class)
             ->createNodeTranslationFor($myLanguagePage, $this->locale, $node, $this->user);
         $nodeVersion = $nodeTranslation->getPublicNodeVersion();
 
@@ -219,18 +220,18 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
-        $otherLanguageNodeTranslation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')->find($request->get('source'));
+        $otherLanguageNodeTranslation = $this->em->getRepository(NodeTranslation::class)->find($request->get('source'));
         $otherLanguageNodeNodeVersion = $otherLanguageNodeTranslation->getPublicNodeVersion();
         $otherLanguagePage = $otherLanguageNodeNodeVersion->getRef($this->em);
         $myLanguagePage = $this->get('kunstmaan_admin.clone.helper')
             ->deepCloneAndSave($otherLanguagePage);
 
         /* @var NodeTranslation $nodeTranslation */
-        $nodeTranslation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $nodeTranslation = $this->em->getRepository(NodeTranslation::class)
             ->addDraftNodeVersionFor($myLanguagePage, $this->locale, $node, $this->user);
         $nodeVersion = $nodeTranslation->getPublicNodeVersion();
 
@@ -270,7 +271,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
@@ -282,7 +283,7 @@ class NodeAdminController extends Controller
         $this->em->persist($myLanguagePage);
         $this->em->flush();
         /* @var NodeTranslation $nodeTranslation */
-        $nodeTranslation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $nodeTranslation = $this->em->getRepository(NodeTranslation::class)
             ->createNodeTranslationFor($myLanguagePage, $this->locale, $node, $this->user);
         $nodeVersion = $nodeTranslation->getPublicNodeVersion();
 
@@ -310,7 +311,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $nodeTranslation = $node->getNodeTranslation($this->locale, true);
         $request = $this->get('request_stack')->getCurrentRequest();
@@ -338,7 +339,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $nodeTranslation = $node->getNodeTranslation($this->locale, true);
         $request = $this->get('request_stack')->getCurrentRequest();
@@ -367,7 +368,7 @@ class NodeAdminController extends Controller
         $this->init($request);
 
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $nodeTranslation = $node->getNodeTranslation($this->locale, true);
         $this->nodePublisher->unSchedulePublish($nodeTranslation);
@@ -399,7 +400,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_DELETE, $node);
 
@@ -464,7 +465,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $parentNode */
-        $originalNode = $this->em->getRepository('KunstmaanNodeBundle:Node')
+        $originalNode = $this->em->getRepository(Node::class)
             ->find($id);
 
         // Check with Acl
@@ -493,7 +494,7 @@ class NodeAdminController extends Controller
         $this->em->flush();
 
         /* @var Node $nodeNewPage */
-        $nodeNewPage = $this->em->getRepository('KunstmaanNodeBundle:Node')->createNodeFor(
+        $nodeNewPage = $this->em->getRepository(Node::class)->createNodeFor(
             $newPage,
             $this->locale,
             $this->user
@@ -539,7 +540,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
@@ -550,7 +551,7 @@ class NodeAdminController extends Controller
         }
 
         /* @var NodeVersionRepository $nodeVersionRepo */
-        $nodeVersionRepo = $this->em->getRepository('KunstmaanNodeBundle:NodeVersion');
+        $nodeVersionRepo = $this->em->getRepository(NodeVersion::class);
         /* @var NodeVersion $nodeVersion */
         $nodeVersion = $nodeVersionRepo->find($version);
 
@@ -624,7 +625,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $parentNode */
-        $parentNode = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $parentNode = $this->em->getRepository(Node::class)->find($id);
 
         // Check with Acl
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $parentNode);
@@ -638,13 +639,13 @@ class NodeAdminController extends Controller
         $newPage->setParent($parentPage);
 
         /* @var Node $nodeNewPage */
-        $nodeNewPage = $this->em->getRepository('KunstmaanNodeBundle:Node')
+        $nodeNewPage = $this->em->getRepository(Node::class)
             ->createNodeFor($newPage, $this->locale, $this->user);
         $nodeTranslation = $nodeNewPage->getNodeTranslation(
             $this->locale,
             true
         );
-        $weight = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $weight = $this->em->getRepository(NodeTranslation::class)
                 ->getMaxChildrenWeight($parentNode, $this->locale) + 1;
         $nodeTranslation->setWeight($weight);
 
@@ -694,7 +695,7 @@ class NodeAdminController extends Controller
         $newPage = $this->createNewPage($request, $type);
 
         /* @var Node $nodeNewPage */
-        $nodeNewPage = $this->em->getRepository('KunstmaanNodeBundle:Node')
+        $nodeNewPage = $this->em->getRepository(Node::class)
             ->createNodeFor($newPage, $this->locale, $this->user);
         $nodeTranslation = $nodeNewPage->getNodeTranslation(
             $this->locale,
@@ -741,7 +742,7 @@ class NodeAdminController extends Controller
 
         foreach ($nodeIds as $id) {
             /* @var Node $node */
-            $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+            $node = $this->em->getRepository(Node::class)->find($id);
             $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
             $nodes[] = $node;
         }
@@ -750,7 +751,7 @@ class NodeAdminController extends Controller
         foreach ($nodes as $node) {
             $newParentId = isset($changeParents[$node->getId()]) ? $changeParents[$node->getId()] : null;
             if ($newParentId) {
-                $parent = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($newParentId);
+                $parent = $this->em->getRepository(Node::class)->find($newParentId);
                 $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $parent);
                 $node->setParent($parent);
                 $this->em->persist($node);
@@ -811,7 +812,7 @@ class NodeAdminController extends Controller
     {
         $this->init($request);
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
@@ -988,15 +989,11 @@ class NodeAdminController extends Controller
             }
         }
 
-        $nodeVersions = $this->em->getRepository(
-            'KunstmaanNodeBundle:NodeVersion'
-        )->findBy(
+        $nodeVersions = $this->em->getRepository(NodeVersion::class)->findBy(
             ['nodeTranslation' => $nodeTranslation],
             ['updated' => 'ASC']
         );
-        $queuedNodeTranslationAction = $this->em->getRepository(
-            'KunstmaanNodeBundle:QueuedNodeTranslationAction'
-        )->findOneBy(['nodeTranslation' => $nodeTranslation]);
+        $queuedNodeTranslationAction = $this->em->getRepository(QueuedNodeTranslationAction::class)->findOneBy(['nodeTranslation' => $nodeTranslation]);
 
         return [
             'page' => $page,
@@ -1035,7 +1032,7 @@ class NodeAdminController extends Controller
         $this->init($request);
 
         /* @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->find($id);
+        $node = $this->em->getRepository(Node::class)->find($id);
 
         try {
             $this->checkPermission($node, PermissionMap::PERMISSION_EDIT);
@@ -1094,7 +1091,7 @@ class NodeAdminController extends Controller
         /* @var NodeVersion $publicNodeVersion */
 
         $publicNodeVersion = $this->em->getRepository(
-            'KunstmaanNodeBundle:NodeVersion'
+            NodeVersion::class
         )->createNodeVersionFor(
             $publicPage,
             $nodeTranslation,
@@ -1248,7 +1245,7 @@ class NodeAdminController extends Controller
 
             if ($parentNodeTranslation) {
                 $parentsAreOk = $this->em->getRepository(
-                    'KunstmaanNodeBundle:NodeTranslation'
+                    NodeTranslation::class
                 )->hasParentNodeTranslationsForLanguage(
                     $node->getParent()->getNodeTranslation(
                         $this->locale,

--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Event\SlugEvent;
 use Kunstmaan\NodeBundle\Event\SlugSecurityEvent;
@@ -129,7 +130,7 @@ class SlugController extends Controller
         if ($preview) {
             $version = $request->get('version');
             if (!empty($version) && is_numeric($version)) {
-                $nodeVersion = $em->getRepository('KunstmaanNodeBundle:NodeVersion')->find($version);
+                $nodeVersion = $em->getRepository(NodeVersion::class)->find($version);
                 if (!\is_null($nodeVersion)) {
                     $entity = $nodeVersion->getRef($em);
                 }

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -75,7 +75,7 @@ class WidgetsController extends Controller
 
         $results = [];
         if ($search) {
-            $nts = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getNodeTranslationsLikeTitle($search, $locale);
+            $nts = $em->getRepository(NodeTranslation::class)->getNodeTranslationsLikeTitle($search, $locale);
             /** @var NodeTranslation $nt */
             foreach ($nts as $nt) {
                 $node = $nt->getNode();
@@ -116,10 +116,10 @@ class WidgetsController extends Controller
                 $switchedHost = $domainConfig->getHostSwitched();
                 $rootItems = [$domainConfig->getRootNode($switchedHost['host'])];
             } else {
-                $rootItems = $em->getRepository('KunstmaanNodeBundle:Node')->getAllTopNodes();
+                $rootItems = $em->getRepository(Node::class)->getAllTopNodes();
             }
         } else {
-            $rootItems = $em->getRepository('KunstmaanNodeBundle:Node')->find($id)->getChildren();
+            $rootItems = $em->getRepository(Node::class)->find($id)->getChildren();
         }
 
         $results = $this->nodesToArray($locale, $rootItems, $depth);

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Kunstmaan\NodeBundle\Entity\NodeVersion;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
@@ -71,7 +72,7 @@ class RenderContextListener
             if ($request->get('preview') === true) {
                 $version = $request->get('version');
                 if (!empty($version) && is_numeric($version)) {
-                    $nodeVersion = $this->em->getRepository('KunstmaanNodeBundle:NodeVersion')->find($version);
+                    $nodeVersion = $this->em->getRepository(NodeVersion::class)->find($version);
                     if (!\is_null($nodeVersion)) {
                         $entity = $nodeVersion->getRef($this->em);
                     }

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/ActionsMenuBuilder.php
@@ -8,6 +8,7 @@ use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
+use Kunstmaan\NodeBundle\Entity\QueuedNodeTranslationAction;
 use Kunstmaan\NodeBundle\Event\ConfigureActionMenuEvent;
 use Kunstmaan\NodeBundle\Event\Events;
 use Kunstmaan\NodeBundle\Helper\PagesConfiguration;
@@ -164,9 +165,7 @@ class ActionsMenuBuilder
 
         $activeNodeTranslation = $activeNodeVersion->getNodeTranslation();
         $node = $activeNodeTranslation->getNode();
-        $queuedNodeTranslationAction = $this->em->getRepository(
-            'KunstmaanNodeBundle:QueuedNodeTranslationAction'
-        )->findOneBy(['nodeTranslation' => $activeNodeTranslation]);
+        $queuedNodeTranslationAction = $this->em->getRepository(QueuedNodeTranslationAction::class)->findOneBy(['nodeTranslation' => $activeNodeTranslation]);
 
         $isFirst = true;
         $canEdit = $this->authorizationChecker->isGranted(PermissionMap::PERMISSION_EDIT, $node);

--- a/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
@@ -144,7 +144,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
         $includeHiddenFromNav
     ) {
         if (null === $this->treeNodes) {
-            $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+            $repo = $this->em->getRepository(Node::class);
             $this->treeNodes = [];
 
             $rootNode = $this->domainConfiguration->getRootNode();
@@ -184,7 +184,7 @@ class PageMenuAdaptor implements MenuAdaptorInterface
     private function getActiveNodeIds($request)
     {
         if ((null === $this->activeNodeIds) && strncasecmp($request->attributes->get('_route'), 'KunstmaanNodeBundle_nodes_edit', 30) === 0) {
-            $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+            $repo = $this->em->getRepository(Node::class);
 
             $currentNode = $repo->findOneById($request->attributes->get('id'));
             $parentNodes = $repo->getAllParents($currentNode);

--- a/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeAdminPublisher.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeAdminPublisher.php
@@ -213,7 +213,7 @@ class NodeAdminPublisher
     public function unSchedulePublish(NodeTranslation $nodeTranslation)
     {
         /* @var Node $node */
-        $queuedNodeTranslationAction = $this->em->getRepository('KunstmaanNodeBundle:QueuedNodeTranslationAction')
+        $queuedNodeTranslationAction = $this->em->getRepository(QueuedNodeTranslationAction::class)
             ->findOneBy(array('nodeTranslation' => $nodeTranslation));
 
         if (!\is_null($queuedNodeTranslationAction)) {
@@ -239,7 +239,7 @@ class NodeAdminPublisher
         BaseUser $user
     ) {
         $newPublicPage = $this->cloneHelper->deepCloneAndSave($page);
-        $newNodeVersion = $this->em->getRepository('KunstmaanNodeBundle:NodeVersion')->createNodeVersionFor(
+        $newNodeVersion = $this->em->getRepository(NodeVersion::class)->createNodeVersionFor(
             $newPublicPage,
             $nodeTranslation,
             $user,

--- a/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeVersionLockHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeVersionLockHelper.php
@@ -80,7 +80,7 @@ class NodeVersionLockHelper implements ContainerAwareInterface
     protected function removeExpiredLocks(NodeTranslation $nodeTranslation)
     {
         $threshold = $this->container->getParameter('kunstmaan_node.lock_threshold');
-        $locks = $this->objectManager->getRepository('KunstmaanNodeBundle:NodeVersionLock')->getExpiredLocks($nodeTranslation, $threshold);
+        $locks = $this->objectManager->getRepository(NodeVersionLock::class)->getExpiredLocks($nodeTranslation, $threshold);
         foreach ($locks as $lock) {
             $this->objectManager->remove($lock);
         }
@@ -95,7 +95,7 @@ class NodeVersionLockHelper implements ContainerAwareInterface
      */
     protected function createNodeVersionLock(BaseUser $user, NodeTranslation $nodeTranslation, $isPublicVersion)
     {
-        $lock = $this->objectManager->getRepository('KunstmaanNodeBundle:NodeVersionLock')->findOneBy([
+        $lock = $this->objectManager->getRepository(NodeVersionLock::class)->findOneBy([
             'owner' => $user->getUsername(),
             'nodeTranslation' => $nodeTranslation,
             'publicVersion' => $isPublicVersion,
@@ -125,7 +125,7 @@ class NodeVersionLockHelper implements ContainerAwareInterface
     {
         $threshold = $this->container->getParameter('kunstmaan_node.lock_threshold');
         /** @var NodeVersionLockRepository $objectRepository */
-        $objectRepository = $this->objectManager->getRepository('KunstmaanNodeBundle:NodeVersionLock');
+        $objectRepository = $this->objectManager->getRepository(NodeVersionLock::class);
 
         return $objectRepository->getLocksForNodeTranslation($nodeTranslation, $isPublicVersion, $threshold, $userToExclude);
     }

--- a/src/Kunstmaan/NodeBundle/Helper/NodeHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeHelper.php
@@ -78,7 +78,7 @@ class NodeHelper
         $publicPage = $this->cloneHelper->deepCloneAndSave($page);
 
         /* @var NodeVersion $publicNodeVersion */
-        $publicNodeVersion = $this->em->getRepository('KunstmaanNodeBundle:NodeVersion')
+        $publicNodeVersion = $this->em->getRepository(NodeVersion::class)
             ->createNodeVersionFor(
                 $publicPage,
                 $nodeTranslation,
@@ -215,10 +215,10 @@ class NodeHelper
         }
 
         /* @var Node $nodeNewPage */
-        $nodeNewPage = $this->em->getRepository('KunstmaanNodeBundle:Node')->createNodeFor($newPage, $locale, $user);
+        $nodeNewPage = $this->em->getRepository(Node::class)->createNodeFor($newPage, $locale, $user);
         $nodeTranslation = $nodeNewPage->getNodeTranslation($locale, true);
         if (null !== $parentNode) {
-            $weight = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getMaxChildrenWeight(
+            $weight = $this->em->getRepository(NodeTranslation::class)->getMaxChildrenWeight(
                     $parentNode,
                     $locale
                 ) + 1;

--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
@@ -177,7 +177,7 @@ class NodeMenu
         $this->nodesByInternalName = array();
 
         /* @var NodeRepository $repo */
-        $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+        $repo = $this->em->getRepository(Node::class);
 
         // Get all possible menu items in one query (also fetch offline nodes)
         $nodes = $repo->getChildNodes(
@@ -245,7 +245,7 @@ class NodeMenu
             $this->breadCrumb = array();
 
             /* @var NodeRepository $repo */
-            $repo = $this->em->getRepository('KunstmaanNodeBundle:Node');
+            $repo = $this->em->getRepository(Node::class);
 
             // Generate breadcrumb MenuItems - fetch *all* languages so you can link translations if needed
             $parentNodes = $repo->getAllParents($this->currentNode);
@@ -346,8 +346,8 @@ class NodeMenu
     }
 
     /**
-     * @param \Kunstmaan\NodeBundle\Entity\Node $node
-     * @param bool                              $includeHiddenFromNav
+     * @param Node $node
+     * @param bool $includeHiddenFromNav
      *
      * @return array|\Kunstmaan\NodeBundle\Helper\NodeMenuItem[]
      */
@@ -370,8 +370,8 @@ class NodeMenu
     }
 
     /**
-     * @param \Kunstmaan\NodeBundle\Entity\Node $node
-     * @param bool                              $includeHiddenFromNav
+     * @param Node $node
+     * @param bool $includeHiddenFromNav
      *
      * @return bool|\Kunstmaan\NodeBundle\Helper\NodeMenuItem
      */
@@ -393,8 +393,8 @@ class NodeMenu
     }
 
     /**
-     * @param \Kunstmaan\NodeBundle\Entity\Node $node
-     * @param bool                              $includeHiddenFromNav
+     * @param Node $node
+     * @param bool $includeHiddenFromNav
      *
      * @return bool|\Kunstmaan\NodeBundle\Helper\NodeMenuItem
      */
@@ -445,7 +445,7 @@ class NodeMenu
      */
     public function getNodeBySlug(NodeTranslation $parentNode, $slug)
     {
-        return $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        return $this->em->getRepository(NodeTranslation::class)
             ->getNodeTranslationForSlug($slug, $parentNode);
     }
 
@@ -492,7 +492,7 @@ class NodeMenu
                     $parentNode = $parent->getNode();
                 } elseif ($parent instanceof HasNodeInterface) {
                     $repo = $this->em->getRepository(
-                        'KunstmaanNodeBundle:Node'
+                        Node::class
                     );
                     $parentNode = $repo->getNodeFor($parent);
                 }

--- a/src/Kunstmaan/NodeBundle/Helper/Services/PageCreatorService.php
+++ b/src/Kunstmaan/NodeBundle/Helper/Services/PageCreatorService.php
@@ -7,8 +7,10 @@ use Doctrine\ORM\ORMException;
 use Kunstmaan\AdminBundle\Repository\UserRepository;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Repository\NodeRepository;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
+use Kunstmaan\SeoBundle\Entity\Seo;
 use Kunstmaan\SeoBundle\Repository\SeoRepository;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -106,12 +108,12 @@ class PageCreatorService
         $em = $this->entityManager;
 
         /** @var NodeRepository $nodeRepo */
-        $nodeRepo = $em->getRepository('KunstmaanNodeBundle:Node');
+        $nodeRepo = $em->getRepository(Node::class);
         /** @var UserRepository $userRepo */
         $userRepo = $em->getRepository($this->userEntityClass);
         /* @var SeoRepository $seoRepo */
         try {
-            $seoRepo = $em->getRepository('KunstmaanSeoBundle:Seo');
+            $seoRepo = $em->getRepository(Seo::class);
         } catch (ORMException $e) {
             $seoRepo = null;
         }
@@ -136,7 +138,7 @@ class PageCreatorService
         $rootNode = null;
 
         /* @var \Kunstmaan\NodeBundle\Repository\NodeTranslationRepository $nodeTranslationRepo*/
-        $nodeTranslationRepo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
+        $nodeTranslationRepo = $em->getRepository(NodeTranslation::class);
 
         foreach ($translations as $translation) {
             $language = $translation['language'];

--- a/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
@@ -119,7 +119,7 @@ class NodeRepository extends NestedTreeRepository
     {
         /* @var NodeVersion $nodeVersion */
         $nodeVersion = $this->getEntityManager()->getRepository(
-            'KunstmaanNodeBundle:NodeVersion'
+            NodeVersion::class
         )->getNodeVersionFor(
             $hasNode
         );
@@ -144,7 +144,7 @@ class NodeRepository extends NestedTreeRepository
     {
         /* @var NodeVersion $nodeVersion */
         $nodeVersion = $this->getEntityManager()->getRepository(
-            'KunstmaanNodeBundle:NodeVersion'
+            NodeVersion::class
         )->findOneBy(
             array('refId' => $id, 'refEntityName' => $entityName)
         );
@@ -212,7 +212,7 @@ class NodeRepository extends NestedTreeRepository
         if ($parent) {
             /* @var NodeVersion $parentNodeVersion */
             $parentNodeVersion = $em->getRepository(
-                'KunstmaanNodeBundle:NodeVersion'
+                NodeVersion::class
             )->findOneBy(
                 array(
                     'refId' => $parent->getId(),
@@ -231,7 +231,7 @@ class NodeRepository extends NestedTreeRepository
         $em->persist($node);
         $em->flush();
         $em->refresh($node);
-        $em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $em->getRepository(NodeTranslation::class)
             ->createNodeTranslationFor(
                 $hasNode,
                 $lang,

--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -183,7 +183,7 @@ class NodeTranslationRepository extends EntityRepository
     {
         /* @var NodeVersion $nodeVersion */
         $nodeVersion = $this->getEntityManager()
-            ->getRepository('KunstmaanNodeBundle:NodeVersion')
+            ->getRepository(NodeVersion::class)
             ->getNodeVersionFor($hasNode);
 
         if (!\is_null($nodeVersion)) {
@@ -411,7 +411,7 @@ class NodeTranslationRepository extends EntityRepository
 
         $em->persist($nodeTranslation);
 
-        $nodeVersion = $em->getRepository('KunstmaanNodeBundle:NodeVersion')
+        $nodeVersion = $em->getRepository(NodeVersion::class)
             ->createNodeVersionFor(
                 $hasNode,
                 $nodeTranslation,
@@ -452,9 +452,9 @@ class NodeTranslationRepository extends EntityRepository
             throw new \InvalidArgumentException('The entity of class ' . $className . ' has no id, maybe you forgot to flush first');
         }
 
-        $nodeTranslation = $em->getRepository('KunstmaanNodeBundle:NodeTranslation')->findOneBy(['lang' => $lang, 'node' => $node]);
+        $nodeTranslation = $em->getRepository(NodeTranslation::class)->findOneBy(['lang' => $lang, 'node' => $node]);
 
-        $em->getRepository('KunstmaanNodeBundle:NodeVersion')
+        $em->getRepository(NodeVersion::class)
             ->createNodeVersionFor(
                 $hasNode,
                 $nodeTranslation,

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -348,7 +348,7 @@ class SlugRouter implements RouterInterface
     /**
      * @param array $matchResult
      *
-     * @return \Kunstmaan\NodeBundle\Entity\NodeTranslation
+     * @return NodeTranslation
      */
     protected function getNodeTranslation($matchResult)
     {
@@ -371,7 +371,7 @@ class SlugRouter implements RouterInterface
     {
         /* @var NodeTranslationRepository $nodeTranslationRepo */
         $nodeTranslationRepo = $this->em->getRepository(
-            'KunstmaanNodeBundle:NodeTranslation'
+            NodeTranslation::class
         );
 
         return $nodeTranslationRepo;

--- a/src/Kunstmaan/NodeBundle/Tests/unit/Helper/NodeHelperTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/Helper/NodeHelperTest.php
@@ -199,8 +199,8 @@ class NodeHelperTest extends TestCase
         $this->em
             ->method('getRepository')
             ->withConsecutive(
-                [$this->equalTo('KunstmaanNodeBundle:Node')],
-                [$this->equalTo('KunstmaanNodeBundle:NodeTranslation')]
+                [$this->equalTo(Node::class)],
+                [$this->equalTo(NodeTranslation::class)]
             )
             ->willReturnOnConsecutiveCalls(
                 $nodeRepository,
@@ -369,7 +369,7 @@ class NodeHelperTest extends TestCase
             ->willReturn($publicNodeVersion);
 
         $this->em->method('getRepository')
-            ->with('KunstmaanNodeBundle:NodeVersion')
+            ->with(NodeVersion::class)
             ->willReturn($nodeVersionRepository);
 
         $this->eventDispatcher

--- a/src/Kunstmaan/NodeBundle/Tests/unit/Router/SlugRouterTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/Router/SlugRouterTest.php
@@ -100,7 +100,7 @@ class SlugRouterTest extends TestCase
         $em = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $em
             ->method('getRepository')
-            ->with($this->equalTo('KunstmaanNodeBundle:NodeTranslation'))
+            ->with($this->equalTo(NodeTranslation::class))
             ->willReturn($this->getNodeTranslationRepository($nodeTranslation));
 
         return $em;

--- a/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
@@ -123,7 +123,7 @@ class NodeTwigExtension extends AbstractExtension
      */
     public function getNodeTranslationByNodeId($nodeId, $lang)
     {
-        $repo = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation');
+        $repo = $this->em->getRepository(NodeTranslation::class);
 
         return $repo->getNodeTranslationByNodeIdQueryBuilder($nodeId, $lang);
     }
@@ -145,7 +145,7 @@ class NodeTwigExtension extends AbstractExtension
      */
     public function getNodeFor(PageInterface $page)
     {
-        return $this->em->getRepository('KunstmaanNodeBundle:Node')->getNodeFor($page);
+        return $this->em->getRepository(Node::class)->getNodeFor($page);
     }
 
     /**
@@ -155,7 +155,7 @@ class NodeTwigExtension extends AbstractExtension
      */
     public function getNodeTranslationFor(PageInterface $page)
     {
-        return $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')->getNodeTranslationFor($page);
+        return $this->em->getRepository(NodeTranslation::class)->getNodeTranslationFor($page);
     }
 
     /**
@@ -166,7 +166,7 @@ class NodeTwigExtension extends AbstractExtension
      */
     public function getNodeByInternalName($internalName, $locale)
     {
-        $nodes = $this->em->getRepository('KunstmaanNodeBundle:Node')
+        $nodes = $this->em->getRepository(Node::class)
             ->getNodesByInternalName($internalName, $locale);
         if (!empty($nodes)) {
             return $nodes[0];
@@ -252,7 +252,7 @@ class NodeTwigExtension extends AbstractExtension
     private function getRouteParametersByInternalName($internalName, $locale, $parameters = array())
     {
         $url = '';
-        $translation = $this->em->getRepository('KunstmaanNodeBundle:NodeTranslation')
+        $translation = $this->em->getRepository(NodeTranslation::class)
             ->getNodeTranslationByLanguageAndInternalName($locale, $internalName);
 
         if (!\is_null($translation)) {

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -195,7 +195,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
      */
     public function populateIndex()
     {
-        $nodeRepository = $this->em->getRepository('KunstmaanNodeBundle:Node');
+        $nodeRepository = $this->em->getRepository(Node::class);
         $nodes = $nodeRepository->getAllTopNodes();
 
         foreach ($nodes as $node) {
@@ -397,7 +397,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
         $rootNode = $this->currentTopNode;
         if (!$rootNode) {
             // Fetch main parent of current node...
-            $rootNode = $this->em->getRepository('KunstmaanNodeBundle:Node')->getRootNodeFor(
+            $rootNode = $this->em->getRepository(Node::class)->getRootNodeFor(
                 $node,
                 $nodeTranslation->getLang()
             );

--- a/src/Kunstmaan/NodeSearchBundle/Helper/FormWidgets/SearchFormWidget.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/FormWidgets/SearchFormWidget.php
@@ -24,7 +24,7 @@ class SearchFormWidget extends FormWidget
     public function __construct(Node $node, EntityManager $em)
     {
         $this->node = $node;
-        $this->nodeSearch = $em->getRepository('KunstmaanNodeSearchBundle:NodeSearch')->findOneByNode($this->node);
+        $this->nodeSearch = $em->getRepository(NodeSearch::class)->findOneByNode($this->node);
     }
 
     /**
@@ -52,7 +52,7 @@ class SearchFormWidget extends FormWidget
      */
     public function persist(EntityManager $em)
     {
-        $nodeSearch = $em->getRepository('KunstmaanNodeSearchBundle:NodeSearch')->findOneByNode($this->node);
+        $nodeSearch = $em->getRepository(NodeSearch::class)->findOneByNode($this->node);
 
         if ($this->data['node_search'] !== null) {
             if ($nodeSearch === null) {

--- a/src/Kunstmaan/NodeSearchBundle/Helper/IndexablePagePartsService.php
+++ b/src/Kunstmaan/NodeSearchBundle/Helper/IndexablePagePartsService.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeSearchBundle\Helper;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\SearchBundle\Helper\IndexableInterface;
 
@@ -47,7 +48,7 @@ class IndexablePagePartsService
         $indexablePageParts = [];
         foreach ($contexts as $context) {
             $pageParts = $this->em
-                ->getRepository('KunstmaanPagePartBundle:PagePartRef')
+                ->getRepository(PagePartRef::class)
                 ->getPageParts($page, $context);
 
             foreach ($pageParts as $pagePart) {

--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -11,6 +11,8 @@ use Elastica\Query\Term;
 use Elastica\Util;
 use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
+use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeSearchBundle\Entity\NodeSearch;
 use Kunstmaan\NodeSearchBundle\Helper\SearchBoostInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -186,7 +188,7 @@ class NodeSearcher extends AbstractElasticaSearcher
         $rescoreQueryBool = new BoolQuery();
 
         //Apply page type boosts
-        $pageClasses = $this->em->getRepository('KunstmaanNodeBundle:Node')->findAllDistinctPageClasses();
+        $pageClasses = $this->em->getRepository(Node::class)->findAllDistinctPageClasses();
         foreach ($pageClasses as $pageClass) {
             $page = new $pageClass['refEntityName']();
 
@@ -202,7 +204,7 @@ class NodeSearcher extends AbstractElasticaSearcher
         }
 
         //Apply page specific boosts
-        $nodeSearches = $this->em->getRepository('KunstmaanNodeSearchBundle:NodeSearch')->findAll();
+        $nodeSearches = $this->em->getRepository(NodeSearch::class)->findAll();
         foreach ($nodeSearches as $nodeSearch) {
             $elasticaQueryNodeId = new QueryString();
             $elasticaQueryNodeId

--- a/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/Twig/KunstmaanNodeSearchTwigExtension.php
@@ -58,7 +58,7 @@ class KunstmaanNodeSearchTwigExtension extends AbstractExtension
     public function getParentPage(HasNodeInterface $page, $locale)
     {
         /** @var Node $node */
-        $node = $this->em->getRepository('KunstmaanNodeBundle:Node')->getNodeFor($page);
+        $node = $this->em->getRepository(Node::class)->getNodeFor($page);
         $parentNode = $node->getParent();
         $nodeTranslation = $parentNode->getNodeTranslation($locale);
 

--- a/src/Kunstmaan/PagePartBundle/EventListener/CloneListener.php
+++ b/src/Kunstmaan/PagePartBundle/EventListener/CloneListener.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\PagePartBundle\EventListener;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
+use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Kunstmaan\PagePartBundle\PagePartConfigurationReader\PagePartConfigurationReaderInterface;
@@ -52,7 +53,7 @@ class CloneListener
 
             $contexts = $this->pagePartReader->getPagePartContexts($originalEntity);
             foreach ($contexts as $context) {
-                $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef')->copyPageParts($this->em, $originalEntity, $clonedEntity, $context);
+                $this->em->getRepository(PagePartRef::class)->copyPageParts($this->em, $originalEntity, $clonedEntity, $context);
             }
         }
 

--- a/src/Kunstmaan/PagePartBundle/Helper/Services/PagePartCreatorService.php
+++ b/src/Kunstmaan/PagePartBundle/Helper/Services/PagePartCreatorService.php
@@ -5,9 +5,11 @@ namespace Kunstmaan\PagePartBundle\Helper\Services;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Entity\EntityInterface;
+use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Repository\NodeRepository;
 use Kunstmaan\NodeBundle\Repository\NodeTranslationRepository;
+use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Entity\PageTemplateConfiguration;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
@@ -53,9 +55,9 @@ class PagePartCreatorService
         $this->em = $em;
         // Because these repositories are shared between the different functions it's
         // easier to make them available in the class.
-        $this->pagePartRepo = $em->getRepository('KunstmaanPagePartBundle:PagePartRef');
-        $this->translationRepo = $em->getRepository('KunstmaanNodeBundle:NodeTranslation');
-        $this->nodeRepo = $em->getRepository('KunstmaanNodeBundle:Node');
+        $this->pagePartRepo = $em->getRepository(PagePartRef::class);
+        $this->translationRepo = $em->getRepository(NodeTranslation::class);
+        $this->nodeRepo = $em->getRepository(Node::class);
     }
 
     /**
@@ -178,7 +180,7 @@ class PagePartCreatorService
         $page = $translation->getRef($this->em);
 
         /** @var PageTemplateConfigurationRepository $repo */
-        $repo = $this->em->getRepository('KunstmaanPagePartBundle:PageTemplateConfiguration');
+        $repo = $this->em->getRepository(PageTemplateConfiguration::class);
         $pageTemplateConfiguration = $repo->findFor($page);
         if ($pageTemplateConfiguration) {
             $pageTemplateConfiguration->setPageTemplate($templateName);

--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -99,7 +99,7 @@ class PagePartAdmin
     {
         // Get all the pagepartrefs
         /** @var PagePartRefRepository $ppRefRepo */
-        $ppRefRepo = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        $ppRefRepo = $this->em->getRepository(PagePartRef::class);
         $ppRefs = $ppRefRepo->getPagePartRefs($this->page, $this->context);
 
         // Group pagepartrefs per type
@@ -250,7 +250,7 @@ class PagePartAdmin
     public function persist(Request $request)
     {
         /** @var PagePartRefRepository $ppRefRepo */
-        $ppRefRepo = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        $ppRefRepo = $this->em->getRepository(PagePartRef::class);
 
         // Add new pageparts on the correct position + Re-order and save pageparts if needed
         $sequences = $request->get($this->context.'_sequence', []);
@@ -309,7 +309,7 @@ class PagePartAdmin
                 if (\array_key_exists('pagelimit', $possibleTypeData)) {
                     $pageLimit = $possibleTypeData['pagelimit'];
                     /** @var PagePartRefRepository $entityRepository */
-                    $entityRepository = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+                    $entityRepository = $this->em->getRepository(PagePartRef::class);
                     $formPPCount = $entityRepository->countPagePartsOfType(
                         $this->page,
                         $possibleTypeData['class'],
@@ -369,7 +369,7 @@ class PagePartAdmin
     public function getPagePart($id, $sequenceNumber)
     {
         /** @var PagePartRefRepository $ppRefRepo */
-        $ppRefRepo = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        $ppRefRepo = $this->em->getRepository(PagePartRef::class);
 
         return $ppRefRepo->getPagePart($id, $this->context, $sequenceNumber);
     }

--- a/src/Kunstmaan/PagePartBundle/Tests/unit/EventListener/CloneListenerTest.php
+++ b/src/Kunstmaan/PagePartBundle/Tests/unit/EventListener/CloneListenerTest.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\PagePartBundle\Tests\EventListener;
 
 use Kunstmaan\AdminBundle\Event\DeepCloneAndSaveEvent;
+use Kunstmaan\PagePartBundle\Entity\PagePartRef;
 use Kunstmaan\PagePartBundle\Entity\PageTemplateConfiguration;
 use Kunstmaan\PagePartBundle\EventListener\CloneListener;
 use Kunstmaan\PagePartBundle\Helper\HasPagePartsInterface;
@@ -61,7 +62,7 @@ class CloneListenerTest extends TestCase
 
         $this->em->expects($this->any())
             ->method('getRepository')
-            ->with($this->equalTo('KunstmaanPagePartBundle:PagePartRef'))
+            ->with($this->equalTo(PagePartRef::class))
             ->willReturn($this->repo);
 
         $this->configurator = new PagePartAdminConfigurator();

--- a/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
+++ b/src/Kunstmaan/PagePartBundle/Twig/Extension/PagePartTwigExtension.php
@@ -75,7 +75,7 @@ class PagePartTwigExtension extends AbstractExtension
     public function getPageParts(HasPagePartsInterface $page, $context = 'main')
     {
         /** @var $entityRepository PagePartRefRepository */
-        $entityRepository = $this->em->getRepository('KunstmaanPagePartBundle:PagePartRef');
+        $entityRepository = $this->em->getRepository(PagePartRef::class);
 
         return $entityRepository->getPageParts($page, $context);
     }

--- a/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/Admin/SettingsController.php
@@ -28,7 +28,7 @@ class SettingsController extends BaseSettingsController
         $this->denyAccessUnlessGranted('ROLE_SUPER_ADMIN');
 
         $em = $this->getDoctrine()->getManager();
-        $repo = $this->getDoctrine()->getRepository('KunstmaanSeoBundle:Robots');
+        $repo = $this->getDoctrine()->getRepository(Robots::class);
         $robot = $repo->findOneBy(array());
         $default = $this->container->getParameter('robots_default');
         $isSaved = true;

--- a/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
+++ b/src/Kunstmaan/SeoBundle/Controller/RobotsController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SeoBundle\Controller;
 
+use Kunstmaan\SeoBundle\Entity\Robots;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -21,7 +22,7 @@ class RobotsController extends Controller
      */
     public function indexAction(Request $request)
     {
-        $entity = $this->getDoctrine()->getRepository('KunstmaanSeoBundle:Robots')->findOneBy(array());
+        $entity = $this->getDoctrine()->getRepository(Robots::class)->findOneBy(array());
         $robots = $this->getParameter('robots_default');
 
         if ($entity && $entity->getRobotsTxt()) {

--- a/src/Kunstmaan/SeoBundle/EventListener/CloneListener.php
+++ b/src/Kunstmaan/SeoBundle/EventListener/CloneListener.php
@@ -42,7 +42,7 @@ class CloneListener
 
         if ($originalEntity instanceof AbstractEntity) {
             /* @var Seo $seo */
-            $seo = $this->em->getRepository('KunstmaanSeoBundle:Seo')->findFor($originalEntity);
+            $seo = $this->em->getRepository(Seo::class)->findFor($originalEntity);
 
             if (!\is_null($seo)) {
                 /* @var Seo $clonedSeo */

--- a/src/Kunstmaan/SeoBundle/EventListener/NodeListener.php
+++ b/src/Kunstmaan/SeoBundle/EventListener/NodeListener.php
@@ -36,7 +36,7 @@ class NodeListener
     {
         if ($event->getPage() instanceof HasNodeInterface && !$event->getPage()->isStructureNode()) {
             /* @var Seo $seo */
-            $seo = $this->em->getRepository('KunstmaanSeoBundle:Seo')->findOrCreateFor($event->getPage());
+            $seo = $this->em->getRepository(Seo::class)->findOrCreateFor($event->getPage());
 
             $seoWidget = new FormWidget();
             $seoWidget->addType('seo', SeoType::class, $seo);

--- a/src/Kunstmaan/SeoBundle/Tests/unit/Twig/TwigExtensionTest.php
+++ b/src/Kunstmaan/SeoBundle/Tests/unit/Twig/TwigExtensionTest.php
@@ -156,7 +156,7 @@ class TwigExtensionTest extends TestCase
     {
         $this->emMock->expects($this->once())
             ->method('getRepository')
-            ->with($this->equalTo('KunstmaanSeoBundle:Seo'))
+            ->with($this->equalTo(Seo::class))
             ->willReturn($this->seoRepoMock);
     }
 

--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -105,7 +105,7 @@ class SeoTwigExtension extends AbstractExtension
         $key = md5(\get_class($entity).$entity->getId());
 
         if (!\array_key_exists($key, $this->seoCache)) {
-            $seo = $this->em->getRepository('KunstmaanSeoBundle:Seo')->findOrCreateFor($entity);
+            $seo = $this->em->getRepository(Seo::class)->findOrCreateFor($entity);
             $this->seoCache[$key] = $seo;
         }
 

--- a/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/TaggingBundle/Controller/TagAdminListController.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\TaggingBundle\Controller;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
 use Kunstmaan\AdminListBundle\Controller\AdminListController;
 use Kunstmaan\TaggingBundle\AdminList\TagAdminListConfigurator;
+use Kunstmaan\TaggingBundle\Entity\Tag;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -78,7 +79,7 @@ class TagAdminListController extends AdminListController
     {
         $search = $request->get('term');
         $em = $this->getDoctrine()->getManager();
-        $qb = $em->getRepository('KunstmaanTaggingBundle:Tag')->createQueryBuilder('n')
+        $qb = $em->getRepository(Tag::class)->createQueryBuilder('n')
             ->where('n.name LIKE :search')
             ->orderBy('n.name', 'ASC')
             ->setParameter('search', '%' . $search . '%');

--- a/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
+++ b/src/Kunstmaan/TranslatorBundle/Controller/TranslatorController.php
@@ -93,7 +93,7 @@ class TranslatorController extends AdminListController
 
             // Fetch form data
             $data = $form->getData();
-            if (!$em->getRepository('KunstmaanTranslatorBundle:Translation')->isUnique($data)) {
+            if (!$em->getRepository(Translation::class)->isUnique($data)) {
                 $error = new FormError($translator->trans('translator.translation_not_unique'));
                 $form->get('domain')->addError($error);
                 $form->get('keyword')->addError($error);
@@ -101,7 +101,7 @@ class TranslatorController extends AdminListController
 
             if ($form->isSubmitted() && $form->isValid()) {
                 // Create translation
-                $em->getRepository('KunstmaanTranslatorBundle:Translation')->createTranslations($data);
+                $em->getRepository(Translation::class)->createTranslations($data);
                 $em->flush();
 
                 $this->addFlash(
@@ -142,7 +142,7 @@ class TranslatorController extends AdminListController
         $em = $this->getDoctrine()->getManager();
         $configurator = $this->getAdminListConfigurator();
 
-        $translations = $em->getRepository('KunstmaanTranslatorBundle:Translation')->findBy(['translationId' => $id]);
+        $translations = $em->getRepository(Translation::class)->findBy(['translationId' => $id]);
         if (\count($translations) < 1) {
             throw new \InvalidArgumentException('No existing translations found for this id');
         }
@@ -171,7 +171,7 @@ class TranslatorController extends AdminListController
 
             if ($form->isSubmitted() && $form->isValid()) {
                 // Update translations
-                $em->getRepository('KunstmaanTranslatorBundle:Translation')->updateTranslations($translation, $id);
+                $em->getRepository(Translation::class)->updateTranslations($translation, $id);
                 $em->flush();
 
                 $this->addFlash(
@@ -252,7 +252,7 @@ class TranslatorController extends AdminListController
     {
         $configurator = $this->getAdminListConfigurator();
         $em = $this->getDoctrine()->getManager();
-        $translation = $em->getRepository('KunstmaanTranslatorBundle:Translation')->findOneBy(
+        $translation = $em->getRepository(Translation::class)->findOneBy(
             ['domain' => $domain, 'keyword' => $keyword, 'locale' => $locale]
         );
 
@@ -285,7 +285,7 @@ class TranslatorController extends AdminListController
 
         $indexUrl = $this->getAdminListConfigurator()->getIndexUrl();
         if ($request->isMethod('POST')) {
-            $em->getRepository('KunstmaanTranslatorBundle:Translation')->removeTranslations($id);
+            $em->getRepository(Translation::class)->removeTranslations($id);
         }
 
         return new RedirectResponse($this->generateUrl($indexUrl['path'], isset($indexUrl['params']) ? $indexUrl['params'] : []));
@@ -339,7 +339,7 @@ class TranslatorController extends AdminListController
         try {
             if ($id !== 0) {
                 // Find existing translation
-                $translation = $em->getRepository('KunstmaanTranslatorBundle:Translation')->find($id);
+                $translation = $em->getRepository(Translation::class)->find($id);
 
                 if (\is_null($translation)) {
                     return new Response($translator->trans('translator.translator.invalid_translation'), 500);

--- a/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/GroupsController.php
@@ -105,7 +105,7 @@ class GroupsController extends BaseSettingsController
         /* @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
         /* @var Group $group */
-        $group = $em->getRepository('KunstmaanAdminBundle:Group')->find($id);
+        $group = $em->getRepository(Group::class)->find($id);
         $form = $this->createForm(GroupType::class, $group);
 
         if ($request->isMethod('POST')) {
@@ -148,7 +148,7 @@ class GroupsController extends BaseSettingsController
 
         /* @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
-        $group = $em->getRepository('KunstmaanAdminBundle:Group')->find($id);
+        $group = $em->getRepository(Group::class)->find($id);
         if (!\is_null($group)) {
             $em->remove($group);
             $em->flush();

--- a/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
+++ b/src/Kunstmaan/UserManagementBundle/Controller/RolesController.php
@@ -104,7 +104,7 @@ class RolesController extends BaseSettingsController
         /* @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
         /* @var Role $role */
-        $role = $em->getRepository('KunstmaanAdminBundle:Role')->find($id);
+        $role = $em->getRepository(Role::class)->find($id);
         $form = $this->createForm(RoleType::class, $role);
 
         if ($request->isMethod('POST')) {
@@ -148,7 +148,7 @@ class RolesController extends BaseSettingsController
         /* @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
         /* @var Role $role */
-        $role = $em->getRepository('KunstmaanAdminBundle:Role')->find($id);
+        $role = $em->getRepository(Role::class)->find($id);
         if (!\is_null($role)) {
             $em->remove($role);
             $em->flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The string entity alias is deprecated in doctrine/orm v2 and won't be supported in v3.
