### PR TITLE
[MultiDomainBundle] Fix keying of host configurations

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('hosts')
                     ->isRequired()
                     ->requiresAtLeastOneElement()
-                    // ->useAttributeAsKey('host')
+                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
                             ->scalarNode('host')

--- a/src/Kunstmaan/MultiDomainBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -27,7 +27,7 @@ class ConfigurationTest extends TestCase
     {
         $array = [
             'hosts' => [
-                [
+                'host_one' => [
                     'host' => 'cia.gov',
                     'protocol' => 'https',
                     'aliases' => ['cia.com'],

--- a/src/Kunstmaan/MultiDomainBundle/Tests/DependencyInjection/KunstmaanMultiDomainExtensionTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/DependencyInjection/KunstmaanMultiDomainExtensionTest.php
@@ -11,7 +11,7 @@ class KunstmaanMultiDomainExtensionTest extends AbstractExtensionTestCase
     /**
      * @return ExtensionInterface[]
      */
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [new KunstmaanMultiDomainExtension()];
     }
@@ -20,7 +20,7 @@ class KunstmaanMultiDomainExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([
             'hosts' => [
-                [
+                'host_one' => [
                     'host' => 'cia.gov',
                     'protocol' => 'https',
                     'aliases' => ['cia.com'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature? |no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/a

This fixes the configuration for the hosts in the multi domain bundle.

When modifying the configuration from another bundle (using PrependExtensionInterface) the configuration get re-indexed by the Symfony configuration component. This cause the configuration to be added twice.
Once using the origin key (the modified configuration) and once using numeric ids re-indexed by Symfony.

I figured this was attempted previously as the code is commented out. Enabling this as-is will remove the 'host' configuration field. (as it is should only be used as the key, not a value).

By using a different name for the attribute, the original configuration is left as is. And Symfony now uses the correct value as the key.