### PR TITLE
[AllBundles] Remove unused incenteev/composer-parameter-handler dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
         "doctrine/doctrine-bundle": "^1.12.3|^2.0.3",
         "symfony/swiftmailer-bundle": "^3.1.1",
         "sensio/framework-extra-bundle": "^5.0",
-        "incenteev/composer-parameter-handler": "^2.0",
 
         "knplabs/knp-menu-bundle": "^3.0",
         "guzzlehttp/guzzle": "^6.1|^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 