### PR TITLE
[SeoBundle] Revert espacing extra metatags string to avoid render issue

### DIFF
--- a/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
+++ b/src/Kunstmaan/SeoBundle/Resources/views/SeoTwigExtension/metadata.html.twig
@@ -110,5 +110,5 @@
 {% endif %}
 
 {% if seo.getExtraMetadata() %}
-    {{ seo.getExtraMetadata()|escape('html')|raw }}
+    {{ seo.getExtraMetadata()|raw }}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This will be reimplemented later with an html sanatizer