### PR TITLE
[NodeSearchBundle] Deprecate direct instantiation of the abstractSearchPage

### DIFF
--- a/UPGRADE-5.9.md
+++ b/UPGRADE-5.9.md
@@ -4,4 +4,9 @@ UPGRADE FROM 5.8 to 5.9
 AdminlistBundle
 ------------
 
-* Using the `setObjectManager`, `setThreshold` and `setLockEnabled` methods of `Kunstmaan\AdminListBundle\Service\EntityVersionLockService` is deprecated, use the constructor to inject the required values instead. 
+* Using the `setObjectManager`, `setThreshold` and `setLockEnabled` methods of `Kunstmaan\AdminListBundle\Service\EntityVersionLockService` is deprecated, use the constructor to inject the required values instead.
+
+NodeSearchBundle
+------------
+
+* Instantiating the `Kunstmaan\NodeSearchBundle\Entity\AbstractSearchPage` class is deprecated and will be made abstract. Extend your implementation from this class instead.

--- a/src/Kunstmaan/NodeSearchBundle/Entity/AbstractSearchPage.php
+++ b/src/Kunstmaan/NodeSearchBundle/Entity/AbstractSearchPage.php
@@ -11,6 +11,13 @@ use Kunstmaan\SearchBundle\Helper\IndexableInterface;
  */
 class AbstractSearchPage extends AbstractPage implements IndexableInterface, SlugActionInterface
 {
+    public function __construct()
+    {
+        if (\get_class($this) === __CLASS__) {
+            @trigger_error(sprintf('Instantiating the "%s" class is deprecated in KunstmaanNodeSearchBundle 5.9 and will be made abstract in KunstmaanNodeSearchBundle 6.0. Extend your implementation from this class instead.', __CLASS__), E_USER_DEPRECATED);
+        }
+    }
+
     /**
      * @return string
      */

--- a/src/Kunstmaan/NodeSearchBundle/Tests/Entity/AbstractSearchPageTest.php
+++ b/src/Kunstmaan/NodeSearchBundle/Tests/Entity/AbstractSearchPageTest.php
@@ -4,16 +4,29 @@ namespace Kunstmaan\NodeSearchBundle\Tests\Entity;
 
 use Kunstmaan\NodeSearchBundle\Entity\AbstractSearchPage;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class AbstractSearchPageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testGetters()
     {
-        $page = new AbstractSearchPage();
+        $page = new class() extends AbstractSearchPage {};
         $this->assertEquals('KunstmaanNodeSearchBundle:AbstractSearchPage:service', $page->getControllerAction());
         $this->assertEquals('@KunstmaanNodeSearch/AbstractSearchPage/view.html.twig', $page->getDefaultView());
         $this->assertEquals('kunstmaan_node_search.search.node', $page->getSearcher());
         $this->assertFalse($page->isIndexable());
         $this->assertIsArray($page->getPossibleChildTypes());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testInstantiationDeprecation()
+    {
+        $this->expectDeprecation('Instantiating the "Kunstmaan\NodeSearchBundle\Entity\AbstractSearchPage" class is deprecated in KunstmaanNodeSearchBundle 5.9 and will be made abstract in KunstmaanNodeSearchBundle 6.0. Extend your implementation from this class instead.');
+
+        new AbstractSearchPage();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

the class was already named abstract and will be made abstract in 6.0
