### PR TITLE
[AdminListBundle] Change pagerfanta dependencies to require the minimum needed packages

### DIFF
--- a/UPGRADE-5.9.md
+++ b/UPGRADE-5.9.md
@@ -5,6 +5,10 @@ General
 -------
 
 * All event classes are marked as final.
+* If you still require the `kunstmaan/bundles-cms` package, update you `composer.json` to require `babdev/pagerfanta-bundle`
+  instead of `white-october/pagerfanta-bundle`. All specific bundle packages that use pagerfanta functionality are now requiring
+  the specifc pagerfanta packages. Newer skeleton installs will require the correct pagerfanta bundle package but old projects
+  or projects using the `white-october` package are encouraged to switch their dependencies.
 
 AdminBundle
 ------------

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "friendsofsymfony/user-bundle": "^2.0",
         "knplabs/knp-menu-bundle": "^3.0",
         "guzzlehttp/guzzle": "~6.1",
-        "white-october/pagerfanta-bundle": "~1.0",
+        "babdev/pagerfanta-bundle": "^2.5",
         "kunstmaan/google-api-custom": "~1.0",
         "gedmo/doctrine-extensions": "^2.4.34",
         "doctrine/doctrine-fixtures-bundle": "^3.3",

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/PagerfantaBridgePass.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Compiler/PagerfantaBridgePass.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kunstmaan\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
+ * NEXT_MAJOR remove class
+ *
+ * @deprecated since KunstmaanAdminBundle 5.9. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in KunstmaanAdminBundle 6.0.
+ *
+ * @internal
+ */
+final class PagerfantaBridgePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $this->changeViewFactoryClass($container);
+        $this->aliasRenamedServices($container);
+    }
+
+    private function changeViewFactoryClass(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('white_october_pagerfanta.view_factory.class') || !$container->hasDefinition('pagerfanta.view_factory')) {
+            return;
+        }
+
+        $container->getDefinition('pagerfanta.view_factory')
+            ->setClass($container->getParameter('white_october_pagerfanta.view_factory.class'));
+    }
+
+    private function aliasRenamedServices(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('pagerfanta.twig_extension')) {
+            $alias = $container->setAlias('twig.extension.pagerfanta', 'pagerfanta.twig_extension');
+            if (method_exists(Alias::class, 'setDeprecated')) {
+                $alias->setDeprecated(true, 'The "%alias_id%" service alias is deprecated since KunstmaanAdminBundle 5.9, use the "pagerfanta.twig_extension" service ID instead.');
+            }
+        }
+
+        if ($container->hasDefinition('pagerfanta.view_factory')) {
+            $alias = $container->setAlias('white_october_pagerfanta.view_factory', 'pagerfanta.view_factory');
+            if (method_exists(Alias::class, 'setDeprecated')) {
+                $alias->setDeprecated(true, 'The "%alias_id%" service alias is deprecated since KunstmaanAdminBundle 5.9, use the "pagerfanta.view_factory" service ID instead.');
+            }
+        }
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/PagerfantaConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/PagerfantaConfiguration.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Container configuration to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
+ * NEXT_MAJOR remove class
+ *
+ * @deprecated since KunstmaanAdminBundle 5.9. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in KunstmaanAdminBundle 6.0.
+ *
+ * @internal
+ */
+final class PagerfantaConfiguration implements ConfigurationInterface
+{
+    public const EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND = 'to_http_not_found';
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('white_october_pagerfanta');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('white_october_pagerfanta');
+        }
+
+        $this->addExceptionsStrategySection($rootNode);
+
+        $rootNode
+            ->children()
+                ->scalarNode('default_view')
+                    ->defaultValue('default')
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+
+    private function addExceptionsStrategySection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('exceptions_strategy')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('out_of_range_page')->defaultValue(self::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND)->end()
+                        ->scalarNode('not_valid_current_page')->defaultValue(self::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND)->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/PagerfantaExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/PagerfantaExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * Container extension to bridge the configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle
+ * NEXT_MAJOR remove class
+ *
+ * @deprecated since KunstmaanAdminBundle 5.9. Migrate your Pagerfanta configuration from WhiteOctoberPagerfantaBundle to BabDevPagerfantaBundle, the configuration bridge will be removed in KunstmaanAdminBundle 6.0.
+ *
+ * @internal
+ */
+class PagerfantaExtension extends Extension implements PrependExtensionInterface
+{
+    public function getAlias(): string
+    {
+        return 'white_october_pagerfanta';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): PagerfantaConfiguration
+    {
+        return new PagerfantaConfiguration();
+    }
+
+    public function load(array $config, ContainerBuilder $container): void
+    {
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
+
+        $container->setParameter('white_october_pagerfanta.default_view', $config['default_view']);
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $config = $this->processConfiguration($this->getConfiguration([], $container), $container->getExtensionConfig($this->getAlias()));
+
+        $container->prependExtensionConfig('babdev_pagerfanta', $config);
+    }
+}

--- a/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
+++ b/src/Kunstmaan/AdminBundle/KunstmaanAdminBundle.php
@@ -12,8 +12,11 @@ use Kunstmaan\AdminBundle\DependencyInjection\Compiler\DomainConfigurationPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\EnablePermissionsPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\InjectUntrackedTokenStorageCompilerPass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\MenuCompilerPass;
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\PagerfantaBridgePass;
 use Kunstmaan\AdminBundle\DependencyInjection\Compiler\VersionCheckerCacheBcPass;
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
+use Kunstmaan\AdminBundle\DependencyInjection\PagerfantaExtension;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -43,5 +46,8 @@ class KunstmaanAdminBundle extends Bundle
         $container->addCompilerPass(new VersionCheckerCacheBcPass());
 
         $container->registerExtension(new KunstmaanAdminExtension());
+
+        $container->registerExtension(new PagerfantaExtension());
+        $container->addCompilerPass(new PagerfantaBridgePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1); // Should run after all passes from BabDevPagerfantaBundle
     }
 }

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/Compiler/PagerfantaBridgePassTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/Compiler/PagerfantaBridgePassTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Kunstmaan\AdminBundle\DependencyInjection\Compiler\PagerfantaBridgePass;
+use Kunstmaan\AdminBundle\DependencyInjection\PagerfantaExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Pagerfanta\View\ViewFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class PagerfantaBridgePassTest extends AbstractCompilerPassTestCase
+{
+    public function testWhiteOctoberAliasedServicesAndParametersAreCreated(): void
+    {
+        $this->registerService('pagerfanta.twig_extension', PagerfantaExtension::class);
+        $this->registerService('pagerfanta.view_factory', ViewFactory::class);
+
+        $this->setParameter('white_october_pagerfanta.view_factory.class', 'My\ViewFactory');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('twig.extension.pagerfanta', 'pagerfanta.twig_extension');
+        $this->assertContainerBuilderHasAlias('white_october_pagerfanta.view_factory', 'pagerfanta.view_factory');
+        $this->assertContainerBuilderHasService('pagerfanta.view_factory', 'My\ViewFactory');
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new PagerfantaBridgePass());
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/PagerfantaExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/PagerfantaExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\DependencyInjection;
+
+use BabDev\PagerfantaBundle\BabDevPagerfantaBundle;
+use BabDev\PagerfantaBundle\DependencyInjection\BabDevPagerfantaExtension;
+use Kunstmaan\AdminBundle\DependencyInjection\PagerfantaExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+
+class PagerfantaExtensionTest extends AbstractExtensionTestCase
+{
+    public function testWhiteOctoberBundleConfigPrependedToBabDevBundle(): void
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'BabDevPagerfantaBundle' => BabDevPagerfantaBundle::class,
+                'TwigBundle' => TwigBundle::class,
+            ]
+        );
+
+        $bundleConfig = [
+            'default_view' => 'twitter_bootstrap',
+            'exceptions_strategy' => [
+                'out_of_range_page' => 'custom',
+                'not_valid_current_page' => 'to_http_not_found',
+            ],
+        ];
+
+        // Prepend config now to allow the prepend pass to work
+        $this->container->prependExtensionConfig('white_october_pagerfanta', $bundleConfig);
+
+        $this->load($bundleConfig);
+
+        $this->assertSame([$bundleConfig], $this->container->getExtensionConfig('babdev_pagerfanta'));
+        $this->assertContainerBuilderHasParameter('white_october_pagerfanta.default_view', $bundleConfig['default_view']);
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new PagerfantaExtension(),
+            new BabDevPagerfantaExtension(),
+        ];
+    }
+}

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "babdev/pagerfanta-bundle": "^2.5",
         "doctrine/orm": "^2.5",
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.6.12|^2.0",
@@ -53,8 +54,7 @@
         "symfony/yaml": "^3.4|^4.4",
         "twig/twig": "^1.40|^2.9",
         "twig/extensions": "~1.0",
-        "sensio/framework-extra-bundle": "^5.0",
-        "white-october/pagerfanta-bundle": "~1.0"
+        "sensio/framework-extra-bundle": "^5.0"
     },
     "suggest": {
         "kunstmaan/translator-bundle": "^5.2",

--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineORMAdminListConfigurator.php
@@ -10,7 +10,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionDefinition;
 use Kunstmaan\AdminListBundle\AdminList\Filter;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\AbstractORMFilterType;
 use Kunstmaan\AdminListBundle\AdminList\SortableInterface;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter as OrmQueryAdapter;
 use Pagerfanta\Pagerfanta;
 use Traversable;
 
@@ -92,7 +92,7 @@ abstract class AbstractDoctrineORMAdminListConfigurator extends AbstractAdminLis
     public function getPagerfanta()
     {
         if (\is_null($this->pagerfanta)) {
-            $adapter = new DoctrineORMAdapter($this->getQuery());
+            $adapter = new OrmQueryAdapter($this->getQuery());
             $this->pagerfanta = new Pagerfanta($adapter);
             $this->pagerfanta->setNormalizeOutOfRangePages(true);
             $this->pagerfanta->setMaxPerPage($this->getLimit());

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Helper/DoctrineDBALAdapterTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Helper/DoctrineDBALAdapterTest.php
@@ -9,6 +9,11 @@ use PHPUnit\Framework\TestCase;
 
 class DoctrineDBALAdapterTest extends TestCase
 {
+    /**
+     * Mark test as legacy to avoid "\Pagerfanta\Exception\Exception" interface deprecation
+     *
+     * @group legacy
+     */
     public function testConstructorWithIncorrectCountField()
     {
         $this->expectExceptionMessage('The $countField must contain a table alias in the string.');

--- a/src/Kunstmaan/AdminListBundle/composer.json
+++ b/src/Kunstmaan/AdminListBundle/composer.json
@@ -14,8 +14,11 @@
     ],
     "require": {
         "php": "^7.2",
+        "box/spout": "^2.5",
         "kunstmaan/admin-bundle": "^5.7",
-        "box/spout": "^2.5"
+        "pagerfanta/core": "^2.4",
+        "pagerfanta/doctrine-orm-adapter": "^2.4",
+        "pagerfanta/twig": "^2.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -15,7 +15,9 @@
     "require": {
         "php": "^7.2",
         "kunstmaan/adminlist-bundle": "^5.2",
-        "kunstmaan/pagepart-bundle": "^5.2"
+        "kunstmaan/pagepart-bundle": "^5.2",
+        "pagerfanta/core": "^2.4",
+        "pagerfanta/twig": "^2.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Kunstmaan/MediaBundle/composer.json
+++ b/src/Kunstmaan/MediaBundle/composer.json
@@ -20,7 +20,8 @@
         "symfony/mime": "^4.4",
         "imagine/imagine": "^1.1",
         "knplabs/knp-gaufrette-bundle": "~0.1",
-        "kunstmaan/adminlist-bundle": "~5.2"
+        "kunstmaan/adminlist-bundle": "~5.2",
+        "pagerfanta/twig": "^2.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Kunstmaan/NodeSearchBundle/composer.json
+++ b/src/Kunstmaan/NodeSearchBundle/composer.json
@@ -22,7 +22,9 @@
         "php": "^7.2",
         "kunstmaan/admin-bundle": "^5.7",
         "kunstmaan/pagepart-bundle": "~5.2",
-        "kunstmaan/search-bundle": "~5.2"
+        "kunstmaan/search-bundle": "~5.2",
+        "pagerfanta/core": "^2.4",
+        "pagerfanta/twig": "^2.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #2755

The `white-october/pagerfanta-bundle` package is not a required dependency for the cms, this will also make supporting symfony 5 easier. This PR also adds a BC layer to convert "old" WhiteOctober bundle config to the new bundle

TODO:

- [ ] Create PR for cms skeleton to require babdev bundle
- [ ] Test with projects requiring old bundle