### PR TITLE
[AllBundles] Add return type declarations and improve docblocks

### DIFF
--- a/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
@@ -90,7 +90,7 @@ class ApplyAclCommand extends ContainerAwareCommand
     /**
      * @return bool
      */
-    private function isRunning()
+    private function isRunning(): bool
     {
         // Check if we have records in running state, if so read PID & check if process is active
         /* @var AclChangeset $runningAclChangeset */

--- a/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ApplyAclCommand.php
@@ -87,9 +87,6 @@ class ApplyAclCommand extends ContainerAwareCommand
         return 0;
     }
 
-    /**
-     * @return bool
-     */
     private function isRunning(): bool
     {
         // Check if we have records in running state, if so read PID & check if process is active

--- a/src/Kunstmaan/AdminBundle/Command/ExceptionCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/ExceptionCommand.php
@@ -51,6 +51,9 @@ class ExceptionCommand extends ContainerAwareCommand
             );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->em) {

--- a/src/Kunstmaan/AdminBundle/Command/UpdateAclCommand.php
+++ b/src/Kunstmaan/AdminBundle/Command/UpdateAclCommand.php
@@ -58,6 +58,9 @@ class UpdateAclCommand extends ContainerAwareCommand
                 'with given role and permissions');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $helper = $this->getHelper('question');

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -137,6 +137,8 @@ class KunstmaanAdminExtension extends Extension implements PrependExtensionInter
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getNamespace()
     {

--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -206,6 +206,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function setEnabled($boolean)
     {
@@ -292,6 +294,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function isAccountNonLocked()
     {
@@ -303,6 +307,9 @@ abstract class BaseUser implements UserInterface
         return $this->email;
     }
 
+    /**
+     * @return static
+     */
     public function setEmail($email)
     {
         $this->email = $email;
@@ -315,6 +322,9 @@ abstract class BaseUser implements UserInterface
         return $this->password;
     }
 
+    /**
+     * @return static
+     */
     public function setPassword($password)
     {
         $this->password = $password;
@@ -327,6 +337,9 @@ abstract class BaseUser implements UserInterface
         return $this->plainPassword;
     }
 
+    /**
+     * @return static
+     */
     public function setPlainPassword($plainPassword)
     {
         $this->plainPassword = $plainPassword;
@@ -351,6 +364,9 @@ abstract class BaseUser implements UserInterface
         return array_unique($roles);
     }
 
+    /**
+     * @return bool
+     */
     public function hasRole($role)
     {
         return in_array(strtoupper($role), $this->getRoles(), true);
@@ -358,6 +374,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function setRoles(array $roles)
     {
@@ -370,6 +388,9 @@ abstract class BaseUser implements UserInterface
         return $this;
     }
 
+    /**
+     * @return static
+     */
     public function removeRole($role)
     {
         if (false !== $key = array_search(strtoupper($role), $this->roles, true)) {
@@ -385,6 +406,9 @@ abstract class BaseUser implements UserInterface
         return $this->salt;
     }
 
+    /**
+     * @return static
+     */
     public function setSalt($salt)
     {
         $this->salt = $salt;
@@ -392,6 +416,9 @@ abstract class BaseUser implements UserInterface
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabled()
     {
         return $this->enabled;
@@ -405,6 +432,9 @@ abstract class BaseUser implements UserInterface
         return $this->username;
     }
 
+    /**
+     * @return static
+     */
     public function setUsername($username)
     {
         $this->username = $username;
@@ -422,6 +452,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function addRole($role)
     {
@@ -439,6 +471,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function getGroupNames()
     {
@@ -452,6 +486,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function hasGroup($name)
     {
@@ -460,6 +496,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function addGroup(GroupInterface $group)
     {
@@ -472,6 +510,8 @@ abstract class BaseUser implements UserInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function removeGroup(GroupInterface $group)
     {
@@ -482,6 +522,9 @@ abstract class BaseUser implements UserInterface
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return (string) $this->getUsername();
@@ -561,11 +604,17 @@ abstract class BaseUser implements UserInterface
         return $this;
     }
 
+    /**
+     * @return string|null
+     */
     public function getConfirmationToken()
     {
         return $this->confirmationToken;
     }
 
+    /**
+     * @return static
+     */
     public function setConfirmationToken($confirmationToken)
     {
         $this->confirmationToken = $confirmationToken;
@@ -573,6 +622,9 @@ abstract class BaseUser implements UserInterface
         return $this;
     }
 
+    /**
+     * @return static
+     */
     public function setPasswordRequestedAt(\DateTime $date = null)
     {
         //TODO: check if this propery is usefull?
@@ -587,6 +639,9 @@ abstract class BaseUser implements UserInterface
         return $this->lastLogin;
     }
 
+    /**
+     * @return static
+     */
     public function setLastLogin(?\DateTime $lastLogin = null)
     {
         $this->lastLogin = $lastLogin;

--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -85,7 +85,7 @@ class AdminLocaleListener implements EventSubscriberInterface
      *
      * @return bool
      */
-    private function isAdminToken($providerKey, TokenInterface $token = null)
+    private function isAdminToken($providerKey, TokenInterface $token = null): bool
     {
         return \is_callable([$token, 'getProviderKey']) && $token->getProviderKey() === $providerKey;
     }

--- a/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/AdminLocaleListener.php
@@ -82,14 +82,15 @@ class AdminLocaleListener implements EventSubscriberInterface
 
     /**
      * @param TokenInterface $token
-     *
-     * @return bool
      */
     private function isAdminToken($providerKey, TokenInterface $token = null): bool
     {
         return \is_callable([$token, 'getProviderKey']) && $token->getProviderKey() === $providerKey;
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return [

--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
@@ -20,7 +20,7 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConsoleEvents::ERROR => 'onConsoleError',

--- a/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/ConsoleExceptionSubscriber.php
@@ -17,9 +17,6 @@ final class ConsoleExceptionSubscriber implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
-    /**
-     * @return array
-     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
@@ -120,7 +120,7 @@ class SessionSecurityListener
     /**
      * @return string
      */
-    private function getIp(Request $request)
+    private function getIp(Request $request): string
     {
         if (!$this->ip) {
             $forwarded = $request->server->get('HTTP_X_FORWARDED_FOR');

--- a/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
@@ -117,9 +117,6 @@ class SessionSecurityListener
         $session->set('kuma_ua', $this->getUserAgent($request));
     }
 
-    /**
-     * @return string
-     */
     private function getIp(Request $request): string
     {
         if (!$this->ip) {

--- a/src/Kunstmaan/AdminBundle/EventSubscriber/LoginEventSubscriber.php
+++ b/src/Kunstmaan/AdminBundle/EventSubscriber/LoginEventSubscriber.php
@@ -18,7 +18,7 @@ final class LoginEventSubscriber implements EventSubscriberInterface
         $this->em = $em;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SecurityEvents::INTERACTIVE_LOGIN => 'setLastLoginDate',

--- a/src/Kunstmaan/AdminBundle/Form/ColorType.php
+++ b/src/Kunstmaan/AdminBundle/Form/ColorType.php
@@ -13,11 +13,17 @@ class ColorType extends AbstractType
         $resolver->setDefaults([TextType::class]);
     }
 
+    /**
+     * @return string|null
+     */
     public function getParent()
     {
         return TextType::class;
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'color';

--- a/src/Kunstmaan/AdminBundle/Form/DashboardConfigurationType.php
+++ b/src/Kunstmaan/AdminBundle/Form/DashboardConfigurationType.php
@@ -24,6 +24,9 @@ class DashboardConfigurationType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'dashboardconfiguration';

--- a/src/Kunstmaan/AdminBundle/Form/GroupType.php
+++ b/src/Kunstmaan/AdminBundle/Form/GroupType.php
@@ -45,6 +45,9 @@ class GroupType extends AbstractType
             );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'group';

--- a/src/Kunstmaan/AdminBundle/Form/RoleType.php
+++ b/src/Kunstmaan/AdminBundle/Form/RoleType.php
@@ -19,6 +19,9 @@ class RoleType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'role';

--- a/src/Kunstmaan/AdminBundle/Form/UserType.php
+++ b/src/Kunstmaan/AdminBundle/Form/UserType.php
@@ -86,6 +86,9 @@ class UserType extends AbstractType implements RoleDependentUserFormInterface
         }
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'user';

--- a/src/Kunstmaan/AdminBundle/Helper/AdminPanel/AdminPanel.php
+++ b/src/Kunstmaan/AdminBundle/Helper/AdminPanel/AdminPanel.php
@@ -49,7 +49,7 @@ class AdminPanel
      *
      * @return AdminPanelAdaptorInterface[]
      */
-    private function getAdaptors()
+    private function getAdaptors(): array
     {
         if (!isset($this->sorted)) {
             $this->sortAdaptors();

--- a/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
@@ -49,8 +49,6 @@ class CloneHelper
 
     /**
      * @param object $event
-     *
-     * @return object
      */
     private function dispatch($event, string $eventName): object
     {

--- a/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/CloneHelper.php
@@ -52,7 +52,7 @@ class CloneHelper
      *
      * @return object
      */
-    private function dispatch($event, string $eventName)
+    private function dispatch($event, string $eventName): object
     {
         if (class_exists(LegacyEventDispatcherProxy::class)) {
             $eventDispatcher = LegacyEventDispatcherProxy::decorate($this->eventDispatcher);

--- a/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
+++ b/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
@@ -105,7 +105,7 @@ class TabPane
     /**
      * @return string
      */
-    private function generateIdentifier(TabInterface $tab)
+    private function generateIdentifier(TabInterface $tab): string
     {
         return $this->slugifier->slugify($tab->getTitle());
     }

--- a/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
+++ b/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
@@ -102,9 +102,6 @@ class TabPane
         }
     }
 
-    /**
-     * @return string
-     */
     private function generateIdentifier(TabInterface $tab): string
     {
         return $this->slugifier->slugify($tab->getTitle());

--- a/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
@@ -52,8 +52,6 @@ class SimpleMenuAdaptor implements MenuAdaptorInterface
 
     /**
      * @param array $item
-     *
-     * @return bool
      */
     private function parentMatches(?MenuItem $parent, $item): bool
     {

--- a/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Menu/SimpleMenuAdaptor.php
@@ -55,7 +55,7 @@ class SimpleMenuAdaptor implements MenuAdaptorInterface
      *
      * @return bool
      */
-    private function parentMatches(?MenuItem $parent, $item)
+    private function parentMatches(?MenuItem $parent, $item): bool
     {
         if (null === $parent) {
             return null === $item['parent'];

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclHelper.php
@@ -135,8 +135,6 @@ class AclHelper
      * http://www.scribd.com/doc/14683263/Efficient-Pagination-Using-MySQL
      * This will only check permissions on the first entity added in the from clause, it will not check permissions
      * By default the number of rows returned are 10 starting from 0
-     *
-     * @return string
      */
     private function getPermittedAclIdsSQLForUser(Query $query): string
     {

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclHelper.php
@@ -138,7 +138,7 @@ class AclHelper
      *
      * @return string
      */
-    private function getPermittedAclIdsSQLForUser(Query $query)
+    private function getPermittedAclIdsSQLForUser(Query $query): string
     {
         $databasePlatform = $this->em->getConnection()->getDatabasePlatform();
         $mask = $query->getHint('acl.mask');

--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/Voter/AclVoter.php
@@ -35,6 +35,9 @@ class AclVoter extends BaseAclVoter
         $this->permissionsEnabled = $permissionsEnabled;
     }
 
+    /**
+     * @return int
+     */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
         $attributeIsSupported = false;

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
@@ -75,7 +75,7 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
      *
      * @return string[]|null
      */
-    private function getAccessLevels($email)
+    private function getAccessLevels($email): ?array
     {
         foreach ($this->hostedDomains as $hostedDomain) {
             if (preg_match('/' . $hostedDomain['domain_name'] . '$/', $email)) {
@@ -93,7 +93,7 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
      *
      * @return bool
      */
-    private function isConfiguredDomain($email)
+    private function isConfiguredDomain($email): bool
     {
         foreach ($this->hostedDomains as $hostedDomain) {
             if (preg_match('/' . $hostedDomain['domain_name'] . '$/', $email)) {

--- a/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/OAuth/OAuthUserCreator.php
@@ -90,8 +90,6 @@ class OAuthUserCreator implements OAuthUserCreatorInterface
      * This method returns wether a domain for the given email has been configured
      *
      * @param string $email
-     *
-     * @return bool
      */
     private function isConfiguredDomain($email): bool
     {

--- a/src/Kunstmaan/AdminBundle/Service/PasswordResetService.php
+++ b/src/Kunstmaan/AdminBundle/Service/PasswordResetService.php
@@ -57,8 +57,6 @@ class PasswordResetService
 
     /**
      * @param object $event
-     *
-     * @return object
      */
     private function dispatch($event, string $eventName): object
     {

--- a/src/Kunstmaan/AdminBundle/Service/PasswordResetService.php
+++ b/src/Kunstmaan/AdminBundle/Service/PasswordResetService.php
@@ -60,7 +60,7 @@ class PasswordResetService
      *
      * @return object
      */
-    private function dispatch($event, string $eventName)
+    private function dispatch($event, string $eventName): object
     {
         if (class_exists(LegacyEventDispatcherProxy::class)) {
             $eventDispatcher = LegacyEventDispatcherProxy::decorate($this->eventDispatcher);

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -9,6 +9,7 @@ use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationTest extends TestCase
 {
@@ -64,9 +65,9 @@ class ConfigurationTest extends TestCase
     ];
 
     /**
-     * @return \Symfony\Component\Config\Definition\ConfigurationInterface
+     * @return ConfigurationInterface
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();
     }

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -64,9 +64,6 @@ class ConfigurationTest extends TestCase
         ],
     ];
 
-    /**
-     * @return ConfigurationInterface
-     */
     protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();

--- a/src/Kunstmaan/AdminBundle/Tests/Entity/GroupTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Entity/GroupTest.php
@@ -157,9 +157,9 @@ class GroupTest extends TestCase
     /**
      * @param string $name
      *
-     * @return \Kunstmaan\AdminBundle\Entity\Role
+     * @return Role
      */
-    protected function getRole($name = 'role1')
+    protected function getRole($name = 'role1'): Role
     {
         $role = $this->getMockBuilder('Kunstmaan\AdminBundle\Entity\Role')
             ->disableOriginalConstructor()

--- a/src/Kunstmaan/AdminBundle/Tests/Entity/GroupTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Entity/GroupTest.php
@@ -156,8 +156,6 @@ class GroupTest extends TestCase
 
     /**
      * @param string $name
-     *
-     * @return Role
      */
     protected function getRole($name = 'role1'): Role
     {

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/FakeView.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/FakeView.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\FormView;
 
 class FakeView extends FormView
 {
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         $this->children[$name] = $value;
     }

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/MaskBuilderTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/MaskBuilderTest.php
@@ -38,8 +38,6 @@ class MaskBuilderTest extends TestCase
 
     /**
      * Provides data to the {@link testSlugify} function
-     *
-     * @return array
      */
     public function getInvalidConstructorData(): array
     {

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/MaskBuilderTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/MaskBuilderTest.php
@@ -41,7 +41,7 @@ class MaskBuilderTest extends TestCase
      *
      * @return array
      */
-    public function getInvalidConstructorData()
+    public function getInvalidConstructorData(): array
     {
         return [
             [234.463],

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/PermissionAdminTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/PermissionAdminTest.php
@@ -150,7 +150,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return EntityManager
      */
-    public function getEntityManager()
+    public function getEntityManager(): EntityManager
     {
         return $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
@@ -162,7 +162,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return AclProviderInterface
      */
-    public function getAclProvider()
+    public function getAclProvider(): AclProviderInterface
     {
         return $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclProviderInterface');
     }
@@ -172,7 +172,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return TokenStorageInterface
      */
-    public function getTokenStorage()
+    public function getTokenStorage(): TokenStorageInterface
     {
         return $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
     }
@@ -182,7 +182,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return ObjectIdentityRetrievalStrategyInterface
      */
-    public function getOidRetrievalStrategy()
+    public function getOidRetrievalStrategy(): ObjectIdentityRetrievalStrategyInterface
     {
         return $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
     }
@@ -192,7 +192,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return EventDispatcherInterface
      */
-    public function getEventDispatcher()
+    public function getEventDispatcher(): EventDispatcherInterface
     {
         return $this->createMock('Symfony\Component\EventDispatcher\EventDispatcher');
     }
@@ -200,7 +200,7 @@ class PermissionAdminTest extends TestCase
     /**
      * @return Shell
      */
-    public function getShell()
+    public function getShell(): Shell
     {
         $mock = $this->createMock(Shell::class);
         $mock->method('runInBackground')
@@ -213,7 +213,7 @@ class PermissionAdminTest extends TestCase
     /**
      * @return KernelInterface
      */
-    public function getKernel()
+    public function getKernel(): KernelInterface
     {
         $mock = $this->createMock(Kernel::class);
         $mock->method('getProjectDir')->willReturn('/some/project/directory');
@@ -227,7 +227,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return PermissionAdmin
      */
-    public function getPermissionAdmin()
+    public function getPermissionAdmin(): PermissionAdmin
     {
         $em = $this->getEntityManager();
         $context = $this->getTokenStorage();
@@ -279,7 +279,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return AbstractEntity
      */
-    public function getEntity()
+    public function getEntity(): AbstractEntity
     {
         return $this->getMockForAbstractClass('Kunstmaan\AdminBundle\Entity\AbstractEntity');
     }
@@ -289,7 +289,7 @@ class PermissionAdminTest extends TestCase
      *
      * @return PermissionAdmin
      */
-    public function getInitializedPermissionAdmin()
+    public function getInitializedPermissionAdmin(): PermissionAdmin
     {
         $object = $this->getPermissionAdmin();
         $entity = $this->getEntity();

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/PermissionAdminTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/Permission/PermissionAdminTest.php
@@ -147,8 +147,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return entity manager mock
-     *
-     * @return EntityManager
      */
     public function getEntityManager(): EntityManager
     {
@@ -159,8 +157,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return alc provider mock
-     *
-     * @return AclProviderInterface
      */
     public function getAclProvider(): AclProviderInterface
     {
@@ -169,8 +165,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return security token storage
-     *
-     * @return TokenStorageInterface
      */
     public function getTokenStorage(): TokenStorageInterface
     {
@@ -179,8 +173,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return oid retrieval strategy mock
-     *
-     * @return ObjectIdentityRetrievalStrategyInterface
      */
     public function getOidRetrievalStrategy(): ObjectIdentityRetrievalStrategyInterface
     {
@@ -189,17 +181,12 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return event dispatcher mock
-     *
-     * @return EventDispatcherInterface
      */
     public function getEventDispatcher(): EventDispatcherInterface
     {
         return $this->createMock('Symfony\Component\EventDispatcher\EventDispatcher');
     }
 
-    /**
-     * @return Shell
-     */
     public function getShell(): Shell
     {
         $mock = $this->createMock(Shell::class);
@@ -210,9 +197,6 @@ class PermissionAdminTest extends TestCase
         return $mock;
     }
 
-    /**
-     * @return KernelInterface
-     */
     public function getKernel(): KernelInterface
     {
         $mock = $this->createMock(Kernel::class);
@@ -224,8 +208,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return permission admin mock
-     *
-     * @return PermissionAdmin
      */
     public function getPermissionAdmin(): PermissionAdmin
     {
@@ -276,8 +258,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return entity mock
-     *
-     * @return AbstractEntity
      */
     public function getEntity(): AbstractEntity
     {
@@ -286,8 +266,6 @@ class PermissionAdminTest extends TestCase
 
     /**
      * Return permission admin mock
-     *
-     * @return PermissionAdmin
      */
     public function getInitializedPermissionAdmin(): PermissionAdmin
     {

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserCreatorTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserCreatorTest.php
@@ -30,9 +30,6 @@ class OAuthUserCreatorTest extends TestCase
      */
     private $finder;
 
-    /**
-     * @return MockObject
-     */
     private function getEm(): MockObject
     {
         if (!isset($this->em)) {
@@ -42,9 +39,6 @@ class OAuthUserCreatorTest extends TestCase
         return $this->em;
     }
 
-    /**
-     * @return MockObject
-     */
     private function getFinder(): MockObject
     {
         if (!isset($this->finder)) {

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserCreatorTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserCreatorTest.php
@@ -33,7 +33,7 @@ class OAuthUserCreatorTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getEm()
+    private function getEm(): MockObject
     {
         if (!isset($this->em)) {
             $this->em = $this->createMock(EntityManager::class);
@@ -45,7 +45,7 @@ class OAuthUserCreatorTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getFinder()
+    private function getFinder(): MockObject
     {
         if (!isset($this->finder)) {
             $this->finder = $this->createMock(OAuthUserFinderInterface::class);

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserFinderTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserFinderTest.php
@@ -25,7 +25,7 @@ class OAuthUserFinderTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getEm()
+    private function getEm(): MockObject
     {
         if (!isset($this->em)) {
             $this->em = $this->createMock(EntityManager::class);

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserFinderTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/OAuth/OAuthUserFinderTest.php
@@ -22,9 +22,6 @@ class OAuthUserFinderTest extends TestCase
      */
     private $em;
 
-    /**
-     * @return MockObject
-     */
     private function getEm(): MockObject
     {
         if (!isset($this->em)) {

--- a/src/Kunstmaan/AdminBundle/Tests/Validator/Constraints/PasswordRestrictionsValidatorTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Validator/Constraints/PasswordRestrictionsValidatorTest.php
@@ -18,9 +18,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     const PARAMETER_MIN_UPPERCASE = 2;
     const PARAMETER_MIN_SPECIAL_CHARACTERS = 1;
 
-    /**
-     * @return PasswordRestrictionsValidator
-     */
     protected function createValidator(): PasswordRestrictionsValidator
     {
         return new PasswordRestrictionsValidator(self::PARAMETER_MIN_DIGITS, self::PARAMETER_MIN_UPPERCASE, self::PARAMETER_MIN_SPECIAL_CHARACTERS, self::PARAMETER_MIN_LENGTH, self::PARAMETER_MAX_LENGTH);
@@ -154,9 +151,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         }
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsWithAllParameters(): array
     {
         return [
@@ -169,9 +163,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsToShort(): array
     {
         return [
@@ -181,9 +172,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsToLong(): array
     {
         return [
@@ -192,9 +180,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsMinimumDigits(): array
     {
         return [
@@ -203,9 +188,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsMinimumUppercase(): array
     {
         return [
@@ -214,9 +196,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
     public function dataPasswordsMinimumSpecialCharacters(): array
     {
         return [
@@ -228,8 +207,6 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * Combine the data of the too long and too short test for an extra length
      * range test.
-     *
-     * @return array
      */
     public function dataPasswordsLengthRange(): array
     {

--- a/src/Kunstmaan/AdminBundle/Tests/Validator/Constraints/PasswordRestrictionsValidatorTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Validator/Constraints/PasswordRestrictionsValidatorTest.php
@@ -21,7 +21,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return PasswordRestrictionsValidator
      */
-    protected function createValidator()
+    protected function createValidator(): PasswordRestrictionsValidator
     {
         return new PasswordRestrictionsValidator(self::PARAMETER_MIN_DIGITS, self::PARAMETER_MIN_UPPERCASE, self::PARAMETER_MIN_SPECIAL_CHARACTERS, self::PARAMETER_MIN_LENGTH, self::PARAMETER_MAX_LENGTH);
     }
@@ -157,7 +157,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsWithAllParameters()
+    public function dataPasswordsWithAllParameters(): array
     {
         return [
             ['ABcdef789!'],
@@ -172,7 +172,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsToShort()
+    public function dataPasswordsToShort(): array
     {
         return [
             ['password'],
@@ -184,7 +184,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsToLong()
+    public function dataPasswordsToLong(): array
     {
         return [
             ['correct!'],
@@ -195,7 +195,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsMinimumDigits()
+    public function dataPasswordsMinimumDigits(): array
     {
         return [
             ['withdigits123'],
@@ -206,7 +206,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsMinimumUppercase()
+    public function dataPasswordsMinimumUppercase(): array
     {
         return [
             ['PassworD'],
@@ -217,7 +217,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
     /**
      * @return array
      */
-    public function dataPasswordsMinimumSpecialCharacters()
+    public function dataPasswordsMinimumSpecialCharacters(): array
     {
         return [
             ['password!'],
@@ -231,7 +231,7 @@ class PasswordRestrictionsValidatorTest extends ConstraintValidatorTestCase
      *
      * @return array
      */
-    public function dataPasswordsLengthRange()
+    public function dataPasswordsLengthRange(): array
     {
         return $this->dataPasswordsToLong() + $this->dataPasswordsToShort();
     }

--- a/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
+++ b/src/Kunstmaan/AdminBundle/Toolbar/BundleVersionDataCollector.php
@@ -83,6 +83,9 @@ class BundleVersionDataCollector extends AbstractDataCollector
         return $this->data;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'kuma_bundle_versions';

--- a/src/Kunstmaan/AdminBundle/Twig/AdminBundleTwigExtension.php
+++ b/src/Kunstmaan/AdminBundle/Twig/AdminBundleTwigExtension.php
@@ -26,6 +26,9 @@ class AdminBundleTwigExtension extends AbstractExtension implements GlobalsInter
         $this->requiredLocales = $requiredLocales;
     }
 
+    /**
+     * @return array
+     */
     public function getGlobals()
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -553,8 +553,6 @@ abstract class AdminListController extends Controller
 
     /**
      * @param object $event
-     *
-     * @return object
      */
     private function dispatch($event, string $eventName): object
     {

--- a/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AdminListController.php
@@ -556,7 +556,7 @@ abstract class AdminListController extends Controller
      *
      * @return object
      */
-    private function dispatch($event, string $eventName)
+    private function dispatch($event, string $eventName): object
     {
         $eventDispatcher = $this->container->get('event_dispatcher');
         if (class_exists(LegacyEventDispatcherProxy::class)) {

--- a/src/Kunstmaan/AdminListBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminListBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_k_admin_list');

--- a/src/Kunstmaan/AdminListBundle/Helper/DoctrineDBALAdapter.php
+++ b/src/Kunstmaan/AdminListBundle/Helper/DoctrineDBALAdapter.php
@@ -57,6 +57,8 @@ class DoctrineDBALAdapter implements AdapterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function getNbResults()
     {
@@ -74,6 +76,8 @@ class DoctrineDBALAdapter implements AdapterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return iterable
      */
     public function getSlice($offset, $length)
     {

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/BooleanFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/BooleanFilterTypeTest.php
@@ -44,9 +44,6 @@ class BooleanFilterTypeTest extends BaseDbalFilterTest
         $this->assertEquals("SELECT * FROM entity e WHERE e.boolean = $value", $qb->getSQL());
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/BooleanFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/BooleanFilterTypeTest.php
@@ -47,7 +47,7 @@ class BooleanFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['true'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateFilterTypeTest.php
@@ -50,9 +50,6 @@ class DateFilterTypeTest extends BaseDbalFilterTest
         $this->assertEquals($testValue, $qb->getParameter('var_date'));
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateFilterTypeTest.php
@@ -53,7 +53,7 @@ class DateFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['before', '<= :var_date', '20/12/2012', '2012-12-20'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateTimeFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateTimeFilterTypeTest.php
@@ -19,9 +19,6 @@ class DateTimeFilterTypeTest extends BaseDbalFilterTest
         $this->object = new DateTimeFilterType('datetime', 'e');
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateTimeFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/DateTimeFilterTypeTest.php
@@ -22,7 +22,7 @@ class DateTimeFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['before', '<= :var_datetime', ['date' => '14/04/2014', 'time' => '09:00'], '2014-04-14 09:00'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/EnumerationFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/EnumerationFilterTypeTest.php
@@ -50,9 +50,6 @@ class EnumerationFilterTypeTest extends BaseDbalFilterTest
         }
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/EnumerationFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/EnumerationFilterTypeTest.php
@@ -53,7 +53,7 @@ class EnumerationFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
           ['in', 'IN (:var_enumeration)', [1, 2], true],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/NumberFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/NumberFilterTypeTest.php
@@ -50,9 +50,6 @@ class NumberFilterTypeTest extends BaseDbalFilterTest
         }
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/NumberFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/NumberFilterTypeTest.php
@@ -53,7 +53,7 @@ class NumberFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['eq', '= :var_number', 1, true],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/StringFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/StringFilterTypeTest.php
@@ -48,9 +48,6 @@ class StringFilterTypeTest extends BaseDbalFilterTest
         $this->assertEquals($testValue, $qb->getParameter('var_string'));
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/StringFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/DBAL/StringFilterTypeTest.php
@@ -51,7 +51,7 @@ class StringFilterTypeTest extends BaseDbalFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['equals', '= :var_string', 'AStringValue1', 'AStringValue1'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/BooleanFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/BooleanFilterTypeTest.php
@@ -53,7 +53,7 @@ class BooleanFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['true'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/BooleanFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/BooleanFilterTypeTest.php
@@ -50,9 +50,6 @@ class BooleanFilterTypeTest extends BaseOrmFilterTest
         $this->assertEquals("SELECT b FROM Entity b WHERE b.boolean = $value", $qb->getDQL());
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateFilterTypeTest.php
@@ -60,7 +60,7 @@ class DateFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['before', '<= :var_date', '20/12/2012', '2012-12-20'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateFilterTypeTest.php
@@ -57,9 +57,6 @@ class DateFilterTypeTest extends BaseOrmFilterTest
         $this->assertEquals($testValue, $qb->getParameter('var_date')->getValue());
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateTimeFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateTimeFilterTypeTest.php
@@ -22,7 +22,7 @@ class DateTimeFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['before', '<= :var_datetime', ['date' => '14/04/2014', 'time' => '09:00'], '2014-04-14 09:00'],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateTimeFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/DateTimeFilterTypeTest.php
@@ -19,9 +19,6 @@ class DateTimeFilterTypeTest extends BaseOrmFilterTest
         $this->object = new DateTimeFilterType('datetime', 'b');
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/EnumerationFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/EnumerationFilterTypeTest.php
@@ -50,9 +50,6 @@ class EnumerationFilterTypeTest extends BaseOrmFilterTest
         }
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/EnumerationFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/EnumerationFilterTypeTest.php
@@ -53,7 +53,7 @@ class EnumerationFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
           ['in', 'IN(:var_enumeration)', [1, 2], true],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/NumberFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/NumberFilterTypeTest.php
@@ -53,7 +53,7 @@ class NumberFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['eq', '= :var_number', 1, true],

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/NumberFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/NumberFilterTypeTest.php
@@ -50,9 +50,6 @@ class NumberFilterTypeTest extends BaseOrmFilterTest
         }
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/StringFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/StringFilterTypeTest.php
@@ -48,9 +48,6 @@ class StringFilterTypeTest extends BaseOrmFilterTest
         $this->assertEquals($testValue, $qb->getParameter('var_string')->getValue());
     }
 
-    /**
-     * @return array
-     */
     public static function applyDataProvider(): array
     {
         return [

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/StringFilterTypeTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/FilterType/ORM/StringFilterTypeTest.php
@@ -51,7 +51,7 @@ class StringFilterTypeTest extends BaseOrmFilterTest
     /**
      * @return array
      */
-    public static function applyDataProvider()
+    public static function applyDataProvider(): array
     {
         return [
             ['equals', '= :var_string', 'AStringValue1', 'AStringValue1'],

--- a/src/Kunstmaan/AdminListBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,9 +11,6 @@ class ConfigurationTest extends TestCase
 {
     use ConfigurationTestCaseTrait;
 
-    /**
-     * @return ConfigurationInterface
-     */
     protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();

--- a/src/Kunstmaan/AdminListBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -5,15 +5,16 @@ namespace Kunstmaan\AdminListBundle\Tests\DependencyInjection;
 use Kunstmaan\AdminListBundle\DependencyInjection\Configuration;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationTest extends TestCase
 {
     use ConfigurationTestCaseTrait;
 
     /**
-     * @return \Symfony\Component\Config\Definition\ConfigurationInterface
+     * @return ConfigurationInterface
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();
     }

--- a/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
+++ b/src/Kunstmaan/AdminListBundle/Twig/AdminListTwigExtension.php
@@ -35,6 +35,8 @@ class AdminListTwigExtension extends AbstractExtension
 
     /**
      * {@inheritdoc}
+     *
+     * @return TwigTest[]
      */
     public function getTests()
     {

--- a/src/Kunstmaan/ArticleBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/ArticleBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_article');

--- a/src/Kunstmaan/ArticleBundle/Form/AbstractAuthorAdminType.php
+++ b/src/Kunstmaan/ArticleBundle/Form/AbstractAuthorAdminType.php
@@ -18,6 +18,9 @@ class AbstractAuthorAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'abstactauthor_form';

--- a/src/Kunstmaan/ArticleBundle/Form/AbstractCategoryAdminType.php
+++ b/src/Kunstmaan/ArticleBundle/Form/AbstractCategoryAdminType.php
@@ -15,6 +15,9 @@ class AbstractCategoryAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'abstactcategory_form';

--- a/src/Kunstmaan/ArticleBundle/Form/AbstractTagAdminType.php
+++ b/src/Kunstmaan/ArticleBundle/Form/AbstractTagAdminType.php
@@ -15,6 +15,9 @@ class AbstractTagAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'abstacttag_form';

--- a/src/Kunstmaan/ArticleBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -5,15 +5,16 @@ namespace Kunstmaan\ArticleBundle\Tests\DependencyInjection;
 use Kunstmaan\ArticleBundle\DependencyInjection\Configuration;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationTest extends TestCase
 {
     use ConfigurationTestCaseTrait;
 
     /**
-     * @return \Symfony\Component\Config\Definition\ConfigurationInterface
+     * @return ConfigurationInterface
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();
     }

--- a/src/Kunstmaan/ArticleBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,9 +11,6 @@ class ConfigurationTest extends TestCase
 {
     use ConfigurationTestCaseTrait;
 
-    /**
-     * @return ConfigurationInterface
-     */
     protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();

--- a/src/Kunstmaan/CacheBundle/Form/Varnish/BanType.php
+++ b/src/Kunstmaan/CacheBundle/Form/Varnish/BanType.php
@@ -24,6 +24,8 @@ class BanType extends AbstractType
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getBlockPrefix()
     {

--- a/src/Kunstmaan/ConfigBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/ConfigBundle/DependencyInjection/Configuration.php
@@ -8,6 +8,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_config');

--- a/src/Kunstmaan/DashboardBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/DashboardBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_dashboard');

--- a/src/Kunstmaan/FixturesBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/FixturesBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_fixtures');

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateAdminTestsCommand.php
@@ -41,6 +41,8 @@ EOT
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateBundleCommand.php
@@ -64,6 +64,8 @@ EOT
      * @param OutputInterface $output An OutputInterface instance
      *
      * @throws \RuntimeException
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
@@ -53,6 +53,8 @@ EOT
      *
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
@@ -120,10 +120,13 @@ final class InstallCommand extends GeneratorCommand
         $output->writeln('<info>Installation start</info>');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($this->shouldStop) {
-            return;
+            return 1;
         }
 
         $this->initAssistant($input, $output);

--- a/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/LeadGenerationBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_lead_generation');

--- a/src/Kunstmaan/LeadGenerationBundle/Form/NewsletterSubscriptionType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/NewsletterSubscriptionType.php
@@ -21,6 +21,9 @@ class NewsletterSubscriptionType extends AbstractPopupAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'newslettersubscription_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/AfterXScrollPercentRuleAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/AfterXScrollPercentRuleAdminType.php
@@ -14,6 +14,9 @@ class AfterXScrollPercentRuleAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'after_x_percent_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/AfterXSecondsAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/AfterXSecondsAdminType.php
@@ -14,6 +14,9 @@ class AfterXSecondsAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'after_x_seconds_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/LocaleBlackListAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/LocaleBlackListAdminType.php
@@ -27,6 +27,9 @@ class LocaleBlackListAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'locale_blacklist_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/LocaleWhiteListAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/LocaleWhiteListAdminType.php
@@ -27,6 +27,9 @@ class LocaleWhiteListAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'locale_whitelist_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/MaxXTimeAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/MaxXTimeAdminType.php
@@ -14,6 +14,9 @@ class MaxXTimeAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'max_x_times_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/OnExitIntentAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/OnExitIntentAdminType.php
@@ -32,6 +32,9 @@ class OnExitIntentAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'on_exit_intent_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/RecurringEveryXTimeAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/RecurringEveryXTimeAdminType.php
@@ -26,6 +26,9 @@ class RecurringEveryXTimeAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'recurring_every_x_time_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/UrlBlackListAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/UrlBlackListAdminType.php
@@ -17,6 +17,9 @@ class UrlBlackListAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'url_blacklist_form';

--- a/src/Kunstmaan/LeadGenerationBundle/Form/Rule/UrlWhiteListAdminType.php
+++ b/src/Kunstmaan/LeadGenerationBundle/Form/Rule/UrlWhiteListAdminType.php
@@ -17,6 +17,9 @@ class UrlWhiteListAdminType extends AbstractRuleAdminType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'url_whitelist_form';

--- a/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CleanDeletedMediaCommand.php
@@ -65,6 +65,9 @@ class CleanDeletedMediaCommand extends ContainerAwareCommand
             );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->em) {

--- a/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/CreatePdfPreviewCommand.php
@@ -71,6 +71,9 @@ class CreatePdfPreviewCommand extends ContainerAwareCommand
             );
     }
 
+    /**
+     * @return int
+     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->em) {

--- a/src/Kunstmaan/MediaBundle/Command/RebuildFolderTreeCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RebuildFolderTreeCommand.php
@@ -51,6 +51,8 @@ class RebuildFolderTreeCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -63,6 +63,9 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
             );
     }
 
+    /**
+     * @return int
+     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->em) {

--- a/src/Kunstmaan/MediaBundle/Form/BulkMoveMediaType.php
+++ b/src/Kunstmaan/MediaBundle/Form/BulkMoveMediaType.php
@@ -44,6 +44,9 @@ class BulkMoveMediaType extends AbstractType
             );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_folder_bulk_move';

--- a/src/Kunstmaan/MediaBundle/Form/BulkUploadType.php
+++ b/src/Kunstmaan/MediaBundle/Form/BulkUploadType.php
@@ -39,6 +39,8 @@ class BulkUploadType extends AbstractType
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getBlockPrefix()
     {

--- a/src/Kunstmaan/MediaBundle/Form/File/FileType.php
+++ b/src/Kunstmaan/MediaBundle/Form/File/FileType.php
@@ -117,6 +117,9 @@ class FileType extends AbstractType
         );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_filetype';

--- a/src/Kunstmaan/MediaBundle/Form/FolderType.php
+++ b/src/Kunstmaan/MediaBundle/Form/FolderType.php
@@ -66,6 +66,9 @@ class FolderType extends AbstractType
             );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_FolderType';

--- a/src/Kunstmaan/MediaBundle/Form/RemoteAudio/RemoteAudioType.php
+++ b/src/Kunstmaan/MediaBundle/Form/RemoteAudio/RemoteAudioType.php
@@ -41,6 +41,9 @@ class RemoteAudioType extends AbstractRemoteType
             );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_audiotype';

--- a/src/Kunstmaan/MediaBundle/Form/RemoteSlide/RemoteSlideType.php
+++ b/src/Kunstmaan/MediaBundle/Form/RemoteSlide/RemoteSlideType.php
@@ -40,6 +40,9 @@ class RemoteSlideType extends AbstractRemoteType
             );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_slidetype';

--- a/src/Kunstmaan/MediaBundle/Form/RemoteVideo/RemoteVideoType.php
+++ b/src/Kunstmaan/MediaBundle/Form/RemoteVideo/RemoteVideoType.php
@@ -53,6 +53,9 @@ class RemoteVideoType extends AbstractRemoteType
         return $choices;
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_videotype';

--- a/src/Kunstmaan/MediaBundle/Form/Type/MediaType.php
+++ b/src/Kunstmaan/MediaBundle/Form/Type/MediaType.php
@@ -82,6 +82,9 @@ class MediaType extends AbstractType
         );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'media';

--- a/src/Kunstmaan/MediaBundle/Helper/File/SVGExtensionGuesser.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/SVGExtensionGuesser.php
@@ -13,6 +13,8 @@ class SVGExtensionGuesser implements ExtensionGuesserInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function guess($mimeType)
     {

--- a/src/Kunstmaan/MediaBundle/Helper/File/SVGMimeTypeGuesser.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/SVGMimeTypeGuesser.php
@@ -21,7 +21,7 @@ class SVGMimeTypeGuesser implements MimeTypeGuesserInterface
     ];
 
     /**
-     * {@inheritdoc}
+     * @return string|null
      */
     public function guess($path)
     {
@@ -34,13 +34,13 @@ class SVGMimeTypeGuesser implements MimeTypeGuesserInterface
         }
 
         if (!self::isSupported()) {
-            return;
+            return null;
         }
 
         $dom = new \DOMDocument();
         $xml = $dom->load($path, LIBXML_NOERROR + LIBXML_ERR_FATAL + LIBXML_ERR_NONE);
         if ($xml === false) {
-            return;
+            return null;
         }
         $xpath = new \DOMXPath($dom);
         foreach ($xpath->query('namespace::*') as $node) {
@@ -49,7 +49,7 @@ class SVGMimeTypeGuesser implements MimeTypeGuesserInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/BackgroundFilterLoader.php
@@ -13,6 +13,8 @@ class BackgroundFilterLoader extends \Liip\ImagineBundle\Imagine\Filter\Loader\B
 {
     /**
      * {@inheritdoc}
+     *
+     * @return ImageInterface
      */
     public function load(ImageInterface $image, array $options = [])
     {

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/CacheManager.php
@@ -8,6 +8,8 @@ class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function generateUrl($path, $filter, array $runtimeConfig = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
     {
@@ -38,6 +40,8 @@ class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function resolve($path, $filter, $resolver = null)
     {
@@ -49,6 +53,8 @@ class CacheManager extends \Liip\ImagineBundle\Imagine\Cache\CacheManager
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getBrowserPath($path, $filter, array $runtimeConfig = [], $resolver = null, $referenceType = UrlGeneratorInterface::ABSOLUTE_URL)
     {

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/ImagineController.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/ImagineController.php
@@ -2,12 +2,15 @@
 
 namespace Kunstmaan\MediaBundle\Helper\Imagine;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class ImagineController extends \Liip\ImagineBundle\Controller\ImagineController
 {
     /**
      * {@inheritdoc}
+     *
+     * @return RedirectResponse
      */
     public function filterAction(Request $request, $path, $filter)
     {
@@ -21,6 +24,8 @@ class ImagineController extends \Liip\ImagineBundle\Controller\ImagineController
 
     /**
      * {@inheritdoc}
+     *
+     * @return RedirectResponse
      */
     public function filterRuntimeAction(Request $request, $hash, $path, $filter)
     {

--- a/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Imagine/WebPathResolver.php
@@ -46,6 +46,8 @@ class WebPathResolver extends \Liip\ImagineBundle\Imagine\Cache\Resolver\WebPath
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function resolve($path, $filter)
     {

--- a/src/Kunstmaan/MediaBundle/Repository/FolderRepository.php
+++ b/src/Kunstmaan/MediaBundle/Repository/FolderRepository.php
@@ -159,6 +159,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getPathQueryBuilder($node)
     {
@@ -171,6 +173,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getRootNodesQueryBuilder($sortByField = null, $direction = 'asc')
     {
@@ -200,6 +204,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getLeafsQueryBuilder($root = null, $sortByField = null, $direction = 'ASC')
     {
@@ -212,6 +218,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getNextSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -224,6 +232,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getPrevSiblingsQueryBuilder($node, $includeSelf = false)
     {
@@ -236,6 +246,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return QueryBuilder
      */
     public function getNodesHierarchyQueryBuilder(
         $node = null,
@@ -252,6 +264,8 @@ class FolderRepository extends NestedTreeRepository
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function getNodesHierarchy($node = null, $direct = false, array $options = [], $includeNode = false)
     {

--- a/src/Kunstmaan/MediaPagePartBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MediaPagePartBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_media_page_part');

--- a/src/Kunstmaan/MediaPagePartBundle/Form/AudioPagePartAdminType.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Form/AudioPagePartAdminType.php
@@ -31,6 +31,9 @@ class AudioPagePartAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_audiopageparttype';

--- a/src/Kunstmaan/MediaPagePartBundle/Form/DownloadPagePartAdminType.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Form/DownloadPagePartAdminType.php
@@ -30,6 +30,9 @@ class DownloadPagePartAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_downloadpageparttype';

--- a/src/Kunstmaan/MediaPagePartBundle/Form/ImagePagePartAdminType.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Form/ImagePagePartAdminType.php
@@ -45,6 +45,9 @@ class ImagePagePartAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_imagepageparttype';

--- a/src/Kunstmaan/MediaPagePartBundle/Form/SlidePagePartAdminType.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Form/SlidePagePartAdminType.php
@@ -30,6 +30,9 @@ class SlidePagePartAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_slidepageparttype';

--- a/src/Kunstmaan/MediaPagePartBundle/Form/VideoPagePartAdminType.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Form/VideoPagePartAdminType.php
@@ -31,6 +31,9 @@ class VideoPagePartAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_mediabundle_videopageparttype';

--- a/src/Kunstmaan/MenuBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MenuBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_menu');

--- a/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
+++ b/src/Kunstmaan/MenuBundle/Form/MenuItemAdminType.php
@@ -151,6 +151,9 @@ class MenuItemAdminType extends AbstractType
         );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'menuitem_form';

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_multi_domain');

--- a/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
+++ b/src/Kunstmaan/NodeBundle/Command/CronUpdateNodeCommand.php
@@ -69,6 +69,8 @@ class CronUpdateNodeCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/NodeBundle/Command/InitAclCommand.php
+++ b/src/Kunstmaan/NodeBundle/Command/InitAclCommand.php
@@ -72,6 +72,8 @@ class InitAclCommand extends ContainerAwareCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -8,6 +8,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_node');

--- a/src/Kunstmaan/NodeBundle/Entity/NodeIterator.php
+++ b/src/Kunstmaan/NodeBundle/Entity/NodeIterator.php
@@ -13,11 +13,19 @@ class NodeIterator implements \RecursiveIterator
         $this->_data = $data;
     }
 
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function hasChildren()
     {
         return !$this->_data->current()->getChildren()->isEmpty();
     }
 
+    /**
+     * @return \?RecursiveIterator
+     */
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         return new NodeIterator($this->_data->current()->getChildren());

--- a/src/Kunstmaan/NodeBundle/Form/DataTransformer/URLChooserToLinkTransformer.php
+++ b/src/Kunstmaan/NodeBundle/Form/DataTransformer/URLChooserToLinkTransformer.php
@@ -10,6 +10,9 @@ class URLChooserToLinkTransformer implements DataTransformerInterface
 {
     use URLValidator;
 
+    /**
+     * @return array
+     */
     public function transform($value)
     {
         if ($this->isEmailAddress($value)) {
@@ -26,10 +29,13 @@ class URLChooserToLinkTransformer implements DataTransformerInterface
         ];
     }
 
+    /**
+     * @return string|null
+     */
     public function reverseTransform($value)
     {
         if (empty($value)) {
-            return;
+            return null;
         }
 
         return $value['link_url'];

--- a/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
+++ b/src/Kunstmaan/NodeBundle/Form/EventListener/URLChooserFormSubscriber.php
@@ -16,6 +16,9 @@ class URLChooserFormSubscriber implements EventSubscriberInterface
 {
     use URLValidator;
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return [

--- a/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
+++ b/src/Kunstmaan/NodeBundle/Form/NodeChoiceType.php
@@ -61,6 +61,9 @@ class NodeChoiceType extends AbstractType
         $resolver->setAllowedTypes('query_builder', ['null', 'callable', 'Doctrine\ORM\QueryBuilder']);
     }
 
+    /**
+     * @return string|null
+     */
     public function getParent()
     {
         return EntityType::class;

--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -170,7 +170,7 @@ class NodeTranslationRepository extends EntityRepository
      * @param string $lang (optional, if not specified all languages will be
      *                     returned)
      *
-     * @return array
+     * @return NodeTranslation[]
      */
     public function getOnlineChildren(Node $parent, $lang = null)
     {
@@ -182,10 +182,9 @@ class NodeTranslationRepository extends EntityRepository
      * Finds all nodetranslations where title is like the given $title parameter
      *
      * @param string $title
-     * @param string $lang  (optional, if not specified all languages will be
-     *                      returned)
+     * @param string $lang  (optional, if not specified all languages will be returned)
      *
-     * @return array
+     * @return NodeTranslation[]
      */
     public function getNodeTranslationsLikeTitle($title, $lang = null)
     {
@@ -297,7 +296,7 @@ class NodeTranslationRepository extends EntityRepository
      * @param Node            $rootNode       Optional Root node of the tree you
      *                                        wish to use
      *
-     * @return array
+     * @return NodeTranslation[]
      */
     public function getAllNodeTranslationsForUrl(
         $urlSlug,
@@ -501,7 +500,7 @@ class NodeTranslationRepository extends EntityRepository
      * @param string $urlSlug The slug
      * @param string $locale  The locale
      *
-     * @return NodeTranslation
+     * @return NodeTranslation|null
      */
     public function getBestMatchForUrl($urlSlug, $locale)
     {
@@ -569,6 +568,8 @@ class NodeTranslationRepository extends EntityRepository
      *
      * It'll only return the latest version. It'll also hide deleted & offline
      * nodes.
+     *
+     * @return NodeTranslation|null
      */
     public function getNodeTranslationByLanguageAndInternalName(
         $language,
@@ -599,6 +600,9 @@ class NodeTranslationRepository extends EntityRepository
         return $qb->getQuery()->getOneOrNullResult();
     }
 
+    /**
+     * @return NodeTranslation[]
+     */
     public function getAllNodeTranslationsByRefEntityName($refEntityName)
     {
         $qb = $this->createQueryBuilder('nt')
@@ -611,6 +615,9 @@ class NodeTranslationRepository extends EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * @return NodeTranslation|null
+     */
     public function getParentNodeTranslation(NodeTranslation $nodeTranslation)
     {
         $parent = $nodeTranslation->getNode()->getParent();

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/Configuration.php
@@ -26,6 +26,9 @@ class Configuration implements ConfigurationInterface
         $this->useElasticSearchVersion6 = $useElasticSearchVersion6;
     }
 
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_node_search');

--- a/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
+++ b/src/Kunstmaan/NodeSearchBundle/DependencyInjection/KunstmaanNodeSearchExtension.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\NodeSearchBundle\DependencyInjection;
 
 use Kunstmaan\NodeSearchBundle\Helper\ElasticSearchUtil;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -189,6 +190,9 @@ class KunstmaanNodeSearchExtension extends Extension implements PrependExtension
         return ElasticSearchUtil::useVersion6($hosts);
     }
 
+    /**
+     * @return ConfigurationInterface|null
+     */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         return new Configuration($this->useElasticSearchV6($container));

--- a/src/Kunstmaan/PagePartBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/PagePartBundle/DependencyInjection/Configuration.php
@@ -9,6 +9,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_page_part');

--- a/src/Kunstmaan/RedirectBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/RedirectBundle/DependencyInjection/Configuration.php
@@ -8,6 +8,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_redirect');

--- a/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
+++ b/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
@@ -69,6 +69,9 @@ class RedirectAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'redirect_form';

--- a/src/Kunstmaan/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/SearchBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_search');

--- a/src/Kunstmaan/SeoBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/SeoBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_seo');

--- a/src/Kunstmaan/SitemapBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/SitemapBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_sitemap');

--- a/src/Kunstmaan/TaggingBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/TaggingBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_tagging');

--- a/src/Kunstmaan/TaggingBundle/Entity/Tag.php
+++ b/src/Kunstmaan/TaggingBundle/Entity/Tag.php
@@ -160,6 +160,9 @@ class Tag extends BaseTag implements Translatable
         return TagAdminType::class;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return $this->getName();

--- a/src/Kunstmaan/TaggingBundle/Form/TagAdminType.php
+++ b/src/Kunstmaan/TaggingBundle/Form/TagAdminType.php
@@ -15,6 +15,9 @@ class TagAdminType extends AbstractType
         ]);
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'tag_admin_form';

--- a/src/Kunstmaan/TaggingBundle/Form/TagsAdminType.php
+++ b/src/Kunstmaan/TaggingBundle/Form/TagsAdminType.php
@@ -47,11 +47,17 @@ class TagsAdminType extends AbstractType
         ];
     }
 
+    /**
+     * @return string|null
+     */
     public function getParent()
     {
         return ChoiceType::class;
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'kunstmaan_taggingbundle_tags';

--- a/src/Kunstmaan/TaggingBundle/Tests/Entity/TagManagerTest.php
+++ b/src/Kunstmaan/TaggingBundle/Tests/Entity/TagManagerTest.php
@@ -24,6 +24,9 @@ use PHPUnit\Framework\TestCase;
 
 class Query extends AbstractQuery
 {
+    /**
+     * @return string
+     */
     public function getSQL()
     {
     }
@@ -32,6 +35,9 @@ class Query extends AbstractQuery
     {
     }
 
+    /**
+     * @return mixed
+     */
     public function getResult($hydrationMode = self::HYDRATE_OBJECT)
     {
         return new ArrayCollection();
@@ -47,11 +53,17 @@ class FakePage extends AbstractPage implements Taggable
         return [];
     }
 
+    /**
+     * @return string
+     */
     public function getTaggableId()
     {
         return 777;
     }
 
+    /**
+     * @return string
+     */
     public function getTaggableType()
     {
         return self::class;

--- a/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ExportTranslationsCommand.php
@@ -50,6 +50,9 @@ class ExportTranslationsCommand extends ContainerAwareCommand
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $domains = $input->getOption('domains');

--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsCommand.php
@@ -86,6 +86,9 @@ class ImportTranslationsCommand extends ContainerAwareCommand
             );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $force = $input->getOption('force');

--- a/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/ImportTranslationsFromFileCommand.php
@@ -49,6 +49,8 @@ final class ImportTranslationsFromFileCommand extends Command
 
     /**
      * @throws LogicException
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Kunstmaan/TranslatorBundle/Command/TranslationCacheCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/TranslationCacheCommand.php
@@ -56,6 +56,9 @@ class TranslationCacheCommand extends ContainerAwareCommand
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption('flush')) {

--- a/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
+++ b/src/Kunstmaan/TranslatorBundle/Command/TranslationFlagCommand.php
@@ -50,6 +50,9 @@ class TranslationFlagCommand extends ContainerAwareCommand
         ;
     }
 
+    /**
+     * @return int
+     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption('reset')) {

--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kuma_translator');

--- a/src/Kunstmaan/TranslatorBundle/Form/TextWithLocaleAdminType.php
+++ b/src/Kunstmaan/TranslatorBundle/Form/TextWithLocaleAdminType.php
@@ -36,6 +36,9 @@ class TextWithLocaleAdminType extends AbstractType
         );
     }
 
+    /**
+     * @return string
+     */
     public function getBlockPrefix()
     {
         return 'text_with_locale';

--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Loader.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Loader.php
@@ -17,6 +17,8 @@ class Loader implements LoaderInterface
 
     /**
      * @{@inheritdoc}
+     *
+     * @return MessageCatalogue
      */
     public function load($resource, $locale, $domain = 'messages')
     {

--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Translator.php
@@ -118,6 +118,9 @@ class Translator extends SymfonyTranslator
         return parent::loadCatalogue($locale);
     }
 
+    /**
+     * @return string
+     */
     public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
     {
         if (!$this->request = $this->container->get('request_stack')->getCurrentRequest()) {

--- a/src/Kunstmaan/TranslatorBundle/Tests/WebTestCase.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/WebTestCase.php
@@ -10,6 +10,7 @@ use Kunstmaan\TranslatorBundle\Tests\Fixtures\TranslationDataFixture;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class WebTestCase extends BaseWebTestCase
 {
@@ -39,6 +40,9 @@ class WebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
+    /**
+     * @return string
+     */
     protected static function getKernelClass()
     {
         require_once __DIR__ . '/app/AppKernel.php';
@@ -46,6 +50,9 @@ class WebTestCase extends BaseWebTestCase
         return 'Kunstmaan\TranslatorBundle\Tests\app\AppKernel';
     }
 
+    /**
+     * @return KernelInterface
+     */
     protected static function createKernel(array $options = [])
     {
         $class = self::getKernelClass();

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/AppKernel.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/AppKernel.php
@@ -15,6 +15,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -47,6 +48,9 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
+    /**
+     * @return BundleInterface[]
+     */
     public function registerBundles()
     {
         if (!file_exists($filename = $this->getProjectDir() . '/' . $this->testCase . '/bundles.php')) {
@@ -56,16 +60,25 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
+    /**
+     * @return string
+     */
     public function getProjectDir()
     {
         return __DIR__;
     }
 
+    /**
+     * @return string
+     */
     public function getCacheDir()
     {
         return sys_get_temp_dir() . '/' . $this->varDir . '/' . $this->testCase . '/cache/' . $this->environment;
     }
 
+    /**
+     * @return string
+     */
     public function getLogDir()
     {
         return sys_get_temp_dir() . '/' . $this->varDir . '/' . $this->testCase . '/logs';
@@ -92,6 +105,9 @@ class AppKernel extends Kernel
         $this->__construct($a[0], $a[1], $a[2], $a[3], $a[4]);
     }
 
+    /**
+     * @return array
+     */
     protected function getKernelParameters()
     {
         $parameters = parent::getKernelParameters();

--- a/src/Kunstmaan/UserManagementBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/UserManagementBundle/DependencyInjection/Configuration.php
@@ -8,6 +8,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_user_management');

--- a/src/Kunstmaan/UserManagementBundle/EventSubscriber/UserDeleteEventSubscriber.php
+++ b/src/Kunstmaan/UserManagementBundle/EventSubscriber/UserDeleteEventSubscriber.php
@@ -17,6 +17,9 @@ class UserDeleteEventSubscriber implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return [

--- a/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
+++ b/src/Kunstmaan/UtilitiesBundle/Command/CipherCommand.php
@@ -51,6 +51,9 @@ class CipherCommand extends ContainerAwareCommand
         $this->setName('kuma:cipher')->setDescription('Cipher utilities commands.');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->cipher) {

--- a/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/UtilitiesBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_utilities');

--- a/src/Kunstmaan/VotingBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/VotingBundle/DependencyInjection/Configuration.php
@@ -7,6 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('kunstmaan_voting');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This PR adds return type declarations where possible (final, private and test methods) and updated phpdoc with return types. This will also prepare our code to add some return type declarations in 6.0 so we can support symfony 6. See https://wouterj.nl/2021/09/symfony-6-native-typing