### PR TITLE
[ArticleBundle] Don't set html5 option on date fields when using custom js datepicker

### DIFF
--- a/src/Kunstmaan/ArticleBundle/Form/AbstractArticlePageAdminType.php
+++ b/src/Kunstmaan/ArticleBundle/Form/AbstractArticlePageAdminType.php
@@ -25,6 +25,7 @@ class AbstractArticlePageAdminType extends PageAdminType
                 'date_widget' => 'single_text',
                 'time_widget' => 'single_text',
                 'date_format' => 'dd/MM/yyyy',
+                'html5' => false,
             ]
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The combination of single_widget + html5 will throw an exception on symfony 5