### PR TITLE
[AdminBundle] Don't trigger deprecation on autoload to ease deprecation logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,5 +131,10 @@
         "branch-alias": {
             "dev-6.x": "6.1-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     }
 }

--- a/src/Kunstmaan/AdminBundle/Form/ColorType.php
+++ b/src/Kunstmaan/AdminBundle/Form/ColorType.php
@@ -6,8 +6,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-trigger_deprecation('kunstmaan/admin-bundle', '6.2', 'The "%s" class is deprecated and will be removed in 7.0. Use "%s" instead.', ColorType::class, \Symfony\Component\Form\Extension\Core\Type\ColorType::class);
-
 /**
  * @deprecated since KunstmaanAdminBundle 6.2 and will be removed in KunstmaanAdminBundle 7.0. Use "Symfony\Component\Form\Extension\Core\Type\ColorType" instead.
  */

--- a/src/Kunstmaan/AdminBundle/Form/RangeType.php
+++ b/src/Kunstmaan/AdminBundle/Form/RangeType.php
@@ -11,8 +11,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-trigger_deprecation('kunstmaan/admin-bundle', '6.2', 'The "%s" class is deprecated and will be removed in 7.0. Use "%s" instead.', RangeType::class, \Symfony\Component\Form\Extension\Core\Type\RangeType::class);
-
 /**
  * HTML5 range type field
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Follow up of #3061 to ease triggering deprecations, otherwise these deprecations would show on each pageload