### PR TITLE
[AdminListBundle] Fix CSRF token in AdminList delete modal

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/sure-modal.html.twig
+++ b/src/Kunstmaan/AdminListBundle/Resources/views/AdminListTwigExtension/sure-modal.html.twig
@@ -12,7 +12,7 @@
                 </h3>
             </div>
             <form action="{{ path(adminlist.getDeleteUrlFor(item)["path"], adminlist.getDeleteUrlFor(item)[("params")] ) }}" method="POST">
-                <input type="hidden" name="token" value="{{ csrf_token('delete-'~adminlist.configurator.entityName|slugify) }}"/>
+                <input type="hidden" name="token" value="{{ csrf_token('node-delete') }}"/>
 
                 <!-- Body -->
                 <div class="modal-body">
@@ -21,7 +21,7 @@
 
                 <!-- Footer -->
                 <div class="modal-footer">
-                    <button type="submit" name="delete" class="btn btn-danger btn--raise-on-hover">
+                    <button type="submit" name="submit" class="btn btn-danger btn--raise-on-hover">
                         {{ 'form.delete' | trans }}
                     </button>
                     <button class="btn btn-default btn--raise-on-hover" data-dismiss="modal">


### PR DESCRIPTION
The CSRF token uses an ID which no longer matches that used in `NodeAdminController`, meaning that the delete function does not work for nodes within an AdminList. This PR updates the ID, and the name of the submit button (for consistency).

To reproduce the original error:
* Go to an AdminList containing nodes.
* Click the delete icon for one of the rows
* Confirm when the modal appears
* Instead of deleting the node, the user is redirected to the node edit page.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | N/A
