### PR TITLE
[AdminListBundle] Fix: Wrong namespace

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Helper/DoctrineDBALAdapterTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/unit/AdminList/Helper/DoctrineDBALAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\AdminListBundle\Tests\AdminList;
+namespace Kunstmaan\AdminListBundle\Tests\AdminList\Helper;
 
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Statement;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

cc @igst

@acrobat can you explain the `unit/` in the path, but not in the namespace? Also `unit/` is not handled properly in `composer.json` 🤔 