### PR TITLE
[AllBundles] Use absolute_url twig function instead of using app.request data

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/DownloadPagePart/view.html.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Resources/views/PageParts/DownloadPagePart/view.html.twig
@@ -5,7 +5,7 @@
     {% endif %}
 
     <p class="download-pp">
-        <a href="{{ app.request.schemeandhttphost ~ app.request.basePath ~ asset(resource.media.url) }}" target="_blank" class="download">{{ name }}</a>
+        <a href="{{ absolute_url(asset(resource.media.url)) }}" target="_blank" class="download">{{ name }}</a>
         <span>| {{ resource.media.contentTypeShort }} {{ resource.media.getFileSize() }}</span>
     </p>
 {% endif %}

--- a/src/Kunstmaan/MediaBundle/Resources/views/Media/File/show.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Media/File/show.html.twig
@@ -14,8 +14,9 @@
         {{ 'media.media.mediainfo.downloadlink'|trans }}:
     </dt>
     <dd>
-        <a href="{{ app.request.getScheme()~'://'~app.request.getHttpHost()~asset(media.url) }}" target="_blank">
-            {{ app.request.getScheme()~'://'~app.request.getHttpHost()~asset(media.url) }}
+        {% set mediaUrl = media.url %}
+        <a href="{{ absolute_url(asset(mediaUrl)) }}" target="_blank">
+            {{ absolute_url(asset(mediaUrl)) }}
         </a>
     </dd>
 {% endblock %}

--- a/src/Kunstmaan/MediaBundle/Resources/views/Media/Image/show.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Media/Image/show.html.twig
@@ -3,7 +3,7 @@
 {% block extraactions %}
 
     {% if handler.aviaryApiKey and not (handler.aviaryApiKey starts with 'Register') %}
-        <button type="button" class="btn btn-primary btn--raise-on-hover" onclick="return launchEditor('editimage', '{{ app.request.getScheme()~'://'~app.request.getHttpHost()~asset(media.url) }}');" >
+        <button type="button" class="btn btn-primary btn--raise-on-hover" onclick="return launchEditor('editimage', '{{ absolute_url(asset(media.url)) }}');" >
             {{ 'media.media.edit.action' | trans }}
         </button>
 

--- a/src/Kunstmaan/MediaPagePartBundle/Resources/views/DownloadPagePart/view.html.twig
+++ b/src/Kunstmaan/MediaPagePartBundle/Resources/views/DownloadPagePart/view.html.twig
@@ -3,6 +3,6 @@
     {% if name is empty %}
         {% set name = "Download" %}
     {% endif %}
-    <p class="download-pp"><a href="{{ app.request.schemeandhttphost ~ app.request.basePath ~ asset(resource.media.url) }}" target="_blank" class="download">{{ name }}</a> <span>| {{ resource.media.contentTypeShort }} {{ resource.media.getFileSize() }}</span></p>
+    <p class="download-pp"><a href="{{ absolute_url(asset(resource.media.url)) }}" target="_blank" class="download">{{ name }}</a> <span>| {{ resource.media.contentTypeShort }} {{ resource.media.getFileSize() }}</span></p>
 {% endif %}
 

--- a/src/Kunstmaan/MediaPagePartBundle/Resources/views/ImagePagePart/view.html.twig
+++ b/src/Kunstmaan/MediaPagePartBundle/Resources/views/ImagePagePart/view.html.twig
@@ -2,7 +2,7 @@
     <div class="image-pp">
         {% set imgUrl = '' %}
         {% if app.request %}
-            {% set imgUrl = app.request.schemeandhttphost ~ app.request.basePath ~ asset(resource.media.url) %}
+            {% set imgUrl = absolute_url(asset(resource.media.url)) %}
         {% endif %}
         {% if resource.link is defined and resource.link != "" %}
             <a href="{{ resource.link | replace_url}}" {% if resource.openinnewwindow %}target="_blank"{% endif %}><img src="{{ imgUrl }}" alt="{{ resource.alttext }}" /></a>

--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -102,7 +102,7 @@
             <meta name="twitter:player" content="{{ videoUrl }}" />
             <meta name="twitter:player:width" content="960">
             <meta name="twitter:player:height" content="540">
-            <meta name="twitter:image:src" content="{{ app.request.schemeandhttphost ~ asset(seo.twitterImage.metaData.thumbnail_url) }}" />
+            <meta name="twitter:image:src" content="{{ absolute_url(asset(seo.twitterImage.metaData.thumbnail_url)) }}" />
         {% else %}
             <meta name="twitter:image:src" content="{{ asset(seo.twitterImage.url | imagine_filter('tw_card_image')) }}" />
         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Use absolute_url twig function instead of making the url based on app.request data. This allows to set a custom base_url.