### PR TITLE
[AdminBundle] Bump knplabs/knp-menu-bundle and remove default config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "incenteev/composer-parameter-handler": "^2.0",
 
         "friendsofsymfony/user-bundle": "^2.0",
-        "knplabs/knp-menu-bundle": "~2.0",
+        "knplabs/knp-menu-bundle": "^3.0",
         "guzzlehttp/guzzle": "~6.1",
         "white-october/pagerfanta-bundle": "~1.0",
         "kunstmaan/google-api-custom": "~1.0",

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -90,11 +90,6 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
 
     public function prepend(ContainerBuilder $container)
     {
-        $knpMenuConfig['twig'] = true; // set to false to disable the Twig extension and the TwigRenderer
-        $knpMenuConfig['templating'] = false; // if true, enables the helper for PHP templates
-        $knpMenuConfig['default_renderer'] = 'twig'; // The renderer to use, list is also available by default
-        $container->prependExtensionConfig('knp_menu', $knpMenuConfig);
-
         $fosUserOriginalConfig = $container->getExtensionConfig('fos_user');
         if (!isset($fosUserOriginalConfig[0]['db_driver'])) {
             $fosUserConfig['db_driver'] = 'orm'; // other valid values are 'mongodb', 'couchdb'

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -20,7 +20,7 @@
         "doctrine/doctrine-cache-bundle": "^1.2",
         "friendsofsymfony/user-bundle": "^2.0",
         "guzzlehttp/guzzle": "~6.1",
-        "knplabs/knp-menu-bundle": "~2.0",
+        "knplabs/knp-menu-bundle": "^3.0",
         "kunstmaan/node-bundle": "~5.2",
         "kunstmaan/utilities-bundle": "~5.2",
         "symfony/acl-bundle": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The config we set in the admin extension is equal to the default config. Prepare code to support symfony 5

Needs rebase after #2748 to make the builds pass
