### PR TITLE
[NodeBundle] Improve nodetranslation repository deprecation

### DIFF
--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -35,10 +35,18 @@ class NodeTranslationRepository extends EntityRepository
     }
 
     /**
+     * NEXT_MAJOR: add int typehint for $nodeId.
+     *
+     * @param int $nodeId
+     *
      * @return NodeTranslation|null
      */
-    public function getNodeTranslationByNodeId(int $nodeId, string $lang)
+    public function getNodeTranslationByNodeId($nodeId, string $lang)
     {
+        if (!is_int($nodeId)) {
+            @trigger_error(sprintf('Not passing an integer for the "$nodeId" parameter in "%s" is deprecated since KunstmaanAdminBundle 5.7 and an integer typehint will be added in KunstmaanAdminBundle 6.0."', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $qb = $this->createQueryBuilder('nt')
             ->select('nt')
             ->innerJoin('nt.node', 'n', 'WITH', 'nt.node = n.id')

--- a/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
@@ -125,7 +125,7 @@ class NodeTwigExtension extends AbstractExtension
     {
         $repo = $this->em->getRepository(NodeTranslation::class);
 
-        return $repo->getNodeTranslationByNodeIdQueryBuilder($nodeId, $lang);
+        return $repo->getNodeTranslationByNodeId($nodeId, $lang);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Follow up for #2716. Don't use the deprecated repository method in our own code and remove the int typehint for now (and deprecate passing other values than integers) to avoid an indirect BC break as passing an object was possible in the past (although the phpdoc didn't indicate this) and actually produced the expected results
