### PR TITLE
[AllBundles] Mark event classes final

### DIFF
--- a/UPGRADE-5.9.md
+++ b/UPGRADE-5.9.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.8 to 5.9
 =======================
 
+General
+-------
+
+* All event classes are marked as final.
+
 AdminlistBundle
 ------------
 

--- a/src/Kunstmaan/AdminBundle/Event/AdaptSimpleFormEvent.php
+++ b/src/Kunstmaan/AdminBundle/Event/AdaptSimpleFormEvent.php
@@ -5,6 +5,9 @@ namespace Kunstmaan\AdminBundle\Event;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\TabPane;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @final since 5.9
+ */
 class AdaptSimpleFormEvent extends BcEvent
 {
     /**

--- a/src/Kunstmaan/AdminBundle/Event/DeepCloneAndSaveEvent.php
+++ b/src/Kunstmaan/AdminBundle/Event/DeepCloneAndSaveEvent.php
@@ -4,6 +4,8 @@ namespace Kunstmaan\AdminBundle\Event;
 
 /**
  * This event wil be used to pass metadata when the deep clone event is triggered.
+ *
+ * @final since 5.9
  */
 class DeepCloneAndSaveEvent extends BcEvent
 {

--- a/src/Kunstmaan/AdminBundle/Event/Events.php
+++ b/src/Kunstmaan/AdminBundle/Event/Events.php
@@ -4,6 +4,8 @@ namespace Kunstmaan\AdminBundle\Event;
 
 /**
  * AdminBundle events
+ *
+ * @final since 5.9
  */
 class Events
 {

--- a/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
+++ b/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @final since 5.9
+ */
 class AdminListEvent extends BcEvent
 {
     /**

--- a/src/Kunstmaan/AdminListBundle/Event/AdminListEvents.php
+++ b/src/Kunstmaan/AdminListBundle/Event/AdminListEvents.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\AdminListBundle\Event;
 
+/**
+ * @final since 5.9
+ */
 class AdminListEvents
 {
     /**

--- a/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
+++ b/src/Kunstmaan/FormBundle/Event/SubmissionEvent.php
@@ -6,6 +6,9 @@ use Kunstmaan\AdminBundle\Event\BcEvent;
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\FormBundle\Helper\FormPageInterface;
 
+/**
+ * @final since 5.9
+ */
 class SubmissionEvent extends BcEvent
 {
     /**

--- a/src/Kunstmaan/NodeBundle/Event/AdaptFormEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/AdaptFormEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The event to pass metadata if the adaptForm event is triggered
+ *
+ * @final since 5.9
  */
 class AdaptFormEvent extends BcEvent
 {

--- a/src/Kunstmaan/NodeBundle/Event/ConfigureActionMenuEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/ConfigureActionMenuEvent.php
@@ -8,7 +8,7 @@ use Kunstmaan\AdminBundle\Event\BcEvent;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 
 /**
- * ConfigureActionMenuEvent
+ * @final since 5.9
  */
 class ConfigureActionMenuEvent extends BcEvent
 {

--- a/src/Kunstmaan/NodeBundle/Event/CopyPageTranslationNodeEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/CopyPageTranslationNodeEvent.php
@@ -8,7 +8,7 @@ use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 
 /**
- * CopyPageTranslationNodeEvent
+ * @final since 5.9
  */
 class CopyPageTranslationNodeEvent extends NodeEvent
 {

--- a/src/Kunstmaan/NodeBundle/Event/Events.php
+++ b/src/Kunstmaan/NodeBundle/Event/Events.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\NodeBundle\Event;
 
 /**
- * Events
+ * @final since 5.9
  */
 class Events
 {

--- a/src/Kunstmaan/NodeBundle/Event/RecopyPageTranslationNodeEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/RecopyPageTranslationNodeEvent.php
@@ -8,7 +8,7 @@ use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersion;
 
 /**
- * RecopyPageTranslationNodeEvent
+ * @final since 5.9
  */
 class RecopyPageTranslationNodeEvent extends NodeEvent
 {

--- a/src/Kunstmaan/NodeBundle/Event/RevertNodeAction.php
+++ b/src/Kunstmaan/NodeBundle/Event/RevertNodeAction.php
@@ -9,6 +9,8 @@ use Kunstmaan\NodeBundle\Entity\NodeVersion;
 
 /**
  * This event will pass metadata when a revert event has been triggered
+ *
+ * @final since 5.9
  */
 class RevertNodeAction extends NodeEvent
 {

--- a/src/Kunstmaan/NodeBundle/Event/SlugEvent.php
+++ b/src/Kunstmaan/NodeBundle/Event/SlugEvent.php
@@ -6,6 +6,9 @@ use Kunstmaan\AdminBundle\Event\BcEvent;
 use Kunstmaan\NodeBundle\Helper\RenderContext;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @final since 5.9
+ */
 class SlugEvent extends BcEvent
 {
     /**

--- a/src/Kunstmaan/NodeSearchBundle/Event/IndexNodeEvent.php
+++ b/src/Kunstmaan/NodeSearchBundle/Event/IndexNodeEvent.php
@@ -5,6 +5,9 @@ namespace Kunstmaan\NodeSearchBundle\Event;
 use Kunstmaan\AdminBundle\Event\BcEvent;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 
+/**
+ * @final since 5.9
+ */
 class IndexNodeEvent extends BcEvent
 {
     const EVENT_INDEX_NODE = 'kunstmaan_node_search.onIndexNode';

--- a/src/Kunstmaan/PagePartBundle/Event/Events.php
+++ b/src/Kunstmaan/PagePartBundle/Event/Events.php
@@ -3,7 +3,7 @@
 namespace Kunstmaan\PagePartBundle\Event;
 
 /**
- * Events
+ * @final since 5.9
  */
 class Events
 {

--- a/src/Kunstmaan/PagePartBundle/Event/PagePartEvent.php
+++ b/src/Kunstmaan/PagePartBundle/Event/PagePartEvent.php
@@ -7,7 +7,7 @@ use Kunstmaan\PagePartBundle\Helper\PagePartInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * PagePartEvent
+ * @final since 5.9
  */
 class PagePartEvent extends BcEvent
 {

--- a/src/Kunstmaan/UserManagementBundle/Event/UserEvents.php
+++ b/src/Kunstmaan/UserManagementBundle/Event/UserEvents.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\UserManagementBundle\Event;
 
+/**
+ * @final since 5.9
+ */
 class UserEvents
 {
     /**

--- a/src/Kunstmaan/VotingBundle/Event/Events.php
+++ b/src/Kunstmaan/VotingBundle/Event/Events.php
@@ -2,6 +2,9 @@
 
 namespace Kunstmaan\VotingBundle\Event;
 
+/**
+ * @final since 5.9
+ */
 class Events
 {
     /**

--- a/src/Kunstmaan/VotingBundle/Event/Facebook/FacebookLikeEvent.php
+++ b/src/Kunstmaan/VotingBundle/Event/Facebook/FacebookLikeEvent.php
@@ -6,6 +6,8 @@ use Kunstmaan\VotingBundle\Event\AbstractVoteEvent;
 
 /**
  * Event triggered through a callback from the Facebook API when a Like has been executed
+ *
+ * @final since 5.9
  */
 class FacebookLikeEvent extends AbstractVoteEvent
 {

--- a/src/Kunstmaan/VotingBundle/Event/Facebook/FacebookSendEvent.php
+++ b/src/Kunstmaan/VotingBundle/Event/Facebook/FacebookSendEvent.php
@@ -6,6 +6,8 @@ use Kunstmaan\VotingBundle\Event\AbstractVoteEvent;
 
 /**
  * Event triggered through a callback from the Facebook API when a Send has been executed
+ *
+ * @final since 5.9
  */
 class FacebookSendEvent extends AbstractVoteEvent
 {

--- a/src/Kunstmaan/VotingBundle/Event/LinkedIn/LinkedInShareEvent.php
+++ b/src/Kunstmaan/VotingBundle/Event/LinkedIn/LinkedInShareEvent.php
@@ -6,6 +6,8 @@ use Kunstmaan\VotingBundle\Event\AbstractVoteEvent;
 
 /**
  * Event triggered through a callback from the LinkedIn Javascript API when a Share has been executed
+ *
+ * @final since 5.9
  */
 class LinkedInShareEvent extends AbstractVoteEvent
 {

--- a/src/Kunstmaan/VotingBundle/Event/UpDown/DownVoteEvent.php
+++ b/src/Kunstmaan/VotingBundle/Event/UpDown/DownVoteEvent.php
@@ -6,6 +6,8 @@ use Kunstmaan\VotingBundle\Event\AbstractVoteEvent;
 
 /**
  * Event when a Down vote has been triggered
+ *
+ * @final since 5.9
  */
 class DownVoteEvent extends AbstractVoteEvent
 {

--- a/src/Kunstmaan/VotingBundle/Event/UpDown/UpVoteEvent.php
+++ b/src/Kunstmaan/VotingBundle/Event/UpDown/UpVoteEvent.php
@@ -6,6 +6,8 @@ use Kunstmaan\VotingBundle\Event\AbstractVoteEvent;
 
 /**
  * Event when an Up vote has been triggered
+ *
+ * @final since 5.9
  */
 class UpVoteEvent extends AbstractVoteEvent
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Mark all kunstmaan event classes as final, because overriding them doesn't change the dispatched event and it will make it easier to do changes in the future
