### PR TITLE
[NodeBundle] Improve url helper by replacing full data load by specific lookup

### DIFF
--- a/src/Kunstmaan/NodeBundle/Tests/unit/Helper/UrlHelperTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/unit/Helper/UrlHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Kunstmaan\NodeBundle\Tests\Helper;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
+use Kunstmaan\NodeBundle\Helper\URLHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class UrlHelperTest extends TestCase
+{
+    public function testReplaceUrlWithEmail()
+    {
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
+        $router = $this->getMockBuilder(RouterInterface::class)->getMock();
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $domainConfig = $this->getMockBuilder(DomainConfigurationInterface::class)->getMock();
+
+        $urlHelper = new URLHelper($em, $router, $logger, $domainConfig);
+
+        $this->assertEquals('mailto:test@example.com', $urlHelper->replaceUrl('test@example.com'));
+    }
+
+    public function testReplaceUrlWithInternalLink()
+    {
+        $stmt = $this->getMockBuilder(Statement::class)->getMock();
+        $stmt->expects($this->once())->method('fetch')->willReturn(['id' => 18, 'url' => 'abc']);
+        $conn = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $conn->expects($this->once())->method('executeQuery')->willReturn($stmt);
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
+        $em->expects($this->once())->method('getConnection')->willReturn($conn);
+        $router = $this->getMockBuilder(RouterInterface::class)->getMock();
+        $router->method('generate')->with('_slug', ['url' => 'abc'])->willReturn('/abc');
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $domainConfig = $this->getMockBuilder(DomainConfigurationInterface::class)->getMock();
+
+        $urlHelper = new URLHelper($em, $router, $logger, $domainConfig);
+        $this->assertEquals('/abc', $urlHelper->replaceUrl('[NT18]'));
+
+        //Second call to replaceUrl should not execute query again
+        $this->assertEquals('/abc', $urlHelper->replaceUrl('[NT18]'));
+    }
+
+    public function testReplaceUrlWithMediaLink()
+    {
+        $stmt = $this->getMockBuilder(Statement::class)->getMock();
+        $stmt->expects($this->once())->method('fetch')->willReturn(['id' => 18, 'url' => '/uploads/media/5e24be27412e6/test.svg']);
+        $conn = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $conn->expects($this->once())->method('executeQuery')->willReturn($stmt);
+        $em = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
+        $em->expects($this->once())->method('getConnection')->willReturn($conn);
+        $router = $this->getMockBuilder(RouterInterface::class)->getMock();
+        $router->method('generate')->with('_slug', ['url' => 'abc'])->willReturn('/abc');
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $domainConfig = $this->getMockBuilder(DomainConfigurationInterface::class)->getMock();
+
+        $urlHelper = new URLHelper($em, $router, $logger, $domainConfig);
+        $this->assertEquals('/uploads/media/5e24be27412e6/test.svg', $urlHelper->replaceUrl('[M18]'));
+
+        //Second call to replaceUrl should not execute query again
+        $this->assertEquals('/uploads/media/5e24be27412e6/test.svg', $urlHelper->replaceUrl('[M18]'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Previously the urlHelper class would load all node translations and all media items before replacing urls. This is unnecessary and would load large amounts of data for large websites. With this setup we do the lookup more efficient by only executing a query to the db for the requested nodetranslations/media objects.
