### PR TITLE
[SearchBundle][NodeSearch] Add elastica/elasticsearch 7 support

### DIFF
--- a/UPGRADE-5.6.md
+++ b/UPGRADE-5.6.md
@@ -1,2 +1,13 @@
 UPGRADE FROM 5.5 to 5.6
 =======================
+
+General
+-------
+
+SearchBundle/NodeSearchBundle: Support for ruflin/elastica and elasticasearch 7 was added. If you still use 
+elasticsearch 6 you should add `"ruflin/elastica": "^5.0|^6.0"` to your project `composer.json`.
+
+SearchBundle
+------------
+
+Support for `ruflin/elastica` and elasticsearch versions below 7 is deprecated and will be removed in 6.0. Upgrade to `ruflin/elastica` ^7.0 and elasticsearch 7.

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "twig/extensions": "~1.0",
         "egulias/email-validator": "^1.2.8|^2.0",
         "box/spout": "^2.5",
-        "ruflin/elastica": "^5.2|^6.0",
+        "ruflin/elastica": "^5.2|^6.0|^7.0",
         "behat/transliterator": "~1.2",
         "defuse/php-encryption": "^2.2",
         "kunstmaan/sensio-generator-bundle": "^3.2",

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -45,6 +45,11 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
             ->addMethodCall('setDefaultProperties', [$config['mapping']]);
 
         $container->setParameter('kunstmaan_node_search.contexts', $config['contexts']);
+
+        if (class_exists(\Elastica\Type\Mapping::class)) {
+            $nodeSearch = $container->getDefinition('kunstmaan_node_search.search.node');
+            $nodeSearch->addMethodCall('setIndexType', ['%kunstmaan_node_search.indextype%']);
+        }
     }
 
     /**

--- a/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeSearchBundle/Resources/config/services.yml
@@ -23,7 +23,6 @@ services:
         parent: kunstmaan_node_search.search.abstract_elastica_searcher
         calls:
             - [ setIndexName, ['%kunstmaan_node_search.indexname%']]
-            - [ setIndexType, ['%kunstmaan_node_search.indextype%']]
             - [ setTokenStorage, ['@security.token_storage']]
             - [ setDomainConfiguration, ['@kunstmaan_admin.domain_configuration']]
             - [ setEntityManager, ['@doctrine.orm.entity_manager']]

--- a/src/Kunstmaan/NodeSearchBundle/Search/AbstractElasticaSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/AbstractElasticaSearcher.php
@@ -98,7 +98,10 @@ abstract class AbstractElasticaSearcher implements SearcherInterface
 
         $search = new Search($this->search->getClient());
         $search->addIndex($index);
-        $search->addType($index->getType($this->indexType));
+
+        if (method_exists($search, 'getType')) {
+            $search->addType($index->getType($this->indexType));
+        }
 
         return $search->search($this->query);
     }

--- a/src/Kunstmaan/NodeSearchBundle/Search/AbstractElasticaSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/AbstractElasticaSearcher.php
@@ -146,22 +146,30 @@ abstract class AbstractElasticaSearcher implements SearcherInterface
     }
 
     /**
+     * @deprecated upgrade to ruflin/elastica and elasticsearch v7 and don't set an index type
+     *
      * @param string $indexType
      *
      * @return SearcherInterface
      */
     public function setIndexType($indexType)
     {
+        @trigger_error(sprintf('The "setIndexType" method in "%s" is deprecated since KunstmaanSearchBundle 5.6 and will be removed in KunstmaanSearchBundle 6.0. Upgrade to ruflin/elastica and elasticsearch v7 and don\'t set an index type.', __CLASS__), E_USER_DEPRECATED);
+
         $this->indexType = $indexType;
 
         return $this;
     }
 
     /**
+     * @deprecated upgrade to ruflin/elastica and elasticsearch v7 and don't set an index type
+     *
      * @return string
      */
     public function getIndexType()
     {
+        @trigger_error(sprintf('The "getIndexType" method in "%s" is deprecated since KunstmaanSearchBundle 5.6 and will be removed in KunstmaanSearchBundle 6.0. Upgrade to ruflin/elastica and elasticsearch v7 and don\'t set an index type.', __CLASS__), E_USER_DEPRECATED);
+
         return $this->indexType;
     }
 

--- a/src/Kunstmaan/NodeSearchBundle/Search/SearcherInterface.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/SearcherInterface.php
@@ -83,6 +83,8 @@ interface SearcherInterface
     public function getIndexName();
 
     /**
+     * @deprecated upgrade to ruflin/elastica and elasticsearch v7 and don't set an index type
+     *
      * @param string $indexType
      *
      * @return SearcherInterface
@@ -90,6 +92,8 @@ interface SearcherInterface
     public function setIndexType($indexType);
 
     /**
+     * @deprecated upgrade to ruflin/elastica and elasticsearch v7 and don't set an index type
+     *
      * @return string
      */
     public function getIndexType();

--- a/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
+++ b/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
@@ -24,6 +24,11 @@ class ElasticaProvider implements SearchProviderInterface
                 array('connections' => $this->nodes,
                 )
             );
+
+            //NEXT_MAJOR: remove checks and update ruflin/elastica dependency constraints
+            if (!class_exists(\Elastica\Mapping::class)) {
+                @trigger_error('Using a version of ruflin/elastica below v7.0 is deprecated since KunstmaanSearchBundle 5.6 and support for older versions will be removed in KunstmaanSearchBundle 6.0. Upgrade to ruflin/elastica and elasticsearch v7 instead.', E_USER_DEPRECATED);
+            }
         }
 
         return $this->client;

--- a/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
+++ b/src/Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
@@ -67,7 +67,11 @@ class ElasticaProvider implements SearchProviderInterface
      */
     public function createDocument($uid, $document, $indexName = '', $indexType = '')
     {
-        return new Document($uid, $document, $indexType, $indexName);
+        if (method_exists(Document::class, 'setType')) {
+            return new Document($uid, $document, $indexType, $indexName);
+        }
+
+        return new Document($uid, $document, $indexName);
     }
 
     /**
@@ -81,8 +85,12 @@ class ElasticaProvider implements SearchProviderInterface
     public function addDocument($indexName, $indexType, $document, $uid)
     {
         $doc = $this->createDocument($uid, $document);
+        $index = $this->getClient()->getIndex($indexName);
+        if (method_exists($index, 'getType')) {
+            return $index->getType($indexType)->addDocument($doc);
+        }
 
-        return $this->getClient()->getIndex($indexName)->getType($indexType)->addDocument($doc);
+        return $index->addDocument($doc);
     }
 
     /**
@@ -122,9 +130,14 @@ class ElasticaProvider implements SearchProviderInterface
     public function deleteDocuments($indexName, $indexType, array $ids)
     {
         $index = $this->getIndex($indexName);
-        $type = $index->getType($indexType);
 
-        return $this->getClient()->deleteIds($ids, $index, $type);
+        if (method_exists($index, 'getType')) {
+            $type = $index->getType($indexType);
+
+            return $this->getClient()->deleteIds($ids, $index, $type);
+        }
+
+        return $this->getClient()->deleteIds($ids, $index);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | fixes #2688 

This PR adds support for `ruflin/elastica` 7.0 (and with that also elasticsearch 7). With this change previous versions of elasticsearch and `ruflin/elastica` <7.0, are deprecated and support for these versions will be removed in 6.0.