### PR TITLE
[AdminBundle] Fix remaining usages of deprecated admin_exception_excludes config

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -60,7 +60,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
 
         $container->setParameter('kunstmaan_admin.admin_prefix', $this->normalizeUrlSlice($config['admin_prefix']));
 
-        $container->setParameter('kunstmaan_admin.admin_exception_excludes', $config['admin_exception_excludes']);
+        $exceptionExcludes = !empty($config['exception_logging']['exclude_patterns']) ? $config['exception_logging']['exclude_patterns'] : $config['admin_exception_excludes'];
+        $container->setParameter('kunstmaan_admin.admin_exception_excludes', $exceptionExcludes);
 
         $container->setParameter('kunstmaan_admin.google_signin.enabled', $config['google_signin']['enabled']);
         $container->setParameter('kunstmaan_admin.google_signin.client_id', $config['google_signin']['client_id']);

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
@@ -180,6 +180,51 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.default_locale', '');
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedExceptionExcludes()
+    {
+        $this->load(array_merge($this->getRequiredConfig(), [
+            'authentication' => [
+                'enable_new_authentication' => true,
+            ],
+            'admin_exception_excludes' => [
+                'test_exclude',
+            ],
+        ]));
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.admin_exception_excludes', ['test_exclude']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedExceptionExcludesWithNewConfig()
+    {
+        $this->load(array_merge($this->getRequiredConfig(), [
+            'admin_exception_excludes' => [
+                'test_exclude',
+            ],
+            'exception_logging' => [
+                'exclude_patterns' => ['test_exclude_new_config'],
+            ],
+        ]));
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.admin_exception_excludes', ['test_exclude_new_config']);
+    }
+
+    public function testExceptionExcludesFromExceptionLoggingConfig()
+    {
+        $this->load(array_merge($this->getRequiredConfig(), [
+            'exception_logging' => [
+                'exclude_patterns' => ['test_exclude_new_config'],
+            ],
+        ]));
+
+        $this->assertContainerBuilderHasParameter('kunstmaan_admin.admin_exception_excludes', ['test_exclude_new_config']);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Follow up of #2857
