### PR TITLE
[NodeBundle] Improve performance of NodeMenu class

### DIFF
--- a/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeMenu.php
@@ -240,32 +240,33 @@ class NodeMenu
      */
     public function getBreadCrumb()
     {
-        $this->init();
-        if (!\is_array($this->breadCrumb)) {
-            $this->breadCrumb = [];
+        if (\is_array($this->breadCrumb)) {
+            return $this->breadCrumb;
+        }
 
-            /* @var NodeRepository $repo */
-            $repo = $this->em->getRepository(Node::class);
+        $this->breadCrumb = [];
 
-            // Generate breadcrumb MenuItems - fetch *all* languages so you can link translations if needed
-            $parentNodes = $repo->getAllParents($this->currentNode);
-            $parentNodeMenuItem = null;
-            /* @var Node $parentNode */
-            foreach ($parentNodes as $parentNode) {
-                $nodeTranslation = $parentNode->getNodeTranslation(
-                    $this->locale,
-                    $this->includeOffline
+        /* @var NodeRepository $repo */
+        $repo = $this->em->getRepository(Node::class);
+
+        // Generate breadcrumb MenuItems - fetch *all* languages so you can link translations if needed
+        $parentNodes = $repo->getAllParents($this->currentNode);
+        $parentNodeMenuItem = null;
+        /* @var Node $parentNode */
+        foreach ($parentNodes as $parentNode) {
+            $nodeTranslation = $parentNode->getNodeTranslation(
+                $this->locale,
+                $this->includeOffline
+            );
+            if (!\is_null($nodeTranslation)) {
+                $nodeMenuItem = new NodeMenuItem(
+                    $parentNode,
+                    $nodeTranslation,
+                    $parentNodeMenuItem,
+                    $this
                 );
-                if (!\is_null($nodeTranslation)) {
-                    $nodeMenuItem = new NodeMenuItem(
-                        $parentNode,
-                        $nodeTranslation,
-                        $parentNodeMenuItem,
-                        $this
-                    );
-                    $this->breadCrumb[] = $nodeMenuItem;
-                    $parentNodeMenuItem = $nodeMenuItem;
-                }
+                $this->breadCrumb[] = $nodeMenuItem;
+                $parentNodeMenuItem = $nodeMenuItem;
             }
         }
 
@@ -277,7 +278,6 @@ class NodeMenu
      */
     public function getCurrent()
     {
-        $this->init();
         $breadCrumb = $this->getBreadCrumb();
         if (\count($breadCrumb) > 0) {
             return $breadCrumb[\count($breadCrumb) - 1];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Don't call the `init()` method when it's not necessary, the `getBreadCrumb` method and other methods depending on this don't need the values from the `init()`. _Diff best viewed with ignoring whitespace changes_

On large websites this gives a huge improvement

![image](https://user-images.githubusercontent.com/1374857/148777875-06cc9e71-a85a-407b-8d1c-7d0cf7f1dd76.png)
