### PR TITLE
[MultidomainBundle] Fix getting host when its not available

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
@@ -177,6 +177,8 @@ class DomainConfiguration implements DomainConfigurationInterface
 
     /**
      * @param string|null $host
+     *
+     * @return string|null
      */
     public function getHostBaseUrl($host = null)
     {

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -325,11 +325,15 @@ class DomainConfiguration extends BaseDomainConfiguration
     /**
      * @param string|null $host
      *
-     * @return string
+     * @return string|null
      */
     public function getHostBaseUrl($host = null)
     {
         $config = $this->getFullHost($host);
+
+        if (!is_array($config)) {
+            return null;
+        }
 
         return sprintf('%s://%s', $config['protocol'], $config['host']);
     }

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
@@ -185,6 +185,13 @@ class DomainConfigurationTest extends TestCase
         $this->assertEquals('http://multilangdomain.tld', $object->getHostBaseUrl('multilangdomain.tld'));
     }
 
+    public function testEmptyGetHostBaseUrl()
+    {
+        $request = $this->getSingleLanguageRequest();
+        $object = $this->getDomainConfiguration($request);
+        $this->assertNull($object->getHostBaseUrl());
+    }
+
     public function testGetFullHost()
     {
         $request = $this->getSingleLanguageRequest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

In one of our already existing live projects, we decided to add the kunstmaan/multidomain-bundle. It works fine, but it seems to break internal links.
If you do not use the kunstmaan/multidomain-bundle, internal links look like [NT45].
When using the `|replace_url` filter in twig, it uses this the method replaceUrl (at kunstmaan/bundles-cms/src/Kunstmaan/NodeBundle/Helper/URLHelper.php:59). Here it expects the domain to be in the internal link when using the kunstmaan/multidomain-bundle:

```php
                    $hostConfig = !empty($hostId) ? $this->domainConfiguration->getFullHostById($hostId) : null;
                    $host = null !== $hostConfig && array_key_exists('host', $hostConfig) ? $hostConfig['host'] : null;
                    $hostBaseUrl = $this->domainConfiguration->getHostBaseUrl($host);
```

And this is where it breaks. `$host` is null, because it cannot be extracted from `[NT45]`, but in the method `getHostBaseUrl()` it tries to access `$config['protocol']` and `$config['host']` when `$config` is actually `null`