### PR TITLE
[GeneratorBundle] Remove buildCmsAssets from generated FE tasks - assets are compiled in git repo

### DIFF
--- a/UPGRADE-5.7.md
+++ b/UPGRADE-5.7.md
@@ -11,6 +11,11 @@ AdminBundle
 
 * Validator\Constraints\PasswordRestrictions have had their error constant values changed from integer to string uuid's because integers have been deprecated by Symfony.
 
+GeneratorBundle
+----------
+
+* The task `npm run buildCmsAssets` is removed from the generated frontend build setup. This task is a remainder of old rework and does not work anymore with the new bundles setup. If you want to extend the Javascript functionality of the CMS, you can use the `admin-bundle-extra.js` in the `/assets/admin/js` directory.
+
 MediaBundle
 ------------
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/gulpfile.babel.js
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/gulpfile.babel.js
@@ -1,5 +1,4 @@
 import gulp from 'gulp';
-import chug from 'gulp-chug';
 
 import {
     images,
@@ -75,13 +74,4 @@ const startOptimized = gulp.series(
     server,
 );
 
-const buildCmsAssets = gulp.series(() => gulp.src('vendor/kunstmaan/bundles-cms/gulpfile.babel.js', { read: false })
-    .pipe(chug({
-        args: [
-            '--rootPath',
-            '../../../../../../../{% if isV4 %}public{% else %}web{% endif %}/assets/',
-        ],
-        tasks: ['buildOptimized'],
-    })));
-
-export { test, buildOptimized, testAndBuildOptimized, startLocal, startOptimized, buildCmsAssets };
+export { test, buildOptimized, testAndBuildOptimized, startLocal, startOptimized };

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/package.json
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/layout/groundcontrol/package.json
@@ -6,9 +6,7 @@
     "startOptimized": "gulp startOptimized",
     "test": "gulp test",
     "build": "gulp buildOptimized",
-    "testAndBuild": "gulp testAndBuildOptimized",
-    "buildCmsAssets": "npm run installCmsAssetsNodemodules && gulp buildCmsAssets",
-    "installCmsAssetsNodemodules": "cd vendor/kunstmaan/bundles-cms && npm install"
+    "testAndBuild": "gulp testAndBuildOptimized"
   },
   "author": "Kunstmaan",
   "license": "ISC",
@@ -37,7 +35,6 @@
     "gulp-autoprefixer": "^3.1.1",
     "gulp-cached": "^1.1.1",
     "gulp-changed": "^3.2.0",
-    "gulp-chug": "^0.5.1",
     "gulp-eslint": "^4.0.0",
     "gulp-if": "^2.0.2",
     "gulp-imagemin": "^4.1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #2440
