### PR TITLE
[NodeBundle] Don't rely on MySQL defaults for page title field lengths

### DIFF
--- a/src/Kunstmaan/NodeBundle/Entity/AbstractPage.php
+++ b/src/Kunstmaan/NodeBundle/Entity/AbstractPage.php
@@ -18,15 +18,17 @@ abstract class AbstractPage extends AbstractEntity implements PageInterface
     /**
      * @var string
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="string", length=255)
      * @Assert\NotBlank()
+     * @Assert\Length(max=255)
      */
     protected $title;
 
     /**
      * @var string
      *
-     * @ORM\Column(type="string", nullable=true, name="page_title")
+     * @ORM\Column(type="string", nullable=true, name="page_title", length=255)
+     * @Assert\Length(max=255)
      */
     protected $pageTitle;
 

--- a/src/Kunstmaan/NodeBundle/Form/PageAdminType.php
+++ b/src/Kunstmaan/NodeBundle/Form/PageAdminType.php
@@ -18,11 +18,15 @@ class PageAdminType extends AbstractType
         $builder->add('id', HiddenType::class);
         $builder->add('title', TextType::class, [
             'label' => 'kuma_node.form.page.title.label',
+            'attr' => [
+                'maxlength' => 255,
+            ],
         ]);
         $builder->add('pageTitle', TextType::class, [
             'label' => 'kuma_node.form.page.page_title.label',
             'attr' => [
                 'info_text' => 'kuma_node.form.page.page_title.info_text',
+                'maxlength' => 255,
             ],
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Prevents uncaught exception on saving nodes if more than 255 characters are entered into the `title` or `page_title` fields of `AbstractPage`.