### PR TITLE
[MultidomainBundle] Fix issues with empty host in multidomain config

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/AdminBundle/Helper/DomainConfiguration.php
@@ -177,6 +177,8 @@ class DomainConfiguration implements DomainConfigurationInterface
 
     /**
      * @param string|null $host
+     *
+     * @return string|null
      */
     public function getHostBaseUrl($host = null)
     {

--- a/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/DomainConfiguration.php
@@ -327,11 +327,15 @@ class DomainConfiguration extends BaseDomainConfiguration
     /**
      * @param string|null $host
      *
-     * @return string
+     * @return string|null
      */
     public function getHostBaseUrl($host = null)
     {
         $config = $this->getFullHost($host);
+
+        if (!is_array($config)) {
+            return null;
+        }
 
         return sprintf('%s://%s', $config['protocol'], $config['host']);
     }

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Helper/DomainConfigurationTest.php
@@ -185,6 +185,18 @@ class DomainConfigurationTest extends TestCase
         $this->assertEquals('http://multilangdomain.tld', $object->getHostBaseUrl('multilangdomain.tld'));
     }
 
+    public function testGetHostBaseUrlWithEmptyRequestUrl()
+    {
+        $object = $this->getDomainConfiguration(Request::create(''));
+        $this->assertNull($object->getHostBaseUrl());
+    }
+
+    public function testGetHostBaseUrlWithUnkownHost()
+    {
+        $object = $this->getDomainConfiguration(Request::create('unkowndomain.tld'));
+        $this->assertNull($object->getHostBaseUrl());
+    }
+
     public function testGetFullHost()
     {
         $request = $this->getSingleLanguageRequest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This issue occurs when "resolving" internal urls without a host part in a multidomain setup (eg. [NT81] but [xxx:NT81] is expected) in the CLI where there is no request context.