### PR TITLE
[Dashboardbundle] Make ConfigHelper service lazy to avoid constructor queries

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/DashboardBundle/Resources/config/services.yml
@@ -41,6 +41,8 @@ services:
         class: 'Kunstmaan\DashboardBundle\Helper\Google\Analytics\ConfigHelper'
         arguments: ['@kunstmaan_dashboard.helper.google.analytics.service', '@doctrine.orm.entity_manager']
         public: true
+        # This is needed to avoid db queries in the service constructor (init()). Can be removed after refactor.
+        lazy: true
 
     # query helper
     kunstmaan_dashboard.helper.google.analytics.query:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #3044 closes #3045 

This class needs refactoring to move the init function from the constructor, this PR adds a workaround so this issue can already be avoided and refactored in the future.