### PR TITLE
[AllBundles] Fix sf5.4 Request::get internal method usages

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
+++ b/src/Kunstmaan/AdminBundle/Helper/FormWidgets/Tabs/TabPane.php
@@ -62,8 +62,8 @@ class TabPane
         $this->slugifier = new Slugifier();
         if ($request->request->get('currenttab')) {
             $this->activeTab = $request->request->get('currenttab');
-        } elseif ($request->get('currenttab')) {
-            $this->activeTab = $request->get('currenttab');
+        } elseif ($request->query->get('currenttab')) {
+            $this->activeTab = $request->query->get('currenttab');
         }
     }
 

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/Tabs/TabPaneTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/Tabs/TabPaneTest.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\AdminBundle\Tests\Helper\FormWidgets\Tabs;
 
-use Doctrine\ORM\EntityManager;
+use Kunstmaan\AdminBundle\Helper\FormWidgets\FormWidget;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\Tab;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\Tabs\TabPane;
 use PHPUnit\Framework\TestCase;
@@ -19,22 +19,18 @@ class TabPaneTest extends TestCase
      */
     public function testTabPane()
     {
-        $request = $this->createMock(Request::class);
-        $request->request = $this->createMock(Request::class);
         $factory = $this->createMock(FormFactory::class);
         $builder = $this->createMock(FormBuilder::class);
         $form = $this->createMock(Form::class);
         $view = $this->createMock(FormView::class);
-        $tab = $this->createMock(Tab::class);
 
-        $request->expects($this->exactly(2))->method('get')->willReturn($tab);
-        $tab->expects($this->any())->method('getExtraParams')->willReturn([1, 2, 3, 4, 5]);
-        $tab->expects($this->any())->method('getTitle')->willReturn('Pass!');
+        $tab = new Tab('properties', new FormWidget());
+
+        $request = new Request([], ['currenttab' => $tab->getTitle()]);
         $form->expects($this->any())->method('createView')->willReturn($view);
         $form->expects($this->any())->method('isValid')->willReturn(true);
         $builder->expects($this->once())->method('getForm')->willReturn($form);
         $factory->expects($this->once())->method('createBuilder')->willReturn($builder);
-        $em = $this->createMock(EntityManager::class);
         $tab2 = clone $tab;
 
         $tabPane = new TabPane('Title', $request, $factory);
@@ -42,27 +38,24 @@ class TabPaneTest extends TestCase
         $tabPane->addTab($tab);
         $tabPane->addTab($tab2, 0);
         $tabPane->buildForm();
-        $tabPane->bindRequest(new Request());
-        $tabPane->persist($em);
+        $tabPane->bindRequest($request);
         $tabPane->removeTab($tab2);
-        $this->assertCount(5, $tabPane->getExtraParams(new Request()));
+
         $this->assertInstanceOf(Form::class, $tabPane->getForm());
         $this->assertInstanceOf(FormView::class, $tabPane->getFormView());
         $this->assertTrue($tabPane->isValid());
-        $this->assertInstanceOf(Tab::class, $tabPane->getActiveTab());
+
+        $this->assertSame('properties', $tabPane->getActiveTab());
         $this->assertNull($tabPane->getTabByPosition(5));
         $this->assertNotNull($tabPane->getTabByPosition(0));
         $this->assertNull($tabPane->getTabByTitle('Fail!'));
-        $this->assertNotNull($tabPane->getTabByTitle('Pass!'));
-        $tabPane->removeTabByTitle('Pass!');
+        $this->assertNotNull($tabPane->getTabByTitle('properties'));
+        $tabPane->removeTabByTitle('properties');
         $tabPane->removeTabByTitle('not here');
         $this->assertEmpty($tabPane->getTabs());
         $tabPane->addTab($tab);
         $tabPane->addTab($tab2, 0);
         $tabPane->removeTabByPosition(0);
         $this->assertCount(1, $tabPane->getTabs());
-
-        $request->request->expects($this->exactly(2))->method('get')->willReturn($tab);
-        new TabPane('Title', $request, $factory);
     }
 }

--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -754,7 +754,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
         $query = $request->query;
         $session = $request->getSession();
 
-        $adminListName = 'listconfig_' . $request->get('_route');
+        $adminListName = 'listconfig_' . $request->attributes->get('_route');
 
         $this->page = $request->query->getInt('page', 1);
         // Allow alphanumeric, _ & . in order by parameter!

--- a/src/Kunstmaan/AdminListBundle/AdminList/FilterBuilder.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/FilterBuilder.php
@@ -89,7 +89,7 @@ class FilterBuilder
 
     public function bindRequest(Request $request)
     {
-        $filterBuilderName = 'filter_' . $request->get('_route');
+        $filterBuilderName = 'filter_' . $request->attributes->get('_route');
 
         $this->currentParameters = $request->query->all();
         if (\count($this->currentParameters) === 0) {

--- a/src/Kunstmaan/AdminListBundle/Traits/ChangeableLimitTrait.php
+++ b/src/Kunstmaan/AdminListBundle/Traits/ChangeableLimitTrait.php
@@ -19,7 +19,7 @@ trait ChangeableLimitTrait
         $query = $request->query;
         $session = $request->getSession();
 
-        $adminListName = 'listconfig_' . $request->get('_route');
+        $adminListName = 'listconfig_' . $request->attributes->get('_route');
 
         $this->page = $request->query->getInt('page', 1);
         $this->limit = $request->query->getInt('limit', $this->getLimitOptions()[0]);

--- a/src/Kunstmaan/ArticleBundle/Twig/ArticleTwigExtension.php
+++ b/src/Kunstmaan/ArticleBundle/Twig/ArticleTwigExtension.php
@@ -67,7 +67,7 @@ final class ArticleTwigExtension extends AbstractExtension
         $tagRepository = $this->em->getRepository($className);
         $context['tags'] = $tagRepository->findBy([], ['name' => 'ASC']);
 
-        $searchTag = $request->get('tag') ? explode(',', $request->get('tag')) : null;
+        $searchTag = $request->query->get('tag') ? explode(',', $request->query->get('tag')) : null;
         if ($searchTag) {
             $context['activeTag'] = true;
             $context['activeTags'] = $searchTag;
@@ -90,7 +90,7 @@ final class ArticleTwigExtension extends AbstractExtension
         $categoryRepository = $this->em->getRepository($className);
         $context['categories'] = $categoryRepository->findBy([], ['name' => 'ASC']);
 
-        $searchCategory = $request->get('category') ? explode(',', $request->get('category')) : null;
+        $searchCategory = $request->query->get('category') ? explode(',', $request->query->get('category')) : null;
         if ($searchCategory) {
             $context['activeCategory'] = true;
             $context['activeCategories'] = $searchCategory;

--- a/src/Kunstmaan/ArticleBundle/ViewDataProvider/ArticlePageViewDataProvider.php
+++ b/src/Kunstmaan/ArticleBundle/ViewDataProvider/ArticlePageViewDataProvider.php
@@ -40,7 +40,7 @@ final class ArticlePageViewDataProvider implements PageViewDataProviderInterface
         $pagerfanta = new Pagerfanta($adapter);
         $pagerfanta->setMaxPerPage(5);
 
-        $pagenumber = $request->get('page');
+        $pagenumber = $request->query->get('page');
         if (!$pagenumber || $pagenumber < 1) {
             $pagenumber = 1;
         }

--- a/src/Kunstmaan/FormBundle/ViewDataProvider/FormPageViewDataProvider.php
+++ b/src/Kunstmaan/FormBundle/ViewDataProvider/FormPageViewDataProvider.php
@@ -35,7 +35,7 @@ final class FormPageViewDataProvider implements PageViewDataProviderInterface
             return;
         }
 
-        $thanksParam = $request->get('thanks');
+        $thanksParam = $request->query->get('thanks');
         $entity = $nodeTranslation->getRef($this->em);
         $renderContext['nodetranslation'] = $nodeTranslation;
         $renderContext['slug'] = $request->attributes->get('url');

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/ViewDataProvider/PageViewDataProvider.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/ViewDataProvider/PageViewDataProvider.php
@@ -45,8 +45,8 @@ $request = $this->requestStack->getMasterRequest();
             return;
         }
 
-        $searchCategory = $request->get('category') ? explode(',', $request->get('category')) : null;
-        $searchTag = $request->get('tag') ? explode(',', $request->get('tag')) : null;
+        $searchCategory = $request->query->get('category') ? explode(',', $request->query->get('category')) : null;
+        $searchTag = $request->query->get('tag') ? explode(',', $request->query->get('tag')) : null;
 
         $pageRepository = $this->em->getRepository({% if isV4 %}{{ entity_class }}Page::class{%else%}'{{ bundle.getName() }}:Pages\{{ entity_class }}Page'{%endif%});
         $result = $pageRepository->getArticles($request->getLocale(), null, null, $searchCategory, $searchTag);

--- a/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/ChooserController.php
@@ -49,9 +49,9 @@ final class ChooserController extends AbstractController
         $session = $request->getSession();
         $folderId = false;
 
-        $type = $request->get('type', self::TYPE_ALL);
-        $cKEditorFuncNum = $request->get('CKEditorFuncNum');
-        $linkChooser = $request->get('linkChooser');
+        $type = $request->query->get('type', self::TYPE_ALL);
+        $cKEditorFuncNum = $request->query->get('CKEditorFuncNum');
+        $linkChooser = $request->query->get('linkChooser');
 
         // Go to the last visited folder
         if ($session->get('last-media-folder')) {
@@ -92,9 +92,9 @@ final class ChooserController extends AbstractController
     {
         $session = $request->getSession();
 
-        $type = $request->get('type');
-        $cKEditorFuncNum = $request->get('CKEditorFuncNum');
-        $linkChooser = $request->get('linkChooser');
+        $type = $request->query->get('type');
+        $cKEditorFuncNum = $request->query->get('CKEditorFuncNum');
+        $linkChooser = $request->query->get('linkChooser');
 
         // Remember the last visited folder in the session
         $session->set('last-media-folder', $folderId);

--- a/src/Kunstmaan/MediaBundle/Controller/FolderController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/FolderController.php
@@ -203,7 +203,7 @@ final class FolderController extends AbstractController
                     $redirect = 'KunstmaanMediaBundle_folder_show';
                 }
 
-                $type = $request->get('type');
+                $type = $request->query->get('type');
 
                 return new RedirectResponse(
                     $this->generateUrl($redirect,
@@ -290,7 +290,7 @@ final class FolderController extends AbstractController
     public function reorderAction(Request $request)
     {
         $folders = [];
-        $nodeIds = $request->get('nodes');
+        $nodeIds = $request->request->get('nodes');
 
         $repository = $this->em->getRepository(Folder::class);
 

--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -429,8 +429,8 @@ final class MediaController extends AbstractController
      */
     public function createModalAction(Request $request, $folderId, $type)
     {
-        $cKEditorFuncNum = $request->get('CKEditorFuncNum');
-        $linkChooser = $request->get('linkChooser');
+        $cKEditorFuncNum = $request->query->get('CKEditorFuncNum');
+        $linkChooser = $request->query->get('linkChooser');
 
         $extraParams = [];
         if (!empty($cKEditorFuncNum)) {

--- a/src/Kunstmaan/MediaBundle/Helper/Menu/MediaMenuAdaptor.php
+++ b/src/Kunstmaan/MediaBundle/Helper/Menu/MediaMenuAdaptor.php
@@ -33,7 +33,7 @@ class MediaMenuAdaptor implements MenuAdaptorInterface
         if (\is_null($parent)) {
             // Add menu item for root gallery
             $rootFolders = $this->repo->getRootNodes();
-            $currentId = $request->get('folderId');
+            $currentId = $request->attributes->get('folderId');
             $currentFolder = null;
             if (isset($currentId)) {
                 /* @var Folder $currentFolder */

--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -186,7 +186,7 @@ final class NodeAdminController extends AbstractController
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
-        $originalLanguage = $request->get('originallanguage');
+        $originalLanguage = $request->query->get('originallanguage');
         $otherLanguageNodeTranslation = $node->getNodeTranslation($originalLanguage, true);
         $otherLanguageNodeNodeVersion = $otherLanguageNodeTranslation->getPublicNodeVersion();
         $otherLanguagePage = $otherLanguageNodeNodeVersion->getRef($this->em);
@@ -241,7 +241,7 @@ final class NodeAdminController extends AbstractController
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
-        $otherLanguageNodeTranslation = $this->em->getRepository(NodeTranslation::class)->find($request->get('source'));
+        $otherLanguageNodeTranslation = $this->em->getRepository(NodeTranslation::class)->find($request->request->get('source'));
         $otherLanguageNodeNodeVersion = $otherLanguageNodeTranslation->getPublicNodeVersion();
         $otherLanguagePage = $otherLanguageNodeNodeVersion->getRef($this->em);
         $myLanguagePage = $this->container->get('kunstmaan_admin.clone.helper')
@@ -493,7 +493,7 @@ final class NodeAdminController extends AbstractController
             ->deepCloneAndSave($originalRef);
 
         //set the title
-        $title = $request->get('title');
+        $title = $request->request->get('title');
         if (\is_string($title) && !empty($title)) {
             $newPage->setTitle($title);
         } else {
@@ -554,7 +554,7 @@ final class NodeAdminController extends AbstractController
         }
 
         $this->init($request);
-        $title = $request->get('title', null);
+        $title = $request->request->get('title');
 
         $nodeNewPage = $this->pageCloningHelper->duplicateWithChildren($id, $this->locale, $this->user, $title);
 
@@ -587,7 +587,7 @@ final class NodeAdminController extends AbstractController
 
         $this->denyAccessUnlessGranted(PermissionMap::PERMISSION_EDIT, $node);
 
-        $version = $request->get('version');
+        $version = $request->query->get('version');
 
         if (empty($version) || !is_numeric($version)) {
             throw new InvalidArgumentException('No version was specified');
@@ -777,8 +777,8 @@ final class NodeAdminController extends AbstractController
     {
         $this->init($request);
         $nodes = [];
-        $nodeIds = $request->get('nodes');
-        $changeParents = $request->get('parent');
+        $nodeIds = $request->request->get('nodes');
+        $changeParents = $request->request->get('parent');
 
         foreach ($nodeIds as $id) {
             /* @var Node $node */
@@ -873,7 +873,7 @@ final class NodeAdminController extends AbstractController
         /* @var HasNodeInterface $page */
         $page = null;
         $draft = ($subaction == 'draft');
-        $saveAsDraft = $request->get('saveasdraft');
+        $saveAsDraft = $request->request->get('saveasdraft');
         if ((!$draft && !empty($saveAsDraft)) || ($draft && \is_null($draftNodeVersion))) {
             // Create a new draft version
             $draft = true;
@@ -1233,7 +1233,7 @@ final class NodeAdminController extends AbstractController
         /* @var HasNodeInterface $newPage */
         $newPage = new $type();
 
-        $title = $request->get('title');
+        $title = $request->request->get('title');
         if (\is_string($title) && !empty($title)) {
             $newPage->setTitle($title);
         } else {
@@ -1253,7 +1253,7 @@ final class NodeAdminController extends AbstractController
      */
     private function validatePageType($request)
     {
-        $type = $request->get('type');
+        $type = $request->request->get('type');
 
         if (empty($type)) {
             throw new InvalidArgumentException('Please specify a type of page you want to create');

--- a/src/Kunstmaan/NodeBundle/Controller/SlugController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/SlugController.php
@@ -144,7 +144,7 @@ final class SlugController extends AbstractController
         /* @var HasNodeInterface $entity */
         $entity = null;
         if ($preview) {
-            $version = $request->get('version');
+            $version = $request->query->get('version');
             if (!empty($version) && is_numeric($version)) {
                 $nodeVersion = $em->getRepository(NodeVersion::class)->find($version);
                 if (!\is_null($nodeVersion)) {

--- a/src/Kunstmaan/NodeBundle/Controller/UrlReplaceController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/UrlReplaceController.php
@@ -28,7 +28,7 @@ final class UrlReplaceController
     {
         $response = new JsonResponse();
 
-        $response->setData(['text' => $this->urlHelper->replaceUrl($request->get('text'))]);
+        $response->setData(['text' => $this->urlHelper->replaceUrl($request->query->get('text'))]);
 
         return $response;
     }

--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -101,7 +101,7 @@ final class WidgetsController extends AbstractController
 
         if (\array_key_exists('KunstmaanMediaBundle', $allBundles)) {
             $params = ['linkChooser' => 1];
-            $cKEditorFuncNum = $request->get('CKEditorFuncNum');
+            $cKEditorFuncNum = $request->query->get('CKEditorFuncNum');
             if (!empty($cKEditorFuncNum)) {
                 $params['CKEditorFuncNum'] = $cKEditorFuncNum;
             }

--- a/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
+++ b/src/Kunstmaan/NodeBundle/EventListener/RenderContextListener.php
@@ -40,8 +40,8 @@ class RenderContextListener
             $nodeMenu = $request->attributes->get('_nodeMenu');
             $parameters = $request->attributes->get('_renderContext');
 
-            if ($request->get('preview') === true) {
-                $version = $request->get('version');
+            if ($request->attributes->get('preview') === true) {
+                $version = $request->query->get('version');
                 if (!empty($version) && is_numeric($version)) {
                     $nodeVersion = $this->em->getRepository(NodeVersion::class)->find($version);
                     if (!\is_null($nodeVersion)) {

--- a/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeAdminPublisher.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeAdminPublisher.php
@@ -273,9 +273,9 @@ class NodeAdminPublisher
         /** @var Session $session */
         $session = $request->getSession();
 
-        if ($request->request->has('publish_later') && $request->get('pub_date')) {
+        if ($request->request->has('publish_later') && $request->request->get('pub_date')) {
             $date = new \DateTime(
-                $request->get('pub_date') . ' ' . $request->get('pub_time')
+                $request->request->get('pub_date') . ' ' . $request->request->get('pub_time')
             );
             $this->publishLater($nodeTranslation, $date);
             $session->getFlashBag()->add(
@@ -298,8 +298,8 @@ class NodeAdminPublisher
         /** @var Session $session */
         $session = $request->getSession();
 
-        if ($request->request->has('unpublish_later') && $request->get('unpub_date')) {
-            $date = new \DateTime($request->get('unpub_date') . ' ' . $request->get('unpub_time'));
+        if ($request->request->has('unpublish_later') && $request->request->get('unpub_date')) {
+            $date = new \DateTime($request->request->get('unpub_date') . ' ' . $request->request->get('unpub_time'));
             $this->unPublishLater($nodeTranslation, $date);
             $session->getFlashBag()->add(
                 FlashTypes::SUCCESS,

--- a/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
+++ b/src/Kunstmaan/PagePartBundle/Controller/PagePartAdminController.php
@@ -42,10 +42,10 @@ final class PagePartAdminController extends AbstractController
      */
     public function newPagePartAction(Request $request)
     {
-        $pageId = $request->get('pageid');
-        $pageClassName = $request->get('pageclassname');
-        $context = $request->get('context');
-        $pagePartClass = $request->get('type');
+        $pageId = $request->query->get('pageid');
+        $pageClassName = $request->query->get('pageclassname');
+        $context = $request->query->get('context');
+        $pagePartClass = $request->query->get('type');
 
         /** @var HasPagePartsInterface $page */
         $page = $this->em->getRepository($pageClassName)->find($pageId);

--- a/src/Kunstmaan/PagePartBundle/Helper/FormWidgets/PageTemplateWidget.php
+++ b/src/Kunstmaan/PagePartBundle/Helper/FormWidgets/PageTemplateWidget.php
@@ -160,7 +160,7 @@ class PageTemplateWidget extends FormWidget
 
     public function bindRequest(Request $request)
     {
-        $configurationname = $request->get('pagetemplate_template');
+        $configurationname = $request->request->get('pagetemplate_template');
         $this->pageTemplateConfiguration->setPageTemplate($configurationname);
         foreach ($this->widgets as $widget) {
             $widget->bindRequest($request);

--- a/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
+++ b/src/Kunstmaan/PagePartBundle/PagePartAdmin/PagePartAdmin.php
@@ -155,7 +155,7 @@ class PagePartAdmin
         $doFlush = false;
         foreach ($this->pagePartRefs as $pagePartRef) {
             // Remove pageparts
-            if ('true' == $request->get($pagePartRef->getId() . '_deleted')) {
+            if ('true' == $request->request->get($pagePartRef->getId() . '_deleted')) {
                 $pagePart = $this->pageParts[$pagePartRef->getId()];
                 $this->em->remove($pagePart);
                 $this->em->remove($pagePartRef);
@@ -187,17 +187,17 @@ class PagePartAdmin
 
         // Create the objects for the new pageparts
         $this->newPageParts = [];
-        $newRefIds = $request->get($this->context . '_new');
+        $newRefIds = $request->request->get($this->context . '_new');
 
         if (\is_array($newRefIds)) {
             foreach ($newRefIds as $newId) {
-                $type = $request->get($this->context . '_type_' . $newId);
+                $type = $request->request->get($this->context . '_type_' . $newId);
                 $this->newPageParts[$newId] = new $type();
             }
         }
 
         // Sort pageparts again
-        $sequences = $request->get($this->context . '_sequence');
+        $sequences = $request->request->get($this->context . '_sequence');
         if (!\is_null($sequences)) {
             $tempPageparts = $this->pageParts;
             $this->pageParts = [];
@@ -242,7 +242,7 @@ class PagePartAdmin
         $ppRefRepo = $this->em->getRepository(PagePartRef::class);
 
         // Add new pageparts on the correct position + Re-order and save pageparts if needed
-        $sequences = $request->get($this->context . '_sequence', []);
+        $sequences = $request->request->get($this->context . '_sequence', []);
         $sequencescount = \count($sequences);
         for ($i = 0; $i < $sequencescount; ++$i) {
             $pagePartRefId = $sequences[$i];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Removed usages of the internal `Request::get` method, see https://symfony.com/blog/new-in-symfony-5-4-controller-changes#deprecated-the-request-get-method