### PR TITLE
[DashboardBundle] Fix ConfigHelper that requires kuma_analytics_confi…

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
+++ b/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
@@ -40,6 +40,11 @@ class ConfigHelper
      */
     public function init($configId = false)
     {
+        // check if table exists before moving on
+        if (!$this->assertTableExists()) {
+            return;
+        }
+
         // if token is already saved in the database
         if ($this->getToken($configId) && '' !== $this->getToken($configId)) {
             $this
@@ -54,6 +59,16 @@ class ConfigHelper
             $this->getPropertyId($configId);
             $this->getProfileId($configId);
         }
+    }
+
+    /**
+     * Check if table exists
+     */
+    private function assertTableExists(): bool
+    {
+        $tableName = $this->em->getClassMetadata(AnalyticsConfig::class)->getTableName();
+
+        return $this->em->getConnection()->getSchemaManager()->tablesExist($tableName);
     }
 
     /* =============================== TOKEN =============================== */

--- a/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
+++ b/src/Kunstmaan/DashboardBundle/Helper/Google/Analytics/ConfigHelper.php
@@ -66,6 +66,10 @@ class ConfigHelper
      */
     private function assertTableExists(): bool
     {
+        if (is_string($this->token)) {
+            return true;
+        }
+
         $tableName = $this->em->getClassMetadata(AnalyticsConfig::class)->getTableName();
 
         return $this->em->getConnection()->getSchemaManager()->tablesExist($tableName);


### PR DESCRIPTION
Fix ConfigHelper that requires kuma_analytics_config table to be present on constuct.

| Q      | A |
| ----------- | ----------- |
| Bug fix?      | Yes       |
| New feature?   | No        |
| BC breaks?   | No        |
| Deprecations?   | No        |
| Deprecations?   | No        |
| Fixed tickets   | #3044         |

Note:
It's not considered good practice to call `init` methods in `__construct` methods.
This PR does not fix the underlying problem and introduces a new query every time this service is used to check if the required table exists if the token is not set in `$token`.
A better solution would be to rework the usage of `\Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper` to remove the `init` method from the constructor and enforce the `init` call wherever the service is used. This however would cause BC breaks.
