### PR TITLE
[MediaBundle] Fix media list without pagination

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
+++ b/src/Kunstmaan/MediaBundle/Resources/views/Folder/show.html.twig
@@ -223,6 +223,8 @@
                     {% if adminlist.count > 0 %}
                         {% if adminlist.pagerfanta.haveToPaginate() %}
                             {{ pagerfanta(adminlist.pagerfanta, 'twitter_bootstrap_translated') }}
+                        {% else %}
+                            <div class="row row--padded"></div>
                         {% endif %}
                         <div class="row">
                             {% for media in adminlist.items %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

When no pagination is available you see this
![before_without_pag](https://user-images.githubusercontent.com/1218389/98009036-6c885880-1df5-11eb-88a1-b93cf1471524.png)

After
![after_without_pag](https://user-images.githubusercontent.com/1218389/98009046-6eeab280-1df5-11eb-8a5a-2ae77b6ac057.png)

With pagination
![with_pag](https://user-images.githubusercontent.com/1218389/98009024-6a25fe80-1df5-11eb-8e55-6d292a076d31.png)
