### PR TITLE
[GeneratorBundle] Remove unnecessary `getBlockPrefix` method and improve return types

### DIFF
--- a/src/Kunstmaan/CookieBundle/Resources/skeleton/legal/Entity/Pages/LegalPage.php
+++ b/src/Kunstmaan/CookieBundle/Resources/skeleton/legal/Entity/Pages/LegalPage.php
@@ -15,28 +15,17 @@ use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
  */
 class LegalPage extends AbstractPage implements HasPageTemplateInterface, CustomViewDataProviderInterface
 {
-    /**
-     * Returns the default backend form type for this page
-     *
-     * @return string
-     */
-    public function getDefaultAdminType()
+    public function getDefaultAdminType(): string
     {
         return LegalPageAdminType::class;
     }
 
-    /**
-     * @return array
-     */
-    public function getPossibleChildTypes()
+    public function getPossibleChildTypes(): array
     {
         return [];
     }
 
-    /**
-     * @return string[]
-     */
-    public function getPagePartAdminConfigurations()
+    public function getPagePartAdminConfigurations(): array
     {
         return [
             '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}legal_header',
@@ -44,18 +33,12 @@ class LegalPage extends AbstractPage implements HasPageTemplateInterface, Custom
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPageTemplates()
+    public function getPageTemplates(): array
     {
         return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}legalpage'];
     }
 
-    /**
-     * @return string
-     */
-    public function getDefaultView()
+    public function getDefaultView(): string
     {
         return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}Pages/LegalPage{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/CategoryAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/CategoryAdminType.php
@@ -6,8 +6,4 @@ use Kunstmaan\ArticleBundle\Form\AbstractCategoryAdminType;
 
 class {{ entity_class }}CategoryAdminType extends AbstractCategoryAdminType
 {
-    public function getBlockPrefix(): string
-{
-    return '{{ entity_class|lower }}_category_form';
-}
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/TagAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Form/TagAdminType.php
@@ -6,8 +6,4 @@ use Kunstmaan\ArticleBundle\Form\AbstractTagAdminType;
 
 class {{ entity_class }}TagAdminType extends AbstractTagAdminType
 {
-    public function getBlockPrefix(): string
-    {
-        return '{{ entity_class|lower }}_tag_form';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/FormPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/FormPage.php
@@ -9,25 +9,17 @@ use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\FormPageAdminType;
 
 /**
- * FormPage
- *
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}form_pages")
  */
 class FormPage extends AbstractFormPage implements HasPageTemplateInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultAdminType()
+    public function getDefaultAdminType(): string
     {
         return FormPageAdminType::class;
     }
 
-    /**
-     * @return array
-     */
-    public function getPossibleChildTypes()
+    public function getPossibleChildTypes(): array
     {
         return [
             [
@@ -41,26 +33,17 @@ class FormPage extends AbstractFormPage implements HasPageTemplateInterface
         ];
     }
 
-    /**
-     * @return string[]
-     */
-    public function getPagePartAdminConfigurations()
+    public function getPagePartAdminConfigurations(): array
     {
         return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}form'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPageTemplates()
+    public function getPageTemplates(): array
     {
         return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}formpage'];
     }
 
-    /**
-     * @return string
-     */
-    public function getDefaultView()
+    public function getDefaultView(): string
     {
         return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}Pages/FormPage{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/HomePage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/HomePage.php
@@ -11,83 +11,63 @@ use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\HomePageAdminType;
 
 /**
- * HomePage
- *
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}home_pages")
  */
 class HomePage extends AbstractPage implements HasPageTemplateInterface, SearchTypeInterface, HomePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultAdminType()
+    public function getDefaultAdminType(): string
     {
         return HomePageAdminType::class;
     }
 
-    /**
-     * @return array
-     */
-    public function getPossibleChildTypes()
+    public function getPossibleChildTypes(): array
     {
-        return array(
-            array(
+        return [
+            [
                 'name'  => 'ContentPage',
                 'class' => '{{ namespace }}\Entity\Pages\ContentPage'
-            ),
+            ],
 {% if demosite %}
-            array(
+            [
                 'name'  => 'FormPage',
                 'class' => '{{ namespace }}\Entity\Pages\FormPage'
-            ),
+            ],
 {% endif %}
-            array(
+            [
                 'name'  => 'BehatTestPage',
                 'class' => '{{ namespace }}\Entity\Pages\BehatTestPage'
-            )
-        );
+            ]
+        ];
     }
 
-    /**
-     * @return string[]
-     */
-    public function getPagePartAdminConfigurations()
+    public function getPagePartAdminConfigurations(): array
     {
 {% if demosite %}
-	    return array(
+	    return [
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}header',
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}section1',
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}section2',
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}section3',
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}section4',
 		'{% if not isV4 %}{{ bundle.getName() }}:{%endif%}section5'
-	    );
+        ];
 {% else %}
-	    return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}main');
+	    return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}main'];
 {% endif %}
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPageTemplates()
+    public function getPageTemplates(): array
     {
-    	return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}homepage');
+    	return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}homepage'];
     }
 
-    /**
-     * @return string
-     */
-    public function getDefaultView()
+    public function getDefaultView(): string
     {
         return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}Pages/HomePage{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSearchType()
+    public function getSearchType(): string
     {
 	    return 'Home';
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/SearchPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/SearchPage.php
@@ -15,27 +15,18 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class SearchPage extends AbstractSearchPage implements HasPageTemplateInterface
 {
-    /**
-     * return string
-     */
-    public function getDefaultView()
+    public function getDefaultView(): string
     {
         return '{% if not isV4 %}{{ bundle.getName() }}:{%endif%}Pages/SearchPage{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }
 
-    /**
-     * @return string[]
-     */
-    public function getPagePartAdminConfigurations()
+    public function getPagePartAdminConfigurations(): array
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}main');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}main'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPageTemplates()
+    public function getPageTemplates(): array
     {
-        return array('{% if not isV4 %}{{ bundle.getName() }}:{%endif%}searchpage');
+        return ['{% if not isV4 %}{{ bundle.getName() }}:{%endif%}searchpage'];
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/BikeAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/BikeAdminType.php
@@ -29,10 +29,4 @@ class BikeAdminType extends AbstractType
 	    'required' => true
 	));
     }
-
-
-    public function getBlockPrefix()
-    {
-	return 'bike';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/BikesListPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/BikesListPagePartAdminType.php
@@ -12,12 +12,6 @@ class BikesListPagePartAdminType extends \Symfony\Component\Form\AbstractType
 	parent::buildForm($builder, $options);
     }
 
-
-    public function getBlockPrefix()
-    {
-	return 'bikeslistpageparttype';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/PageBannerPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/PageBannerPagePartAdminType.php
@@ -38,12 +38,6 @@ class PageBannerPagePartAdminType extends \Symfony\Component\Form\AbstractType
 	));
     }
 
-
-    public function getBlockPrefix()
-    {
-	return 'pagebannerpageparttype';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/ServicePagePartAdminType.php
@@ -47,12 +47,6 @@ class ServicePagePartAdminType extends \Symfony\Component\Form\AbstractType
 	));
     }
 
-
-    public function getBlockPrefix()
-    {
-	return 'servicepageparttype';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/UspPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/PageParts/UspPagePartAdminType.php
@@ -39,10 +39,4 @@ class UspPagePartAdminType extends AbstractType
 	    'data_class' => '\{{ namespace }}\Entity\PageParts\UspPagePart',
 	));
     }
-
-
-    public function getBlockPrefix()
-    {
-	return 'usppageparttype';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/BehatTestPageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/BehatTestPageAdminType.php
@@ -22,14 +22,4 @@ class BehatTestPageAdminType extends PageAdminType
             'data_class' => '{{ namespace }}\Entity\Pages\BehatTestPage'
         ));
     }
-
-    /**
-     * @assert () == 'behat_test_page'
-     *
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return 'behat_test_page';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/ContentPageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/ContentPageAdminType.php
@@ -52,10 +52,4 @@ class ContentPageAdminType extends PageAdminType
             'data_class' => '{{ namespace }}\Entity\Pages\ContentPage'
         ));
     }
-
-
-    public function getBlockPrefix()
-    {
-	return 'contentpage';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/FormPageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/FormPageAdminType.php
@@ -56,12 +56,4 @@ class FormPageAdminType extends PageAdminType
             'data_class' => '{{ namespace }}\Entity\Pages\FormPage'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return 'formpage';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/HomePageAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/Pages/HomePageAdminType.php
@@ -40,12 +40,4 @@ class HomePageAdminType extends PageAdminType
             'data_class' => '{{ namespace }}\Entity\Pages\HomePage'
         ));
     }
-
-    /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return 'homepage';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/UspItemAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Form/UspItemAdminType.php
@@ -44,10 +44,4 @@ class UspItemAdminType extends AbstractType
 	    'data_class' => '\{{ namespace }}\Entity\UspItem'
 	));
     }
-
-
-    public function getBlockPrefix()
-    {
-	return 'uspitemtype';
-    }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/AudioPagePart/AudioPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/AudioPagePart/AudioPagePartAdminType.php
@@ -22,11 +22,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
 
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ButtonPagePart/ButtonPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ButtonPagePart/ButtonPagePartAdminType.php
@@ -56,12 +56,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/CheckboxPagePart/CheckboxPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/CheckboxPagePart/CheckboxPagePartAdminType.php
@@ -55,14 +55,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ChoicePagePart/ChoicePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ChoicePagePart/ChoicePagePartAdminType.php
@@ -89,14 +89,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/DownloadPagePart/DownloadPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/DownloadPagePart/DownloadPagePartAdminType.php
@@ -19,12 +19,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EditableImagePagePart/EditableImagePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EditableImagePagePart/EditableImagePagePartAdminType.php
@@ -48,16 +48,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * Sets the default options for this type.
      *
      * @param OptionsResolver $resolver The resolver for the options.

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EmailPagePart/EmailPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/EmailPagePart/EmailPagePartAdminType.php
@@ -63,14 +63,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/FileUploadPagePart/FileUploadPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/FileUploadPagePart/FileUploadPagePartAdminType.php
@@ -56,14 +56,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/HeaderPagePart/HeaderPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/HeaderPagePart/HeaderPagePartAdminType.php
@@ -42,12 +42,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ImagePagePart/ImagePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ImagePagePart/ImagePagePartAdminType.php
@@ -41,12 +41,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/IntroTextPagePart/IntroTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/IntroTextPagePart/IntroTextPagePartAdminType.php
@@ -31,12 +31,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/LinePagePart/LinePagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/LinePagePart/LinePagePartAdminType.php
@@ -26,12 +26,6 @@ class {{ pagepart }}AdminType extends AbstractType
         parent::buildForm($builder, $options);
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/LinkPagePart/LinkPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/LinkPagePart/LinkPagePartAdminType.php
@@ -41,12 +41,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/MultiLineTextPagePart/MultiLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/MultiLineTextPagePart/MultiLineTextPagePartAdminType.php
@@ -71,14 +71,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/RawHtmlPagePart/RawHtmlPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/RawHtmlPagePart/RawHtmlPagePartAdminType.php
@@ -36,12 +36,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SingleLineTextPagePart/SingleLineTextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SingleLineTextPagePart/SingleLineTextPagePartAdminType.php
@@ -71,14 +71,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SubmitButtonPagePart/SubmitButtonPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/SubmitButtonPagePart/SubmitButtonPagePartAdminType.php
@@ -30,14 +30,6 @@ class {{ pagepart }}AdminType extends AbstractType
     }
 
     /**
-     * @return string
-     */
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TextPagePart/TextPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TextPagePart/TextPagePartAdminType.php
@@ -31,12 +31,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ToTopPagePart/ToTopPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/ToTopPagePart/ToTopPagePartAdminType.php
@@ -26,12 +26,6 @@ class {{ pagepart }}AdminType extends AbstractType
         parent::buildForm($builder, $options);
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TocPagePart/TocPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/TocPagePart/TocPagePartAdminType.php
@@ -26,12 +26,6 @@ class {{ pagepart }}AdminType extends AbstractType
         parent::buildForm($builder, $options);
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/VideoPagePart/VideoPagePartAdminType.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Form/PageParts/VideoPagePart/VideoPagePartAdminType.php
@@ -25,12 +25,6 @@ class {{ pagepart }}AdminType extends AbstractType
         ));
     }
 
-
-    public function getBlockPrefix()
-    {
-        return '{{ pagepart|lower }}type';
-    }
-
     /**
      * Sets the default options for this type.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 