### PR TITLE
[AdminBundle] Prepare code to remove deprecated doctrine/cache and replace with symfony/cache

### DIFF
--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -11,6 +11,7 @@ AdminBundle
 ------------
 
 * Validator\Constraints\PasswordRestrictions have had their error constant values changed from integer to string uuid's because integers have been deprecated by Symfony.
+* Passing an instance of `\Doctrine\Common\Cache\Cache` as the second argument in `\Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker::__construct` and `\Kunstmaan\AdminBundle\Toolbar\BundleVersionDataCollector::__construct` is deprecated, an instance of `\Symfony\Component\Cache\Adapter\AdapterInterface` will be required.
 
 GeneratorBundle
 ----------

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^7.2",
         "symfony/acl-bundle": "^1.0|^2.0",
+        "symfony/cache": "^3.4|^4.4",
         "symfony/config": "^3.4|^4.4",
         "symfony/console": "^3.4|^4.4",
         "symfony/dependency-injection": "^3.4|^4.4",

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/VersionCheckerCacheBcPass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/VersionCheckerCacheBcPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Doctrine\Common\Cache\FilesystemCache;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class VersionCheckerCacheBcPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        // NEXT_MAJOR: remove compiler pass when doctrine/cache dependency is removed.
+        $cacheDefinition = $container->findDefinition('kunstmaan_admin.cache');
+        if ($cacheDefinition->getClass() !== FilesystemCache::class || $cacheDefinition->getArgument(0) !== '%kernel.cache_dir%/fcache') {
+            // The "kunstmaan_admin.cache service" is changed compared to the default definition, injected this service instead to keep BC.
+            $versionChecker = $container->getDefinition('kunstmaan_admin.versionchecker');
+            $versionChecker->setArgument(1, $cacheDefinition);
+
+            $versionDataCollector = $container->getDefinition('kunstmaan_admin.datacollector.bundleversion');
+            $versionDataCollector->setArgument(1, $cacheDefinition);
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Helper/VersionCheck/VersionChecker.php
+++ b/src/Kunstmaan/AdminBundle/Helper/VersionCheck/VersionChecker.php
@@ -3,9 +3,12 @@
 namespace Kunstmaan\AdminBundle\Helper\VersionCheck;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Exception;
 use GuzzleHttp\Client;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\Exception\ParseException;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -15,13 +18,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class VersionChecker
 {
+    public const CACHE_KEY = 'version_check';
+
     /**
      * @var ContainerInterface
      */
     private $container;
 
     /**
-     * @var Cache
+     * @var AdapterInterface
      */
     private $cache;
 
@@ -51,15 +56,23 @@ class VersionChecker
     private $translator;
 
     /**
-     * Constructor
-     *
-     * @param ContainerInterface $container
-     * @param Cache              $cache
+     * @param CacheProvider|AdapterInterface $cache
      */
-    public function __construct(ContainerInterface $container, Cache $cache, $translator)
+    public function __construct(ContainerInterface $container, /* AdapterInterface */$cache, $translator)
     {
         $this->container = $container;
+
+        if (!$cache instanceof CacheProvider && !$cache instanceof AdapterInterface) {
+            // NEXT_MAJOR Add AdapterInterface typehint for the $cache parameter
+            throw new \InvalidArgumentException(sprintf('The "$cache" parameter should extend from "%s" or implement "%s"', CacheProvider::class, AdapterInterface::class));
+        }
+
         $this->cache = $cache;
+        if ($cache instanceof CacheProvider) {
+            @trigger_error(sprintf('Passing an instance of "%s" as the second argument in "%s" is deprecated since KunstmaanAdminBundle 5.7 and an instance of "%s" will be required in KunstmaanAdminBundle 6.0.', CacheProvider::class, __METHOD__, AdapterInterface::class), E_USER_DEPRECATED);
+
+            $this->cache = new DoctrineAdapter($cache);
+        }
 
         // NEXT_MAJOR Add "Symfony\Contracts\Translation\TranslatorInterface" typehint when sf <4.4 support is removed.
         if (!$translator instanceof TranslatorInterface && !$translator instanceof LegacyTranslatorInterface) {
@@ -94,8 +107,8 @@ class VersionChecker
             return;
         }
 
-        $data = $this->cache->fetch('version_check');
-        if (!\is_array($data)) {
+        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+        if (!$cacheItem->isHit() || !\is_array($cacheItem->get())) {
             $this->check();
         }
     }
@@ -137,7 +150,11 @@ class VersionChecker
             }
 
             // Save the result in the cache to make sure we don't do the check too often
-            $this->cache->save('version_check', $data, $this->cacheTimeframe);
+            $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+            $cacheItem->expiresAfter($this->cacheTimeframe);
+            $cacheItem->set($data);
+
+            $this->cache->save($cacheItem);
 
             return $data;
         } catch (Exception $e) {

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -11,6 +11,7 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\EnablePermissionsPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\InjectUntrackedTokenStorageCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\VersionCheckerCacheBcPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -37,6 +38,7 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new EnablePermissionsPass());
 
         $container->addCompilerPass(new DeprecateClassParametersPass());
+        $container->addCompilerPass(new VersionCheckerCacheBcPass());
 
         $container->registerExtension(new KunstmaanAdminExtension());
     }

--- a/src/Kunstmaan/AdminBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/AdminBundle/Resources/config/services.yml
@@ -171,12 +171,18 @@ services:
 
     kunstmaan_admin.versionchecker:
         class: Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker
-        arguments: ['@service_container', '@kunstmaan_admin.cache', '@translator']
+        arguments: ['@service_container', '@cache.kunstmaan_versioncheck', '@translator']
         public: true
 
     kunstmaan_admin.cache:
         class: Doctrine\Common\Cache\FilesystemCache
         arguments: ['%kernel.cache_dir%/fcache']
+        deprecated: 'The "%service_id%" service is deprecated since Kunstmaan/AdminBundle 5.7 and will be removed in KunstmaanAdminBundle 6.0.'
+
+    cache.kunstmaan_versioncheck:
+        parent: cache.adapter.filesystem
+        tags:
+            - { name: cache.pool }
 
     kunstmaan_admin.form.type.color:
         class: Kunstmaan\AdminBundle\Form\ColorType
@@ -322,7 +328,7 @@ services:
         class: '%kunstmaan_admin.toolbar.collector.bundle.class%'
         arguments:
             - '@kunstmaan_admin.versionchecker'
-            - '@kunstmaan_admin.cache'
+            - '@cache.kunstmaan_versioncheck'
         tags:
             - { name: kunstmaan_admin.toolbar_collector, template: '@KunstmaanAdmin/Toolbar/bundles_version.html.twig', id: kuma_bundle_versions }
 

--- a/src/Kunstmaan/AdminBundle/Tests/unit/Helper/VersionCheck/VersionCheckTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/Helper/VersionCheck/VersionCheckTest.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Tests\Helper;
 
+use Doctrine\Common\Cache\ArrayCache;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -9,7 +10,9 @@ use GuzzleHttp\Psr7\Response;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\Exception\ParseException;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
 use PHPUnit\Framework\TestCase;
-use Doctrine\Common\Cache\Cache;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,10 +23,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class VersionCheckTest extends TestCase
 {
+    /** @var \PHPUnit\Framework\MockObject\MockObject|LegacyTranslatorInterface|TranslatorInterface */
+    private $translator;
     /** @var ContainerInterface (mock) */
     private $container;
 
-    /** @var Cache (mock) */
+    /** @var ArrayAdapter */
     private $cache;
 
     public function setUp(): void
@@ -31,14 +36,44 @@ class VersionCheckTest extends TestCase
         /* @var ContainerInterface $container */
         $this->container = $this->createMock(ContainerInterface::class);
 
-        /* @var Cache $cache */
-        $this->cache = $this->createMock(Cache::class);
+        $this->cache = $this->createMock(AdapterInterface::class);
 
         if (\interface_exists(TranslatorInterface::class)) {
             $this->translator = $this->createMock(TranslatorInterface::class);
         } else {
             $this->translator = $this->createMock(LegacyTranslatorInterface::class);
         }
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing an instance of "Doctrine\Common\Cache\CacheProvider" as the second argument in "Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker::__construct" is deprecated since KunstmaanAdminBundle 5.7 and an instance of "Symfony\Component\Cache\Adapter\AdapterInterface" will be required in KunstmaanAdminBundle 6.0.
+     */
+    public function testDeprecatedCacheConstructorParameter()
+    {
+        new VersionChecker($this->createMock(ContainerInterface::class), new ArrayCache(), $this->translator);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCacheConstructorParameterType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "$cache" parameter should extend from "Doctrine\Common\Cache\CacheProvider" or implement "Symfony\Component\Cache\Adapter\AdapterInterface"');
+
+        new VersionChecker($this->createMock(ContainerInterface::class), new \stdClass(), $this->translator);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testTranslatorConstructorParameterType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "$translator" parameter should be instance of "Symfony\Contracts\Translation\TranslatorInterface" or "Symfony\Component\Translation\TranslatorInterface"');
+
+        new VersionChecker($this->createMock(ContainerInterface::class), new ArrayCache(), new \stdClass());
     }
 
     /**
@@ -65,8 +100,9 @@ class VersionCheckTest extends TestCase
             ->will($this->onConsecutiveCalls('url', 300, true))
         ;
 
-        $versionCheckerMock = $this->setUpVersionCheckerMock(null);
-        $this->assertIsBool($versionCheckerMock->isEnabled());
+        $versionChecker = $this->getVersionChecker($this->container, new ArrayAdapter(), $this->translator);
+
+        $this->assertTrue($versionChecker->isEnabled());
     }
 
     public function testPeriodicallyCheck()
@@ -77,10 +113,14 @@ class VersionCheckTest extends TestCase
             ->will($this->onConsecutiveCalls('url', 300, true))
         ;
 
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->method('isHit')->willReturn(true);
+        $cacheItem->method('get')->willReturn([]);
+
         $this->cache
             ->expects($this->once())
-            ->method('fetch')
-            ->willReturn([])
+            ->method('getItem')
+            ->willReturn($cacheItem)
         ;
         $versionCheckerMock = $this->setUpVersionCheckerMock(null);
         $versionCheckerMock->periodicallyCheck();
@@ -135,14 +175,8 @@ class VersionCheckTest extends TestCase
             ->will($this->onConsecutiveCalls('url', 300, true, 'title'))
         ;
 
-        $requestMock = $this->createMock(Request::class);
-
-        $stackMock = $this->createMock(RequestStack::class);
-        $stackMock
-            ->expects($this->once())
-            ->method('getCurrentRequest')
-            ->willReturn($requestMock)
-        ;
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
 
         $translatorMock = $this->createMock(Translator::class);
         $translatorMock
@@ -153,10 +187,22 @@ class VersionCheckTest extends TestCase
 
         $kernelMock = $this->createMock(Kernel::class);
 
+        if ('instanceOf' === $expectedType) {
+            $cacheItem = $this->createMock(CacheItemInterface::class);
+            $cacheItem->method('isHit')->willReturn(false);
+            $cacheItem->expects($this->once())->method('expiresAfter')->with(300);
+            $cacheItem->expects($this->once())->method('set')->with($this->isInstanceOf($expected));
+
+            $this->cache
+                ->expects($this->once())
+                ->method('getItem')
+                ->willReturn($cacheItem);
+        }
+
         $this->container
             ->expects($this->exactly(3))
             ->method('get')
-            ->will($this->onConsecutiveCalls($stackMock, $kernelMock, $translatorMock))
+            ->will($this->onConsecutiveCalls($requestStack, $kernelMock, $translatorMock))
         ;
 
         $mock = new MockHandler([
@@ -195,5 +241,10 @@ class VersionCheckTest extends TestCase
             'composer.lock bundleless' => [$baseDir.'/composer_bundleless.lock', 'exception', 'translated'],
             'composer.lock not found' => [$baseDir.'/composer_not_there.lock', 'exception', 'translated'],
         ];
+    }
+
+    private function getVersionChecker(ContainerInterface $container, AdapterInterface $cache, $translator)
+    {
+        return new VersionChecker($container, $cache, $translator);
     }
 }

--- a/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/unit/KunstmaanAdminBundleTest.php
@@ -18,7 +18,7 @@ class KunstmaanAdminBundleTest extends TestCase
         $resources = $containerBuilder->getResources();
         $extensions = $containerBuilder->getExtensions();
 
-        $this->assertCount(10, $resources);
+        $this->assertCount(11, $resources);
         $this->assertCount(1, $extensions);
         $this->assertArrayHasKey('kunstmaan_admin', $extensions);
         $this->assertInstanceOf(KunstmaanAdminExtension::class, $extensions['kunstmaan_admin']);

--- a/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
@@ -2,9 +2,11 @@
 
 namespace Kunstmaan\AdminBundle\Toolbar;
 
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Kunstmaan\AdminBundle\Helper\Toolbar\AbstractDataCollector;
 use Kunstmaan\AdminBundle\Helper\VersionCheck\VersionChecker;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -13,22 +15,34 @@ class BundleVersionDataCollector extends AbstractDataCollector
     /** @var VersionChecker */
     private $versionChecker;
 
-    /** @var Cache */
+    /** @var AdapterInterface */
     private $cache;
 
-    public function __construct(VersionChecker $versionChecker, /*Logger $logger,*/ /* Cache */ $cache)
+    /**
+     * @param VersionChecker                 $versionChecker
+     * @param CacheProvider|AdapterInterface $cache
+     */
+    public function __construct(VersionChecker $versionChecker, /*Logger $logger,*/ /* AdapterInterface */ $cache)
     {
         $this->versionChecker = $versionChecker;
 
+        if (!$cache instanceof CacheProvider && !$cache instanceof AdapterInterface) {
+            // NEXT_MAJOR Add AdapterInterface typehint for the $cache parameter
+            throw new \InvalidArgumentException(sprintf('The "$cache" parameter should extend from "%s" or implement "%s"', CacheProvider::class, AdapterInterface::class));
+        }
+
+        $this->cache = $cache;
         if (\func_num_args() > 2) {
             @trigger_error(sprintf('Passing the "logger" service as the second argument in "%s" is deprecated in KunstmaanAdminBundle 5.1 and will be removed in KunstmaanAdminBundle 6.0. Remove the "logger" argument from your service definition.', __METHOD__), E_USER_DEPRECATED);
 
             $this->cache = func_get_arg(2);
-
-            return;
         }
 
-        $this->cache = $cache;
+        if ($this->cache instanceof CacheProvider) {
+            @trigger_error(sprintf('Passing an instance of "%s" as the second argument in "%s" is deprecated since KunstmaanAdminBundle 5.7 and an instance of "%s" will be required in KunstmaanAdminBundle 6.0.', CacheProvider::class, __METHOD__, AdapterInterface::class), E_USER_DEPRECATED);
+
+            $this->cache = new DoctrineAdapter($cache);
+        }
     }
 
     public function getAccessRoles()
@@ -40,10 +54,14 @@ class BundleVersionDataCollector extends AbstractDataCollector
     {
         $this->versionChecker->periodicallyCheck();
 
-        $data = $this->cache->fetch('version_check');
+        $cacheItem = $this->cache->getItem(VersionChecker::CACHE_KEY);
+        $collectorData = [];
+        if ($cacheItem->isHit()) {
+            $collectorData = $cacheItem->get() ?? [];
+        }
 
         return [
-            'data' => $data,
+            'data' => $collectorData,
         ];
     }
 

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -24,6 +24,7 @@
         "kunstmaan/node-bundle": "~5.2",
         "kunstmaan/utilities-bundle": "~5.2",
         "symfony/acl-bundle": "^1.0|^2.0",
+        "symfony/cache": "^3.4|^4.4",
         "symfony/config": "^3.4|^4.4",
         "symfony/console": "^3.4|^4.4",
         "symfony/dependency-injection": "^3.4|^4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

The doctrine/cache-bundle is deprecated for symfony 5 and the usage of symfony/cache is advised