### PR TITLE
[AdminListBundle] Use label for item action when icon is null

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/widget.html.twig
@@ -115,12 +115,16 @@
                                         <span class="table__actions__item disabled" title="{{ itemAction.getLabelFor(item) | trans }}">
                                             {% if itemAction.getIconFor(item) is not null %}
                                                 <i class="fa fa-{{ itemAction.getIconFor(item) }}"></i>
+                                            {% else %}
+                                                {{ itemAction.getLabelFor(item) }}
                                             {% endif %}
                                         </span>
                                     {% else %}
                                         <a href="{{ path(url["path"], url[("params")]) }}" class="link--text table__actions__item" title="{{ itemAction.getLabelFor(item) | trans }}">
                                             {% if itemAction.getIconFor(item) is not null %}
                                                 <i class="fa fa-{{ itemAction.getIconFor(item) }}"></i>
+                                            {% else %}
+                                                {{ itemAction.getLabelFor(item) }}
                                             {% endif %}
                                         </a>
                                     {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When the item action icon is not set the action won't show in the adminlist, so fallback to the label so we can atleast show the item