### PR TITLE
[WIP][NodeBundle] Disallow trailing slash in slug router

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
+++ b/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
@@ -5,6 +5,9 @@ namespace Kunstmaan\NodeBundle\Form\Type;
 use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 
@@ -37,6 +40,19 @@ class SlugType extends AbstractType
     public function getBlockPrefix()
     {
         return 'slug';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
+            $slug = $event->getData();
+            $slug = \rtrim($slug, '/');
+            $event->setData($slug);
+        });
     }
 
     /**

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -71,7 +71,7 @@ class SlugRouter implements RouterInterface
         EntityManagerInterface $em = null,
         $adminKey = null
     ) {
-        $this->slugPattern = "[a-zA-Z0-9\-_\/]*";
+        $this->slugPattern = "[a-zA-Z0-9\-_\/]*[^\/]$";
 
         if ($domainConfiguration instanceof ContainerInterface) {
             @trigger_error('Container injection and the usage of the container is deprecated in KunstmaanNodeBundle 5.1 and will be removed in KunstmaanNodeBundle 6.0.', E_USER_DEPRECATED);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Changed the regex to not allow trailing slashes. This way, trailing slashes will fallback to the symfony router, which (when correctly configured) will redirect the page without the slash.

This fixes a bug where the main page under a locale path (example.com/en) has duplicate content because both the trailing slash and non trailing slash return the same content.