### PR TITLE
[AllBundles] Update adminlist-bundle version constraint to allow only ^5.9

### DIFF
--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -22,6 +22,7 @@
         "friendsofsymfony/user-bundle": "^2.0",
         "guzzlehttp/guzzle": "~6.1",
         "knplabs/knp-menu-bundle": "^3.0",
+        "kunstmaan/adminlist-bundle": "^5.9",
         "kunstmaan/node-bundle": "^5.9|^6.0",
         "kunstmaan/utilities-bundle": "^5.9|^6.0",
         "symfony/swiftmailer-bundle": "^2.3|^3.0",

--- a/src/Kunstmaan/ArticleBundle/composer.json
+++ b/src/Kunstmaan/ArticleBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0",
+        "kunstmaan/adminlist-bundle": "^5.9",
         "kunstmaan/node-bundle": "^5.9|^6.0",
         "kunstmaan/pagepart-bundle": "^5.9|^6.0",
         "pagerfanta/core": "^2.4",

--- a/src/Kunstmaan/LeadGenerationBundle/composer.json
+++ b/src/Kunstmaan/LeadGenerationBundle/composer.json
@@ -21,7 +21,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.2|^8.0",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0"
+        "kunstmaan/adminlist-bundle": "^5.9"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Kunstmaan/MenuBundle/composer.json
+++ b/src/Kunstmaan/MenuBundle/composer.json
@@ -19,7 +19,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^7.2|^8.0",
-    "kunstmaan/adminlist-bundle": "^5.9|^6.0"
+    "kunstmaan/adminlist-bundle": "^5.9"
   },
   "require-dev": {
     "matthiasnoback/symfony-config-test": "^4.0",

--- a/src/Kunstmaan/RedirectBundle/composer.json
+++ b/src/Kunstmaan/RedirectBundle/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0",
+        "kunstmaan/adminlist-bundle": "^5.9",
         "symfony-cmf/routing-bundle": "^2.1"
     },
     "require-dev": {

--- a/src/Kunstmaan/TaggingBundle/composer.json
+++ b/src/Kunstmaan/TaggingBundle/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.2|^8.0",
         "fpn/doctrine-extensions-taggable": "~0.9",
         "kunstmaan/admin-bundle": "^5.9|^6.0",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0",
+        "kunstmaan/adminlist-bundle": "^5.9",
         "kunstmaan/node-bundle": "^5.9|^6.0",
         "kunstmaan/pagepart-bundle": "^5.9|^6.0"
     },

--- a/src/Kunstmaan/TranslatorBundle/composer.json
+++ b/src/Kunstmaan/TranslatorBundle/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.2|^8.0",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0",
+        "kunstmaan/adminlist-bundle": "^5.9",
         "doctrine/migrations": "^1.8|^2.3",
         "box/spout": "^2.5"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

These bundles still use a deprecated controller class so it makes them incompatible with v6