### PR TITLE
[NodeBundle] Fix missing route bc-break in url chooser search

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/WidgetsController.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\StructureNode;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -78,6 +79,35 @@ final class WidgetsController extends Controller
         }
 
         $results = $this->nodesToArray($locale, $rootItems, $depth);
+
+        return new JsonResponse($results);
+    }
+
+    /**
+     * Search action in url chooser popup
+     *
+     * @Route("/select-nodes-lazy_search", name="KunstmaanNodeBundle_nodes_lazy_search")
+     */
+    public function selectNodesLazySearch(Request $request): JsonResponse
+    {
+        $locale = $request->getLocale();
+        $search = $request->query->get('str');
+
+        $results = [];
+        if ($search) {
+            $em = $this->getDoctrine()->getManager();
+            $nts = $em->getRepository(NodeTranslation::class)->getNodeTranslationsLikeTitle($search, $locale);
+            foreach ($nts as $nt) {
+                $node = $nt->getNode();
+                $results[] = $node->getId();
+                while ($node->getParent()) {
+                    $node = $node->getParent();
+                    $results[] = $node->getId();
+                }
+            }
+            $results = array_unique($results);
+            sort($results);
+        }
 
         return new JsonResponse($results);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixes #3126. This action was incorrectly deprecated and removed in 6.0