### PR TITLE
[RedirectBundle] Automatically generate redirects

### DIFF
--- a/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
+++ b/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
@@ -140,6 +140,10 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
             return 'All domains';
         }
 
+        if ($columnName === 'isAutoRedirect' && $item->isAutoRedirect() === null) {
+            return false;
+        }
+
         return parent::getValue(
             $item,
             $columnName

--- a/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
+++ b/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
@@ -17,13 +17,19 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     private $domainConfiguration;
 
     /**
-     * @param EntityManager                $em                  The entity manager
-     * @param AclHelper                    $aclHelper           The acl helper
+     * @param EntityManager $em The entity manager
+     * @param AclHelper $aclHelper The acl helper
      * @param DomainConfigurationInterface $domainConfiguration
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper = null, DomainConfigurationInterface $domainConfiguration)
-    {
-        parent::__construct($em, $aclHelper);
+    public function __construct(
+        EntityManager $em,
+        AclHelper $aclHelper = null,
+        DomainConfigurationInterface $domainConfiguration
+    ) {
+        parent::__construct(
+            $em,
+            $aclHelper
+        );
 
         $this->domainConfiguration = $domainConfiguration;
 
@@ -34,65 +40,118 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     /**
      * Configure the visible columns
      */
-    public function buildFields()
+    public function buildFields(): void
     {
         if ($this->domainConfiguration->isMultiDomainHost()) {
-            $this->addField('domain', 'redirect.adminlist.header.domain', true);
+            $this->addField(
+                'domain',
+                'redirect.adminlist.header.domain',
+                true
+            );
         }
-        $this->addField('origin', 'redirect.adminlist.header.origin', true);
-        $this->addField('target', 'redirect.adminlist.header.target', true);
-        $this->addField('permanent', 'redirect.adminlist.header.permanent', true);
-        $this->addField('note', 'redirect.adminlist.header.note', true);
+        $this->addField(
+            'origin',
+            'redirect.adminlist.header.origin',
+            true
+        );
+        $this->addField(
+            'target',
+            'redirect.adminlist.header.target',
+            true
+        );
+        $this->addField(
+            'permanent',
+            'redirect.adminlist.header.permanent',
+            true
+        );
+        $this->addField(
+            'note',
+            'redirect.adminlist.header.note',
+            true
+        );
+        $this->addField(
+            'isAutoRedirect',
+            'redirect.adminlist.header.is_auto_redirect',
+            true
+        );
     }
 
     /**
      * Build filters for admin list
      */
-    public function buildFilters()
+    public function buildFilters(): void
     {
         if ($this->domainConfiguration->isMultiDomainHost()) {
             $hosts = $this->domainConfiguration->getHosts();
-            $domains = array_combine($hosts, $hosts);
-            $domains = array_merge(array('' => 'redirect.all'), $domains);
-            $this->addFilter('domain', new ORM\EnumerationFilterType('domain'), 'redirect.adminlist.filter.domain', $domains);
+            $domains = array_combine(
+                $hosts,
+                $hosts
+            );
+            $domains = array_merge(
+                ['' => 'redirect.all'],
+                $domains
+            );
+            $this->addFilter(
+                'domain',
+                new ORM\EnumerationFilterType('domain'),
+                'redirect.adminlist.filter.domain',
+                $domains
+            );
         }
-        $this->addFilter('origin', new ORM\StringFilterType('origin'), 'redirect.adminlist.filter.origin');
-        $this->addFilter('target', new ORM\StringFilterType('target'), 'redirect.adminlist.filter.target');
-        $this->addFilter('permanent', new ORM\BooleanFilterType('permanent'), 'redirect.adminlist.filter.permanent');
-        $this->addFilter('note', new ORM\StringFilterType('note'), 'redirect.adminlist.filter.note');
+
+        $this->addFilter(
+            'origin',
+            new ORM\StringFilterType('origin'),
+            'redirect.adminlist.filter.origin'
+        );
+        $this->addFilter(
+            'target',
+            new ORM\StringFilterType('target'),
+            'redirect.adminlist.filter.target'
+        );
+        $this->addFilter(
+            'permanent',
+            new ORM\BooleanFilterType('permanent'),
+            'redirect.adminlist.filter.permanent'
+        );
+        $this->addFilter(
+            'note',
+            new ORM\StringFilterType('note'),
+            'redirect.adminlist.filter.note'
+        );
+        $this->addFilter(
+            'isAutoRedirect',
+            new ORM\BooleanFilterType('isAutoRedirect'),
+            'redirect.adminlist.filter.is_auto_redirect'
+        );
     }
 
     /**
-     * @param array|object $item       The item
-     * @param string       $columnName The column name
+     * @param array|object $item The item
+     * @param string $columnName The column name
      *
      * @return string
      */
-    public function getValue($item, $columnName)
-    {
-        if ($columnName == 'domain' && !$item->getDomain()) {
+    public function getValue(
+        $item,
+        $columnName
+    ) {
+        if ($columnName === 'domain' && !$item->getDomain()) {
             return 'All domains';
         }
 
-        return parent::getValue($item, $columnName);
+        return parent::getValue(
+            $item,
+            $columnName
+        );
     }
 
-    /**
-     * Get bundle name
-     *
-     * @return string
-     */
-    public function getBundleName()
+    public function getBundleName(): string
     {
         return 'KunstmaanRedirectBundle';
     }
 
-    /**
-     * Get entity name
-     *
-     * @return string
-     */
-    public function getEntityName()
+    public function getEntityName(): string
     {
         return 'Redirect';
     }

--- a/src/Kunstmaan/RedirectBundle/Entity/AutoRedirectInterface.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/AutoRedirectInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Kunstmaan\RedirectBundle\Entity;
+
+interface AutoRedirectInterface
+{
+}

--- a/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
@@ -124,12 +124,12 @@ class Redirect extends AbstractEntity
         return $this;
     }
 
-    public function isAutoRedirect(): bool
+    public function isAutoRedirect(): ?bool
     {
         return $this->isAutoRedirect;
     }
 
-    public function setIsAutoRedirect(bool $isAutoRedirect): Redirect
+    public function setIsAutoRedirect(?bool $isAutoRedirect): Redirect
     {
         $this->isAutoRedirect = $isAutoRedirect;
 

--- a/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
@@ -21,14 +21,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class Redirect extends AbstractEntity
 {
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="domain", type="string", length=255, nullable=true)
      */
     private $domain;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="origin", type="string", length=255)
      * @Assert\NotBlank()
@@ -36,14 +36,14 @@ class Redirect extends AbstractEntity
     private $origin;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="note", type="string", length=255, nullable=true)
      */
     private $note;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(name="target", type="text")
      * @Assert\NotBlank()
@@ -58,117 +58,82 @@ class Redirect extends AbstractEntity
     private $permanent;
 
     /**
-     * Get domain
+     * @var bool
      *
-     * @return string
+     * @ORM\Column(name="is_auto_redirect", type="boolean")
      */
-    public function getDomain()
+    private $isAutoRedirect = false;
+
+    public function getDomain(): ?string
     {
         return $this->domain;
     }
 
-    /**
-     * Set domain
-     *
-     * @param string $domain
-     *
-     * @return Redirect
-     */
-    public function setDomain($domain)
+    public function setDomain(?string $domain): Redirect
     {
         $this->domain = $domain;
 
         return $this;
     }
 
-    /**
-     * Set origin
-     *
-     * @param string $origin
-     *
-     * @return Redirect
-     */
-    public function setOrigin($origin)
+    public function getOrigin(): ?string
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin(?string $origin): Redirect
     {
         $this->origin = $origin;
 
         return $this;
     }
 
-    /**
-     * Get origin
-     *
-     * @return string
-     */
-    public function getOrigin()
+    public function getNote(): ?string
     {
-        return $this->origin;
+        return $this->note;
     }
 
-    /**
-     * Set target
-     *
-     * @param string $target
-     *
-     * @return Redirect
-     */
-    public function setTarget($target)
+    public function setNote(?string $note): Redirect
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    public function setTarget(?string $target): Redirect
     {
         $this->target = $target;
 
         return $this;
     }
 
-    /**
-     * Get target
-     *
-     * @return string
-     */
-    public function getTarget()
+    public function isPermanent(): bool
     {
-        return $this->target;
+        return $this->permanent;
     }
 
-    /**
-     * Set permanent
-     *
-     * @param bool $permanent
-     *
-     * @return Redirect
-     */
-    public function setPermanent($permanent)
+    public function setPermanent(bool $permanent): Redirect
     {
         $this->permanent = $permanent;
 
         return $this;
     }
 
-    /**
-     * Get permanent
-     *
-     * @return bool
-     */
-    public function isPermanent()
+    public function isAutoRedirect(): bool
     {
-        return $this->permanent;
+        return $this->isAutoRedirect;
     }
 
-    /**
-     * @return string
-     */
-    public function getNote()
+    public function setIsAutoRedirect(bool $isAutoRedirect): Redirect
     {
-        return $this->note;
-    }
+        $this->isAutoRedirect = $isAutoRedirect;
 
-    /**
-     * @param string $note
-     *
-     * @return Redirect
-     */
-    public function setNote($note)
-    {
-        $this->note = $note;
+        return $this;
     }
 
     /**
@@ -176,7 +141,7 @@ class Redirect extends AbstractEntity
      *
      * @param ExecutionContextInterface $context
      */
-    public function validate(ExecutionContextInterface $context)
+    public function validate(ExecutionContextInterface $context): void
     {
         if ($this->getOrigin() === $this->getTarget()) {
             $context->buildViolation('errors.redirect.origin_same_as_target')

--- a/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
+++ b/src/Kunstmaan/RedirectBundle/Entity/Redirect.php
@@ -60,7 +60,7 @@ class Redirect extends AbstractEntity
     /**
      * @var bool
      *
-     * @ORM\Column(name="is_auto_redirect", type="boolean")
+     * @ORM\Column(name="is_auto_redirect", type="boolean", nullable=true)
      */
     private $isAutoRedirect = false;
 

--- a/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
@@ -68,7 +68,7 @@ class RedirectSubscriber implements EventSubscriber
     ): void {
         $changeSet = $unitOfWork->getEntityChangeSet($nodeTranslation);
 
-        if (!isset($changeSet['url'][0], $changeSet['url'][1])) {
+        if (!isset($changeSet['slug'])) {
             return;
         }
 
@@ -78,15 +78,10 @@ class RedirectSubscriber implements EventSubscriber
             return;
         }
 
-        [
-            $oldUrl,
-            $newUrl,
-        ] = $changeSet['url'];
-
         $this->processRedirect(
             $entityManager,
-            $oldUrl,
-            $newUrl
+            $nodeTranslation->getUrl(),
+            $nodeTranslation->getFullSlug()
         );
     }
 

--- a/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
@@ -107,6 +107,17 @@ class RedirectSubscriber implements EventSubscriber
         return $url;
     }
 
+    private function removeSlashAtStart(string $url): string
+    {
+        $firstCharacter = $url[0] ?? '';
+
+        if ($firstCharacter !== '/') {
+            return $url;
+        }
+
+        return substr($url, 1);
+    }
+
     private function processRedirect(
         EntityManager $entityManager,
         string $oldUrl,
@@ -134,9 +145,11 @@ class RedirectSubscriber implements EventSubscriber
         string $newUrl,
         EntityManager $entityManager
     ): void {
+        $origin = $this->removeSlashAtStart($newUrl);
+
         $redirects = $entityManager->getRepository(Redirect::class)->findBy(
             [
-                'origin' => $newUrl,
+                'origin' => $origin,
             ]
         );
 
@@ -145,8 +158,8 @@ class RedirectSubscriber implements EventSubscriber
             $entityManager->remove($redirect);
         }
 
-        if (isset($this->redirects[$newUrl])) {
-            foreach ($this->redirects[$newUrl] as $redirect) {
+        if (isset($this->redirects[$origin])) {
+            foreach ($this->redirects[$origin] as $redirect) {
                 $entityManager->remove($redirect);
             }
         }

--- a/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Kunstmaan\RedirectBundle\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
+use Kunstmaan\RedirectBundle\Entity\AutoRedirectInterface;
+use Kunstmaan\RedirectBundle\Entity\Redirect;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RedirectSubscriber implements EventSubscriber
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var array<string,array<int,Redirect>
+     */
+    private $redirects = [];
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::onFlush,
+        ];
+    }
+
+    public function onFlush(OnFlushEventArgs $onFlushEventArgs): void
+    {
+        $entityManager = $onFlushEventArgs->getEntityManager();
+        $unitOfWork = $entityManager->getUnitOfWork();
+
+        if (!$entityManager instanceof EntityManager) {
+            return;
+        }
+
+        foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
+            if (!$entity instanceof NodeTranslation) {
+                continue;
+            }
+
+            $this->createAutoRedirect(
+                $entity,
+                $entityManager,
+                $unitOfWork
+            );
+        }
+
+        $unitOfWork->computeChangeSets();
+    }
+
+    private function createAutoRedirect(
+        NodeTranslation $nodeTranslation,
+        EntityManager $entityManager,
+        UnitOfWork $unitOfWork
+    ): void {
+        $changeSet = $unitOfWork->getEntityChangeSet($nodeTranslation);
+
+        if (!isset($changeSet['url'][0], $changeSet['url'][1])) {
+            return;
+        }
+
+        $page = $nodeTranslation->getRef($entityManager);
+
+        if (!$page instanceof AutoRedirectInterface) {
+            return;
+        }
+
+        [
+            $oldUrl,
+            $newUrl,
+        ] = $changeSet['url'];
+
+        $this->processRedirect(
+            $entityManager,
+            $oldUrl,
+            $newUrl
+        );
+    }
+
+    private function processRedirect(
+        EntityManager $entityManager,
+        string $oldUrl,
+        string $newUrl
+    ): void {
+        $this->removeOriginRedirects(
+            $newUrl,
+            $entityManager
+        );
+
+        $this->updateTargetRedirects(
+            $oldUrl,
+            $newUrl,
+            $entityManager
+        );
+
+        $this->createRedirect(
+            $entityManager,
+            $oldUrl,
+            $newUrl
+        );
+    }
+
+    private function removeOriginRedirects(
+        string $newUrl,
+        EntityManager $entityManager
+    ): void {
+        $redirects = $entityManager->getRepository(Redirect::class)->findBy(
+            [
+                'origin' => $newUrl,
+            ]
+        );
+
+        /** @var Redirect $redirect */
+        foreach ($redirects as $redirect) {
+            $entityManager->remove($redirect);
+        }
+
+        if (isset($this->redirects[$newUrl])) {
+            foreach ($this->redirects[$newUrl] as $redirect) {
+                $entityManager->remove($redirect);
+            }
+        }
+    }
+
+    private function updateTargetRedirects(
+        string $oldUrl,
+        string $newUrl,
+        EntityManager $entityManager
+    ): void {
+        $redirects = $entityManager->getRepository(Redirect::class)->findBy(
+            [
+                'target' => $oldUrl,
+            ]
+        );
+
+        /** @var Redirect $redirect */
+        foreach ($redirects as $redirect) {
+            $redirect->setTarget($newUrl);
+            $redirect->setIsAutoRedirect(true);
+        }
+    }
+
+    private function createRedirect(
+        EntityManager $entityManager,
+        string $oldUrl,
+        string $newUrl
+    ): void {
+        $redirect = new Redirect();
+        $redirect->setOrigin($oldUrl);
+        $redirect->setTarget($newUrl);
+        $redirect->setPermanent(true);
+        $redirect->setDomain($this->getDomain());
+        $redirect->setIsAutoRedirect(true);
+
+        $entityManager->persist($redirect);
+
+        $entityManager->getUnitOfWork()->computeChangeSet(
+            $entityManager->getClassMetadata(Redirect::class),
+            $redirect
+        );
+
+        if (!isset($this->redirects[$oldUrl])) {
+            $this->redirects[$oldUrl] = [];
+        }
+
+        $this->redirects[$oldUrl][] = $redirect;
+    }
+
+    private function getDomain(): ?string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request instanceof Request) {
+            return null;
+        }
+
+        return $request->getHost();
+    }
+}

--- a/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
@@ -81,8 +81,23 @@ class RedirectSubscriber implements EventSubscriber
         $this->processRedirect(
             $entityManager,
             $nodeTranslation->getUrl(),
-            $nodeTranslation->getFullSlug()
+            $this->getNewUrl($nodeTranslation)
         );
+    }
+
+    private function getNewUrl(NodeTranslation $nodeTranslation): string
+    {
+        $newUrl = $nodeTranslation->getFullSlug();
+
+        if (!is_string($newUrl)) {
+            return '/';
+        }
+
+        if ($newUrl[0] !== '/') {
+            return '/' . $newUrl;
+        }
+
+        return $newUrl;
     }
 
     private function processRedirect(

--- a/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/EventSubscriber/RedirectSubscriber.php
@@ -93,11 +93,18 @@ class RedirectSubscriber implements EventSubscriber
             return '/';
         }
 
-        if ($newUrl[0] !== '/') {
-            return '/' . $newUrl;
+        return $this->startWithSlash($newUrl);
+    }
+
+    private function startWithSlash(string $url): string
+    {
+        $firstCharacter = $url[0] ?? '';
+
+        if ($firstCharacter !== '/') {
+            return '/' . $url;
         }
 
-        return $newUrl;
+        return $url;
     }
 
     private function processRedirect(
@@ -152,7 +159,7 @@ class RedirectSubscriber implements EventSubscriber
     ): void {
         $redirects = $entityManager->getRepository(Redirect::class)->findBy(
             [
-                'target' => $oldUrl,
+                'target' => $this->startWithSlash($oldUrl),
             ]
         );
 

--- a/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
@@ -25,3 +25,7 @@ services:
         arguments: ['@kunstmaan_admin.domain_configuration']
         tags:
             - { name: form.type, alias: kunstmaan_redirect_form_type }
+
+    Kunstmaan\RedirectBundle\EventSubscriber\RedirectSubscriber:
+        arguments:
+            $requestStack: '@request_stack'

--- a/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/config/services.yml
@@ -29,3 +29,5 @@ services:
     Kunstmaan\RedirectBundle\EventSubscriber\RedirectSubscriber:
         arguments:
             $requestStack: '@request_stack'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }

--- a/src/Kunstmaan/RedirectBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/translations/messages.en.yml
@@ -19,14 +19,16 @@ redirect:
 
     adminlist:
         header:
-            domain:     Domain
-            origin:     Origin
-            target:     Target
-            permanent:  Permanent?
-            note:       Note
+            domain:           Domain
+            origin:           Origin
+            target:           Target
+            permanent:        Permanent?
+            note:             Note
+            is_auto_redirect: Automatische redirect?
         filter:
-            domain:     Domain
-            origin:     Origin
-            target:     Target
-            permanent:  Permanent
-            note:       Note
+            domain:           Domain
+            origin:           Origin
+            target:           Target
+            permanent:        Permanent
+            note:             Note
+            is_auto_redirect: Automatische redirect?

--- a/src/Kunstmaan/RedirectBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/RedirectBundle/Resources/translations/messages.nl.yml
@@ -23,6 +23,7 @@ redirect:
       target: Bestemming
       permanent: Permanent?
       note: Notitie
+      is_auto_redirect: Automatische redirect?
     filter:
       domain: Domein
       origin: Herkomst

--- a/src/Kunstmaan/RedirectBundle/Tests/unit/AdminList/RedirectAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/unit/AdminList/RedirectAdminListConfiguratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kunstmaan\RedirectBundle\Tests\Entity;
+namespace Kunstmaan\RedirectBundle\Tests\unit\AdminList;
 
 use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
@@ -41,21 +41,21 @@ class RedirectAdminListConfiguratorTest extends TestCase
         $this->object = new RedirectAdminListConfigurator($this->em, $this->aclHelper, $domainConfiguration);
     }
 
-    public function testBuildFields()
+    public function testBuildFields(): void
     {
         $this->object->buildFields();
         $fields = $this->object->getFields();
-        $this->assertCount(4, $fields);
+        $this->assertCount(5, $fields);
         $fieldNames = array_map(
             function (Field $field) {
                 return $field->getName();
             },
             $fields
         );
-        $this->assertEquals(array('origin', 'target', 'permanent', 'note'), $fieldNames);
+        $this->assertEquals(['origin', 'target', 'permanent', 'note', 'isAutoRedirect'], $fieldNames);
     }
 
-    public function testBuildFilters()
+    public function testBuildFilters(): void
     {
         $filterBuilder = $this->createMock('Kunstmaan\AdminListBundle\AdminList\FilterBuilder');
         $filterBuilder
@@ -74,16 +74,20 @@ class RedirectAdminListConfiguratorTest extends TestCase
             ->expects($this->at(3))
             ->method('add')
             ->with('note');
+        $filterBuilder
+            ->expects($this->at(4))
+            ->method('add')
+            ->with('isAutoRedirect');
         $this->object->setFilterBuilder($filterBuilder);
         $this->object->buildFilters();
     }
 
-    public function testGetBundleName()
+    public function testGetBundleName(): void
     {
         $this->assertEquals('KunstmaanRedirectBundle', $this->object->getBundleName());
     }
 
-    public function testGetEntityName()
+    public function testGetEntityName(): void
     {
         $this->assertEquals('Redirect', $this->object->getEntityName());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

When the slug of a page is changed, if you visit the old url it will result in a 404. This feature will allow Kunstmaan to automatically generate a redirect for each page that implements the `AutoRedirectInterface`

When a slug is changed, the subscriber performs these steps:

- Find all redirects with origin the newly created url. Delete these redirects. (because it is going to be an actual url, you don't need to have an existing redirect for it
- Find all redirects with target the old url. Update the target to the newly created url. (so you don't have to chain redirects going from A to B to C to D, but instead going from A to D and from B to D)
- Create a new redirect with origin the old url and target the newly created url.

Here is an example:

This is the current page:
![afbeelding](https://user-images.githubusercontent.com/37873948/98659818-d1d3d080-2344-11eb-89ab-7f5225eece51.png)

We rename the page to Page B and change the slug accordingly:
![afbeelding](https://user-images.githubusercontent.com/37873948/98660523-b1584600-2345-11eb-924c-0f7c8c1bece3.png)

We now have one automatically generated redirect:
![afbeelding](https://user-images.githubusercontent.com/37873948/98660577-c0d78f00-2345-11eb-9ad4-d557ed05d596.png)

We rename the page to Page C and change the slug accordingly:
![afbeelding](https://user-images.githubusercontent.com/37873948/98660649-d5b42280-2345-11eb-810f-a0c99d0120c4.png)

We now have two automatically generated redirects. Both redirects now target `/page-c` (instead of `page-a` redirecting to `page-b` etc)
![afbeelding](https://user-images.githubusercontent.com/37873948/98660716-e95f8900-2345-11eb-8ed0-110cb73063cf.png)

We regret all the name changes, and rename the page back to Page A and change the slug accordingly:
![afbeelding](https://user-images.githubusercontent.com/37873948/98660906-1f9d0880-2346-11eb-95f4-e9864cbad662.png)

We now still have to redirects where `page-b` and `page-c` both redirect back to `page-a`
![afbeelding](https://user-images.githubusercontent.com/37873948/98660972-34799c00-2346-11eb-8872-d62a8c825f80.png)
