### PR TITLE
[NodeBundle] Add `get_node_translation_by_internal_name` twig helper

### DIFF
--- a/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
+++ b/src/Kunstmaan/NodeBundle/Twig/NodeTwigExtension.php
@@ -70,6 +70,7 @@ final class NodeTwigExtension extends AbstractExtension
                 'get_node_by_internal_name',
                 [$this, 'getNodeByInternalName']
             ),
+            new TwigFunction('get_node_translation_by_internal_name', [$this, 'getNodeTranslationByInternalName']),
             new TwigFunction(
                 'get_url_by_internal_name',
                 [$this, 'getUrlByInternalName']
@@ -159,6 +160,11 @@ final class NodeTwigExtension extends AbstractExtension
         }
 
         return null;
+    }
+
+    public function getNodeTranslationByInternalName(string $internalName, string $locale): ?NodeTranslation
+    {
+        return $this->em->getRepository(NodeTranslation::class)->getNodeTranslationByLanguageAndInternalName($locale, $internalName);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Improve the DX to make it easier to get a node translation in twig.

Before:
```twig
{% set node = get_node_by_internal_name('internal_name', app.request.locale) %}
{% set nodeTranslation = null %}
{% if node is not null %}
    {% set nodeTranslation = node.getNodeTranslation(app.request.locale) %}
{% endif %}
```

After:
```twig
{% set nodeTranslation = get_node_translation_by_internal_name('internal_name', app.request.locale) %}
```
