### PR TITLE
[AllBundles] Fix incorrect typecast in UrlHelper

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
@@ -165,7 +165,7 @@ class DomainConfiguration implements DomainConfigurationInterface
     }
 
     /**
-     * @param int $id
+     * @param string|int $id
      */
     public function getFullHostById($id)
     {

--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfigurationInterface.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfigurationInterface.php
@@ -104,7 +104,7 @@ interface DomainConfigurationInterface
     /**
      * Return the full host of a given id.
      *
-     * @param int $id
+     * @param string|int $id
      *
      * @return array|null
      */

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -291,7 +291,7 @@ class DomainConfiguration extends BaseDomainConfiguration
     }
 
     /**
-     * @param int $id
+     * @param string|int $id
      *
      * @return array
      */

--- a/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/URLHelper.php
@@ -82,7 +82,7 @@ class URLHelper
                     $fullTag = $match[0];
                     $hostId = $match[2];
 
-                    $hostConfig = !empty($hostId) ? $this->domainConfiguration->getFullHostById((int) $hostId) : null;
+                    $hostConfig = !empty($hostId) ? $this->domainConfiguration->getFullHostById($hostId) : null;
                     $host = null !== $hostConfig && array_key_exists('host', $hostConfig) ? $hostConfig['host'] : null;
                     $hostBaseUrl = $this->domainConfiguration->getHostBaseUrl($host);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Don't typecast host id parameter as this can be a string or an int depending on the user config. Bug introduced in #2629 and was caused by incorrect phpdocs. Both the typecast and phpdoc's have been fixed
