### PR TITLE
[AdminBundle] allow slug input-group to use more space if available

### DIFF
--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/_components.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/_components.scss
@@ -31,6 +31,7 @@
         "forms/form-control",
         "forms/label",
         "forms/widget",
+        "forms/slug-chooser",
         "forms/date-time-group";
 
 

--- a/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/forms/_slug-chooser.scss
+++ b/src/Kunstmaan/AdminBundle/Resources/ui/scss/default-theme/components/forms/_slug-chooser.scss
@@ -1,0 +1,34 @@
+/* ==========================================================================
+   Slug Chooser
+   ========================================================================== */
+.slug-chooser {
+    .input-group {
+        position: relative;
+
+        display: inline-flex;
+        align-items: stretch;
+        width: auto;
+        min-width: 40rem;
+        max-width: 100%;
+    }
+
+    .form-control,
+    .input-group-btn,
+    .input-group-addon {
+        width: auto;
+    }
+
+    .form-control {
+        flex: 1 0 auto;
+        width: 200px;
+    }
+
+    .input-group-addon {
+        display: block;
+        overflow: hidden;
+        padding-top: 9px;
+        padding-bottom: 8px;
+
+        text-overflow: ellipsis;
+    }
+}

--- a/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
+++ b/src/Kunstmaan/AdminBundle/Resources/views/Form/fields.html.twig
@@ -146,7 +146,17 @@
 {# Rows #}
 {% block form_row %}
 {% apply spaceless %}
-    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}{% if attr['nested_form'] is defined and attr['nested_form'] == true or 'wysiwyg' in block_prefixes or attr['no-max-width'] is defined and attr['no-max-width'] == true %} form-group--no-max-width{% endif %}">
+    {% set noMaxWidth = false %}
+    {% if
+        (attr['nested_form'] is defined and attr['nested_form'] == true)
+        or 'wysiwyg' in block_prefixes
+        or 'slug' in block_prefixes
+        or (attr['no-max-width'] is defined and attr['no-max-width'])
+    %}
+        {% set noMaxWidth = true %}
+    {% endif %}
+
+    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}{% if noMaxWidth == true %} form-group--no-max-width{% endif %}">
         {{ form_label(form) }}
 
         {% if attr['nested_form'] is defined and attr['nested_form'] == true %}

--- a/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
+++ b/src/Kunstmaan/NodeBundle/Resources/views/Form/formWidgets.html.twig
@@ -83,31 +83,33 @@
             {% set prefix = '/' ~ prefix %}
         {% endif %}
 
-        <div id="{{ id }}-slug-chooser" class="js-slug-chooser" data-url-prefix="{{ prefix }}" data-reset="{{ reset }}">
-            <div class="input-group">
-                {% if prefix is not empty %}
-                    <span class="input-group-addon js-slug-chooser__prefix">
-                        {{ prefix }}
+        <div id="{{ id }}-slug-chooser" class="js-slug-chooser slug-chooser" data-url-prefix="{{ prefix }}" data-reset="{{ reset }}">
+            <div>
+                <div class="input-group slug-chooser">
+                    {% if prefix is not empty %}
+                        <span class="input-group-addon js-slug-chooser__prefix" title="{{ prefix }}">
+                            {{ prefix }}
+                        </span>
+                    {% endif %}
+                    <input type="text" name="{{ full_name }}" id="{{ id }}" value="{{ value|default('') }}" class="js-slug-chooser__input form-control">
+                    <span class="input-group-btn">
+                        <button type="button" class="js-slug-chooser__reset-btn btn btn-default btn--raise-on-hover" id="{{ id }}-slug-chooser__resetbtn">
+                            Reset
+                        </button>
                     </span>
-                {% endif %}
-                <input type="text" name="{{ full_name }}" id="{{ id }}" value="{{ value|default('') }}" class="js-slug-chooser__input form-control">
-                <span class="input-group-btn">
-                    <button type="button" class="js-slug-chooser__reset-btn btn btn-default btn--raise-on-hover" id="{{ id }}-slug-chooser__resetbtn">
-                        Reset
-                    </button>
-                </span>
-            </div>
-            <div>
-                <small>
-                    {{ 'kuma_node.form.current_url' | trans }}: <a href="{{ url }}" target="_blank">
-                        {{ url }}
-                    </a>
-                </small>
-            </div>
-            <div>
-                <small class="js-slug-chooser__preview" style="display: none;">
-                    {{ 'kuma_node.form.updated_url' | trans }}: <span></span>
-                </small>
+                </div>
+                <div>
+                    <small>
+                        {{ 'kuma_node.form.current_url' | trans }}: <a href="{{ url }}" target="_blank">
+                            {{ url }}
+                        </a>
+                    </small>
+                </div>
+                <div>
+                    <small class="js-slug-chooser__preview" style="display: none;">
+                        {{ 'kuma_node.form.updated_url' | trans }}: <span></span>
+                    </small>
+                </div>
             </div>
         </div>
     {% endapply %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2749

Allow the slug input-group to use more space, if available. If not, we truncate de prefix so the input always has enough space.

Screenshots:
![image](https://user-images.githubusercontent.com/5577291/98141031-6f9f4980-1ec6-11eb-8450-da7894ffd00b.png)
![image](https://user-images.githubusercontent.com/5577291/98141048-7332d080-1ec6-11eb-929c-b6c76229b8df.png)
![image](https://user-images.githubusercontent.com/5577291/98141058-75952a80-1ec6-11eb-90ed-46a5a8969fdd.png)
