### PR TITLE
[AdminListBundle] Fix: Remove wrong PHPDoc

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Helper/DoctrineDBALAdapterTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Helper/DoctrineDBALAdapterTest.php
@@ -7,9 +7,6 @@ use Doctrine\DBAL\Statement;
 use Kunstmaan\AdminListBundle\Helper\DoctrineDBALAdapter;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AdminListTest
- */
 class DoctrineDBALAdapterTest extends TestCase
 {
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR
