### PR TITLE
[SitemapBundle] Add pre render event for adding sitemap indexes

### DIFF
--- a/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
+++ b/src/Kunstmaan/SitemapBundle/Controller/SitemapController.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\SitemapBundle\Controller;
 
+use Kunstmaan\SitemapBundle\Event\PreSitemapIndexRenderEvent;
 use Kunstmaan\SitemapBundle\Event\PreSitemapRenderEvent;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -60,9 +61,13 @@ class SitemapController extends Controller
         $locales = $this->get('kunstmaan_admin.domain_configuration')
             ->getBackendLocales();
 
+        $event = new PreSitemapIndexRenderEvent($locales);
+        $this->dispatch($event, PreSitemapIndexRenderEvent::NAME);
+
         return [
             'locales' => $locales,
             'host' => $request->getSchemeAndHttpHost(),
+            'extraSitemaps' => $event->getExtraSitemaps(),
         ];
     }
 

--- a/src/Kunstmaan/SitemapBundle/Event/PreSitemapIndexRenderEvent.php
+++ b/src/Kunstmaan/SitemapBundle/Event/PreSitemapIndexRenderEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\Event;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Kunstmaan\SitemapBundle\Model\SitemapIndex;
+use Symfony\Component\EventDispatcher\Event;
+
+final class PreSitemapIndexRenderEvent extends Event
+{
+    public const NAME = 'sitemap.index.pre_render';
+
+    private $extraSitemaps;
+    private $locales;
+
+    public function __construct(array $locales)
+    {
+        $this->extraSitemaps = new ArrayCollection();
+        $this->locales = $locales;
+    }
+
+    public function getLocales(): array
+    {
+        return $this->locales;
+    }
+
+    public function getExtraSitemaps(): Collection
+    {
+        return $this->extraSitemaps;
+    }
+
+    public function addExtraSitemap(SitemapIndex $sitemapIndex): void
+    {
+        if (!$this->extraSitemaps->contains($sitemapIndex)) {
+            $this->extraSitemaps->add($sitemapIndex);
+        }
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/Model/SitemapIndex.php
+++ b/src/Kunstmaan/SitemapBundle/Model/SitemapIndex.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kunstmaan\SitemapBundle\Model;
+
+class SitemapIndex
+{
+    private $url;
+
+    public function __construct(string $url)
+    {
+        $this->url = $url;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
+++ b/src/Kunstmaan/SitemapBundle/Resources/views/SitemapIndex/view.xml.twig
@@ -5,4 +5,11 @@
 			<loc>{{ url('KunstmaanSitemapBundle_sitemap', {'locale': locale, '_format': 'xml'}) }}</loc>
 		</sitemap>
     {% endfor %}
+    {% if extraSitemaps is defined and extraSitemaps is not empty %}
+        {% for sitemap in extraSitemaps %}
+            <sitemap>
+                <loc>{{ sitemap.url }}</loc>
+            </sitemap>
+        {% endfor %}
+    {% endif %}
 </sitemapindex>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Add a custom event for adding extra sitemaps to the sitemap index page. Implementation example
```
final class SitemapListener implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            PreSitemapIndexRenderEvent::NAME => 'addSitemap',
        ];
    }

    public function addSitemap(PreSitemapIndexRenderEvent $event): void
    {
        $event->addExtraSitemap(new SitemapIndex('https://example.com'));
    }
}
```