### PR TITLE
[TranslatorBundle] Remove forced import from admin interface

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @final      since 5.1
  *
- * @deprecated since 5.1
  * NEXT_MAJOR extend from `Command` and remove `$this->getContainer` usages
  * NEXT_MAJOR file will be renamed
  */

--- a/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
+++ b/src/Kunstmaan/TranslatorBundle/Resources/views/Translator/list.html.twig
@@ -50,11 +50,6 @@
                                             </a>
                                         </li>
                                         <li>
-                                            <a data-toggle="modal" data-target="#import-force-modal">
-                                                {{ 'settings.translator.import_translations_forced' | trans }}
-                                            </a>
-                                        </li>
-                                        <li>
                                             <a href="{{ path('KunstmaanTranslatorBundle_settings_translations_upload') }}">
                                                 {{ 'settings.translator.import_file' | trans }}
                                             </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This option is too dangerous for admin users to accidentally click on it and overwrite all translations. It's still possible to do a forced import from the cli.

In the second commit I removed the incorrect deprecation on the command
