### PR TITLE
[FormBundle] Add length validation to string form field

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/StringFormSubmissionField.php
+++ b/src/Kunstmaan/FormBundle/Entity/FormSubmissionFieldTypes/StringFormSubmissionField.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\FormBundle\Entity\FormSubmissionField;
 use Kunstmaan\FormBundle\Form\StringFormSubmissionType;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * The StringFormSubmissionField can be used to store string values to a FormSubmission
@@ -16,6 +17,7 @@ class StringFormSubmissionField extends FormSubmissionField
 {
     /**
      * @ORM\Column(name="sfsf_value", type="string")
+     * @Assert\Length(max=255)
      */
     protected $value;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The max length in the database is 255. Without validation you get an database error.