### PR TITLE
[MediaBundle] Fix for deleting media

### DIFF
--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -26,10 +26,15 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
     private $mediaManager;
 
     /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
      * @param EntityManagerInterface|null $em
      * @param MediaManager|null           $mediaManager
      */
-    public function __construct(/* EntityManagerInterface */ $em = null, /* MediaManager */ $mediaManager = null)
+    public function __construct(/* EntityManagerInterface */ $em = null, /* MediaManager */ $mediaManager = null, $slugifier = null)
     {
         parent::__construct();
 
@@ -43,6 +48,7 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
 
         $this->em = $em;
         $this->mediaManager = $mediaManager;
+        $this->slugifier = $slugifier;
     }
 
     protected function configure()
@@ -70,6 +76,10 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
             $this->mediaManager = $this->getContainer()->get('kunstmaan_media.media_manager');
         }
 
+        if (null === $this->slugifier) {
+            $this->slugifier = $this->getContainer()->get('kunstmaan_utilities.slugifier');
+        }
+
         $output->writeln('Renaming soft-deleted media...');
 
         $original = $input->getOption('original');
@@ -85,6 +95,11 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
                 if ($media->isDeleted() && $media->getLocation() === 'local' && $handler instanceof FileHandler) {
                     $oldFileUrl = $media->getUrl();
                     $newFileName = ($original ? $media->getOriginalFilename() : uniqid() . '.' . pathinfo($oldFileUrl, PATHINFO_EXTENSION));
+                    $parts = pathinfo($newFileName);
+                    $newFileName = $this->slugifier->slugify($parts['filename']);
+                    if (\array_key_exists('extension', $parts)) {
+                        $newFileName .= '.'.strtolower($parts['extension']);
+                    }
                     $newFileUrl = \dirname($oldFileUrl) . '/' . $newFileName;
                     $fileRenameQueue[] = [$oldFileUrl, $newFileUrl, $handler];
                     $media->setUrl($newFileUrl);

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -26,10 +26,15 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
     private $mediaManager;
 
     /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
      * @param EntityManagerInterface|null $em
      * @param MediaManager|null           $mediaManager
      */
-    public function __construct(/* EntityManagerInterface */ $em = null, /* MediaManager */ $mediaManager = null)
+    public function __construct(/* EntityManagerInterface */ $em = null, /* MediaManager */ $mediaManager = null, $slugifier = null)
     {
         parent::__construct();
 
@@ -43,6 +48,7 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
 
         $this->em = $em;
         $this->mediaManager = $mediaManager;
+        $this->slugifier = $slugifier;
     }
 
     protected function configure()
@@ -70,6 +76,10 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
             $this->mediaManager = $this->getContainer()->get('kunstmaan_media.media_manager');
         }
 
+        if (null === $this->slugifier) {
+            $this->slugifier = $this->getContainer()->get('kunstmaan_utilities.slugifier');
+        }
+
         $output->writeln('Renaming soft-deleted media...');
 
         $original = $input->getOption('original');
@@ -85,6 +95,11 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
                 if ($media->isDeleted() && $media->getLocation() === 'local' && $handler instanceof FileHandler) {
                     $oldFileUrl = $media->getUrl();
                     $newFileName = ($original ? $media->getOriginalFilename() : uniqid() . '.' . pathinfo($oldFileUrl, PATHINFO_EXTENSION));
+                    $parts = pathinfo($newFileName);
+                    $newFileName = $this->slugifier->slugify($parts['filename']);
+                    if (\array_key_exists('extension', $parts)) {
+                        $newFileName .= '.'.strtolower($parts['extension']);
+                    }
                     $newFileUrl = \dirname($oldFileUrl) . '/' . $newFileName;
                     $fileRenameQueue[] = array($oldFileUrl, $newFileUrl, $handler);
                     $media->setUrl($newFileUrl);

--- a/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
+++ b/src/Kunstmaan/MediaBundle/Command/RenameSoftDeletedCommand.php
@@ -83,7 +83,7 @@ class RenameSoftDeletedCommand extends ContainerAwareCommand
         $output->writeln('Renaming soft-deleted media...');
 
         $original = $input->getOption('original');
-        $medias = $this->em->getRepository('KunstmaanMediaBundle:Media')->findAll();
+        $medias = $this->em->getRepository('KunstmaanMediaBundle:Media')->findAllDeleted();
         $updates = 0;
         $fileRenameQueue = [];
 

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -198,7 +198,6 @@ class FileHandler extends AbstractMediaHandler
         if ($adapter->exists($fileKey)) {
             $adapter->delete($fileKey);
         }
-
         // Remove the files containing folder if there's nothing left
         $folderPath = $this->getFileFolderPath($media);
         if ($adapter->exists($folderPath) && $adapter->isDirectory($folderPath) && !empty($folderPath)) {

--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -214,7 +214,6 @@ class FileHandler extends AbstractMediaHandler
         if ($adapter->exists($fileKey)) {
             $adapter->delete($fileKey);
         }
-
         // Remove the files containing folder if there's nothing left
         $folderPath = $this->getFileFolderPath($media);
         if ($adapter->exists($folderPath) && $adapter->isDirectory($folderPath) && !empty($folderPath)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 


This pull request will fix 2 bugs in the MediaBundle.

1. When using the command `php bin/console kuma:media:clean-deleted-media --force` to delete the files by the original filename, it will skip the files from the filesystem that have been renamed due to strange characters in the filename. Using the command `php bin/console kuma:media:rename-soft-deleted -o` will update the filename back to the original filename. However, it doesn't use the same method as when an user uploads a file so this command will not update the filename correctly.
This fix will add the slugifier to the command so it will pass the same method when renaming the filename.

2. The command also expects the directory to be deleted. however, it uses a directory name to check if a file exists, so it fail on the check so it doesn't delete the directory.