### PR TITLE
[NodeBundle] Dont start session if not needed

### DIFF
--- a/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/NodeTranslationListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class NodeTranslationListener
 {
-    /** @var FlashBagInterface */
+    /** @var SessionInterface|FlashBagInterface */
     private $flashBag;
 
     /** @var LoggerInterface */
@@ -66,8 +66,6 @@ class NodeTranslationListener
 
         if ($flashBag instanceof FlashBagInterface) {
             @trigger_error('Passing the "@session.flash_bag" service as first argument is deprecated since KunstmaanNodeBundle 5.6 and will be replaced by the session in KunstmaanNodeBundle 6.0. Inject the "@session" service instead.', E_USER_DEPRECATED);
-        } elseif ($flashBag instanceof SessionInterface) {
-            $this->flashBag = $flashBag->getFlashBag();
         }
 
         $this->logger = $logger;
@@ -339,7 +337,7 @@ class NodeTranslationListener
         } elseif (\count($flashes) > 0 && $this->isInRequestScope()) {
             // No translations found so we're certain we can show this message.
             $flash = current(\array_slice($flashes, -1));
-            $this->flashBag->add(FlashTypes::WARNING, $flash);
+            $this->getFlashBag()->add(FlashTypes::WARNING, $flash);
         }
 
         return true;
@@ -380,5 +378,14 @@ class NodeTranslationListener
     private function isInRequestScope()
     {
         return $this->requestStack && $this->requestStack->getCurrentRequest();
+    }
+
+    private function getFlashBag()
+    {
+        if ($this->flashBag instanceof SessionInterface) {
+            return $this->flashBag->getFlashBag();
+        }
+
+        return $this->flashBag;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The call to getFlashBag in the constructor triggers a session start which is not needed.
