### PR TITLE
[FormBundle] Add length validation to form fields

### DIFF
--- a/src/Kunstmaan/FormBundle/Entity/PageParts/AbstractFormPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/AbstractFormPagePart.php
@@ -18,6 +18,7 @@ abstract class AbstractFormPagePart extends AbstractPagePart implements FormAdap
      *
      * @ORM\Column(type="string")
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     protected $label;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/CheckboxPagePart.php
@@ -8,6 +8,7 @@ use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\BooleanFormSubmissionFi
 use Kunstmaan\FormBundle\Form\BooleanFormSubmissionType;
 use Kunstmaan\FormBundle\Form\CheckboxPagePartAdminType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -29,6 +30,7 @@ class CheckboxPagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/ChoicePagePart.php
@@ -8,6 +8,7 @@ use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\ChoiceFormSubmissionFie
 use Kunstmaan\FormBundle\Form\ChoiceFormSubmissionType;
 use Kunstmaan\FormBundle\Form\ChoicePagePartAdminType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -49,6 +50,7 @@ class ChoicePagePart extends AbstractFormPagePart
      * multiple options are set to false.
      *
      * @ORM\Column(type="string", name="empty_value", nullable=true)
+     * @Length(max=255)
      */
     protected $emptyValue;
 
@@ -63,6 +65,7 @@ class ChoicePagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/EmailPagePart.php
@@ -9,6 +9,7 @@ use Kunstmaan\FormBundle\Form\EmailFormSubmissionType;
 use Kunstmaan\FormBundle\Form\EmailPagePartAdminType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -30,6 +31,7 @@ class EmailPagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 
@@ -37,6 +39,7 @@ class EmailPagePart extends AbstractFormPagePart
      * Error message shows when the value is invalid
      *
      * @ORM\Column(type="string", name="error_message_invalid", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageInvalid;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/FileUploadPagePart.php
@@ -8,6 +8,7 @@ use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\FileFormSubmissionField
 use Kunstmaan\FormBundle\Form\FileFormSubmissionType;
 use Kunstmaan\FormBundle\Form\FileUploadPagePartAdminType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
@@ -30,6 +31,7 @@ class FileUploadPagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/MultiLineTextPagePart.php
@@ -8,6 +8,7 @@ use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\TextFormSubmissionField
 use Kunstmaan\FormBundle\Form\MultiLineTextPagePartAdminType;
 use Kunstmaan\FormBundle\Form\TextFormSubmissionType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -30,6 +31,7 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 
@@ -37,6 +39,7 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      * If set the entered value will be matched with this regular expression
      *
      * @ORM\Column(type="string", nullable=true)
+     * @Length(max=255)
      */
     protected $regex;
 
@@ -44,6 +47,7 @@ class MultiLineTextPagePart extends AbstractFormPagePart
      * If a regular expression is set and it doesn't match with the given value, this error message will be shown
      *
      * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRegex;
 

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SingleLineTextPagePart.php
@@ -8,6 +8,7 @@ use Kunstmaan\FormBundle\Entity\FormSubmissionFieldTypes\StringFormSubmissionFie
 use Kunstmaan\FormBundle\Form\SingleLineTextPagePartAdminType;
 use Kunstmaan\FormBundle\Form\StringFormSubmissionType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -30,6 +31,7 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      * Error message shows when the page part is required and nothing is filled in
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRequired;
 
@@ -37,6 +39,7 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      * If set the entered value will be matched with this regular expression
      *
      * @ORM\Column(type="string", nullable=true)
+     * @Length(max=255)
      */
     protected $regex;
 
@@ -44,11 +47,12 @@ class SingleLineTextPagePart extends AbstractFormPagePart
      * If a regular expression is set and it doesn't match with the given value, this error message will be shown
      *
      * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+     * @Length(max=255)
      */
     protected $errorMessageRegex;
 
     /**
-     * Sets the required valud of this page part
+     * Sets the required value of this page part
      *
      * @param bool $required
      *

--- a/src/Kunstmaan/FormBundle/Entity/PageParts/SubmitButtonPagePart.php
+++ b/src/Kunstmaan/FormBundle/Entity/PageParts/SubmitButtonPagePart.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\FormBundle\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\FormBundle\Form\SubmitButtonPagePartAdminType;
 use Kunstmaan\PagePartBundle\Entity\AbstractPagePart;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * This page part adds a submit button to the forms
@@ -18,6 +19,7 @@ class SubmitButtonPagePart extends AbstractPagePart
      * The label on the submit button
      *
      * @ORM\Column(type="string", nullable=true)
+     * @Length(max=255)
      */
     protected $label;
 

--- a/src/Kunstmaan/FormBundle/Form/CheckboxPagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/CheckboxPagePartAdminType.php
@@ -28,7 +28,7 @@ class CheckboxPagePartAdminType extends AbstractType
                 'label' => 'kuma_form.form.checkbox_page_part.required.label',
                 'required' => false,
             ])
-            ->add('errormessage_required', TextType::class, [
+            ->add('errorMessageRequired', TextType::class, [
                 'label' => 'kuma_form.form.checkbox_page_part.errormessage_required.label',
                 'required' => false,
             ])

--- a/src/Kunstmaan/FormBundle/Form/ChoicePagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/ChoicePagePartAdminType.php
@@ -29,7 +29,7 @@ class ChoicePagePartAdminType extends AbstractType
                 'label' => 'kuma_form.form.choice_page_part.required.label',
                 'required' => false,
             ])
-            ->add('errormessage_required', TextType::class, [
+            ->add('errorMessageRequired', TextType::class, [
                 'label' => 'kuma_form.form.choice_page_part.errormessage_required.label',
                 'required' => false,
             ])
@@ -45,7 +45,7 @@ class ChoicePagePartAdminType extends AbstractType
                 'label' => 'kuma_form.form.choice_page_part.choices.label',
                 'required' => false,
             ])
-            ->add('empty_value', TextType::class, [
+            ->add('emptyValue', TextType::class, [
                 'label' => 'kuma_form.form.choice_page_part.empty_value.label',
                 'required' => false,
             ])

--- a/src/Kunstmaan/FormBundle/Form/FileUploadPagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/FileUploadPagePartAdminType.php
@@ -28,7 +28,7 @@ class FileUploadPagePartAdminType extends AbstractType
                 'required' => false,
                 'label' => 'kuma_form.form.file_upload_page_part.required.label',
             ])
-            ->add('errormessage_required', TextType::class, [
+            ->add('errorMessageRequired', TextType::class, [
                 'required' => false,
                 'label' => 'kuma_form.form.file_upload_page_part.errormessage_required.label',
             ])

--- a/src/Kunstmaan/FormBundle/Form/MultiLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/MultiLineTextPagePartAdminType.php
@@ -28,7 +28,7 @@ class MultiLineTextPagePartAdminType extends AbstractType
                 'required' => false,
                 'label' => 'kuma_form.form.multi_line_text_page_part.required.label',
             ])
-            ->add('errormessage_required', TextType::class, [
+            ->add('errorMessageRequired', TextType::class, [
                 'required' => false,
                 'label' => 'kuma_form.form.multi_line_text_page_part.errormessage_required.label',
             ])
@@ -36,7 +36,7 @@ class MultiLineTextPagePartAdminType extends AbstractType
                 'required' => false,
                 'label' => 'kuma_form.form.multi_line_text_page_part.regex.label',
             ])
-            ->add('errormessage_regex', TextType::class, [
+            ->add('errorMessageRegex', TextType::class, [
                 'required' => false,
                 'label' => 'kuma_form.form.multi_line_text_page_part.errormessage_regex.label',
             ])

--- a/src/Kunstmaan/FormBundle/Form/SingleLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/FormBundle/Form/SingleLineTextPagePartAdminType.php
@@ -37,7 +37,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 ]
             )
             ->add(
-                'errormessage_required',
+                'errorMessageRequired',
                 TextType::class,
                 [
                     'required' => false,
@@ -53,7 +53,7 @@ class SingleLineTextPagePartAdminType extends AbstractType
                 ]
             )
             ->add(
-                'errormessage_regex',
+                'errorMessageRegex',
                 TextType::class,
                 [
                     'required' => false,

--- a/src/Kunstmaan/FormBundle/Tests/Form/CheckboxPagePartAdminTypeTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Form/CheckboxPagePartAdminTypeTest.php
@@ -13,7 +13,7 @@ class CheckboxPagePartAdminTypeTest extends TypeTestCase
         $formData = [
             'required' => false,
             'label' => 'check this box!',
-            'errormessage_required' => 'fill in the form',
+            'errorMessageRequired' => 'fill in the form',
         ];
 
         $form = $this->factory->create(CheckboxPagePartAdminType::class);

--- a/src/Kunstmaan/FormBundle/Tests/Form/FileUploadPagePartAdminTypeTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Form/FileUploadPagePartAdminTypeTest.php
@@ -13,7 +13,7 @@ class FileUploadPagePartAdminTypeTest extends TypeTestCase
         $formData = [
             'required' => false,
             'label' => 'xyz',
-            'errormessage_required' => 'fill in the form',
+            'errorMessageRequired' => 'fill in the form',
         ];
 
         $form = $this->factory->create(FileUploadPagePartAdminType::class);

--- a/src/Kunstmaan/FormBundle/Tests/Form/MultiLineTextPagePartAdminTypeTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Form/MultiLineTextPagePartAdminTypeTest.php
@@ -13,9 +13,9 @@ class MultiLineTextPagePartAdminTypeTest extends TypeTestCase
         $formData = [
             'required' => false,
             'label' => 'type in this box!',
-            'errormessage_required' => 'fill in the form',
+            'errorMessageRequired' => 'fill in the form',
             'regex' => '#\w+#',
-            'errormessage_regex' => 'oops',
+            'errorMessageRegex' => 'oops',
         ];
 
         $form = $this->factory->create(MultiLineTextPagePartAdminType::class);

--- a/src/Kunstmaan/FormBundle/Tests/Form/SingleLineTextPagePartAdminTypeTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Form/SingleLineTextPagePartAdminTypeTest.php
@@ -13,9 +13,9 @@ class SingleLineTextPagePartAdminTypeTest extends TypeTestCase
         $formData = [
             'required' => false,
             'label' => 'type in this box!',
-            'errormessage_required' => 'fill in the form',
+            'errorMessageRequired' => 'fill in the form',
             'regex' => '#\w+#',
-            'errormessage_regex' => 'oops',
+            'errorMessageRegex' => 'oops',
         ];
 
         $form = $this->factory->create(SingleLineTextPagePartAdminType::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The max length in the database is 255. Without validation you get an database error.