### PR TITLE
[MediaBundle] Use parameter instead of hardcoded media path

### DIFF
--- a/UPGRADE-5.9.md
+++ b/UPGRADE-5.9.md
@@ -26,3 +26,8 @@ UserManagementBundle
 ------------
 
 * Overriding the user adminlist configurator class with `kunstmaan_user_management.user_admin_list_configurator.class` is deprecated, use the `kunstmaan_user_management.user.adminlist_configurator` config instead.
+
+MediaBundle
+----------
+
+* Not passing a value for the "$mediaPath" parameter of "\Kunstmaan\MediaBundle\Helper\File\FileHelper::__construct" is deprecated, a value will be required.

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -169,7 +169,7 @@ class FileHandler extends AbstractMediaHandler
      */
     public function getFormHelper(Media $media)
     {
-        return new FileHelper($media);
+        return new FileHelper($media, $this->mediaPath);
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHelper.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHelper.php
@@ -28,9 +28,19 @@ class FileHelper
      */
     protected $path;
 
-    public function __construct(Media $media)
+    /** @var string */
+    private $mediaPath;
+
+    public function __construct(Media $media, string $mediaPath = null)
     {
         $this->media = $media;
+
+        if ($mediaPath === null) {
+            @trigger_error(sprintf('Not passing a value for the "$mediaPath" parameter of "%s" is deprecated since KunstmaanMediaBundle 5.9 and a value will be required in KunstmaanMediaBundle 6.0. Injected the required parameter in the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+            $mediaPath = '/uploads/media/';
+        }
+
+        $this->mediaPath = $mediaPath;
     }
 
     /**
@@ -122,7 +132,7 @@ class FileHelper
             $this->media->setContent($file);
             $this->media->setContentType($file->getMimeType());
             $this->media->setUrl(
-                '/uploads/media/' . $this->media->getUuid() . '.' . $this->media->getContent()->getExtension()
+                $this->mediaPath . $this->media->getUuid() . '.' . $this->media->getContent()->getExtension()
             );
         }
     }

--- a/src/Kunstmaan/MediaBundle/Tests/Helper/File/FileHelperTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Helper/File/FileHelperTest.php
@@ -23,7 +23,7 @@ class FileHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->media = new Media();
-        $this->object = new FileHelper($this->media);
+        $this->object = new FileHelper($this->media, '/uploads/media/');
     }
 
     public function testGetSetName()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR
