### PR TITLE
[TranslatorBundle] Remove leftover concat function on count field

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -40,7 +40,7 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
     {
         parent::__construct($connection);
         $this->locales = $locales;
-        $this->setCountField('CONCAT(b.translation_id)');
+        $this->setCountField('b.translation_id');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 