### PR TITLE
[AdminBundle] change priority of event subscriber AdminLocaleListener

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -102,8 +102,7 @@ class AdminLocaleListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            // Must be registered before the default Locale listener
-            KernelEvents::REQUEST => array(array('onKernelRequest', 17)),
+            KernelEvents::REQUEST => array(array('onKernelRequest', -1)),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #1873 #2691 

Possibly fixes the above tickets.

I tested this on a multi language upgraded site [KZ] and on a new multi lang project and on a new single lang project.
Functionality still works as intended and i can not see anything wrong with the locales in either the menu's or the content of the website. However i was also not able to reproduce the error shown in the tickets when using the old priority. Therefore I can only follow the conclusion the person in these tickets have made that the priority has to be -1. I have at least verified that it does not break existing functionality in my test projects.

