### PR TITLE
[GeneratorBundle] Don't add deprecated logout_on_user_change config option

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/config/security.yaml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/config/security.yaml
@@ -30,7 +30,6 @@ security:
                 lifetime: 604800
                 path:     /
                 domain:   ~
-            logout_on_user_change: true
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/
             security: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This option is a no-op config as it's always true in symfony 4 and is deprecated in symfony 4.1, this will avoid generating deprecations in new projects
