### PR TITLE
[NodeBundle] Change nodetranslation slug/url fields to text type to allow long values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/yaml": "^3.4|^4.2",
         "symfony/css-selector": "^3.4|^4.2",
         "doctrine/orm": "^2.5",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "^2.9",
         "doctrine/doctrine-bundle": "^1.6.12",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^1.3",

--- a/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeTranslation.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(
  *     name="kuma_node_translations",
  *     uniqueConstraints={@ORM\UniqueConstraint(name="ix_kuma_node_translations_node_lang", columns={"node_id", "lang"})},
- *     indexes={@ORM\Index(name="idx__node_translation_lang_url", columns={"lang", "url"})}
+ *     indexes={@ORM\Index(name="idx__node_translation_lang_url", columns={"lang", "url"}, options={"lengths": {null, 750}})}
  * )
  * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
  */
@@ -56,13 +56,15 @@ class NodeTranslation extends AbstractEntity
      *
      * @ORM\Column(type="string", nullable=true)
      * @Assert\Regex("/^[a-zA-Z0-9\-_\/]+$/")
+     * @Assert\Length(max="255")
      */
     protected $slug;
 
     /**
      * @var string
      *
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="text", nullable=true)
+     * @Assert\Length(max="1000")
      */
     protected $url;
 

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "doctrine/dbal": "^2.9",
         "gedmo/doctrine-extensions": "^2.4.34",
         "kunstmaan/adminlist-bundle": "~5.2",
         "stof/doctrine-extensions-bundle": "~1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Currently there is a database limit of 255 chars on urls, this might cause troubles on sites with deep nested content and/or long slugs
