### PR TITLE
[AdminBundle] Fix nonexistent RoleInterface for the BC layer

### DIFF
--- a/.build/stubs/RoleInterface.php
+++ b/.build/stubs/RoleInterface.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\Security\Core\Role;
 
+//NEXT_MAJOR: when sf 3.4 support is dropped this stub can also be removed
 interface RoleInterface
 {
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,8 @@ parameters:
     level: 1
     paths:
         -  src
+    scanFiles:
+        - stubs/RoleInterface.php
 
     excludes_analyse:
         - src/Kunstmaan/*/Tests/*
@@ -18,5 +20,4 @@ parameters:
 
     ignoreErrors:
         # Ignore errors on unfound classes for old symfony version BC layers
-        - '#^Class Symfony\\Component\\Security\\Core\\Role\\RoleInterface not found\.\z#'
         - '#Constructor of class Kunstmaan\\MediaBundle\\AdminList\\MediaAdminListConfigurator has an unused parameter \$mediaManager\.#' # Will be fixed in separate PR

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
     paths:
         -  src
     scanFiles:
-        - stubs/RoleInterface.php
+        - .build/stubs/RoleInterface.php
 
     excludes_analyse:
         - src/Kunstmaan/*/Tests/*
@@ -19,5 +19,4 @@ parameters:
         - src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionListener.php
 
     ignoreErrors:
-        # Ignore errors on unfound classes for old symfony version BC layers
         - '#Constructor of class Kunstmaan\\MediaBundle\\AdminList\\MediaAdminListConfigurator has an unused parameter \$mediaManager\.#' # Will be fixed in separate PR

--- a/stubs/RoleInterface.php
+++ b/stubs/RoleInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Role;
+
+interface RoleInterface
+{
+
+    /**
+     * @return string|null
+     */
+    public function getRole();
+
+}


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan/issues/3542 and https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/2696.

BTW you already have some real errors since the PHPStan check was disabled in the CI so you should also look into them :)

```
 ------ -------------------------------------------------------------------------
  Line   Kunstmaan/DashboardBundle/Repository/AnalyticsSegmentRepository.php
 ------ -------------------------------------------------------------------------
  53     Class Kunstmaan\DashboardBundle\Repository\AnalyticsOverview not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ -------------------------------------------------------------------------

 ------ --------------------------------------------------------------------
  Line   Kunstmaan/MediaBundle/Repository/MediaRepository.php
 ------ --------------------------------------------------------------------
  63     Class Kunstmaan\MediaBundle\Entity\Image not found.
Fix nonexistent RoleInterface for the BC layer
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------

 ------ --------------------------------------------------------------------
  Line   Kunstmaan/NodeBundle/Helper/Menu/PageMenuAdaptor.php
 ------ --------------------------------------------------------------------
  146    Class Kunstmaan\NodeBundle\Helper\Menu\Node not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  185    Class Kunstmaan\NodeBundle\Helper\Menu\Node not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------
  Line   Kunstmaan/SearchBundle/Provider/ElasticaProvider.php
 ------ ------------------------------------------------------------------------------
  76     Class Elastica\Document constructor invoked with 4 parameters, 0-3 required.
 ------ ------------------------------------------------------------------------------
```