### PR TITLE
[AdminBundle] Limit doctrine/persistence to 2.x to avoid issues with deprecated entity notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "doctrine/doctrine-bundle": "^1.12.3|^2.0.3",
         "doctrine/doctrine-cache-bundle": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^1.3|^2.1",
+        "doctrine/persistence": "^1.3|^2.5",
         "symfony/swiftmailer-bundle": "^2.3|^3.0",
         "sensio/framework-extra-bundle": "^5.0",
         "incenteev/composer-parameter-handler": "^2.0",

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclWalkerTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclWalkerTest.php
@@ -24,7 +24,7 @@ class AclWalkerTest extends TestCase
     public function testWalker()
     {
         $range = new RangeVariableDeclaration('someschema', 's');
-        $expr = new PathExpression('int', 'id');
+        $expr = new PathExpression('int', 'id', 'id');
         $expr->type = PathExpression::TYPE_STATE_FIELD;
         $indexBy = new IndexBy($expr);
         $from = new FromClause([new IdentificationVariableDeclaration($range, $indexBy, [])]);

--- a/src/Kunstmaan/AdminBundle/composer.json
+++ b/src/Kunstmaan/AdminBundle/composer.json
@@ -19,6 +19,7 @@
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.12.3|^2.0.3",
         "doctrine/doctrine-cache-bundle": "^1.2",
+        "doctrine/persistence": "^1.3|^2.5",
         "friendsofsymfony/user-bundle": "^2.0",
         "guzzlehttp/guzzle": "~6.1",
         "knplabs/knp-menu-bundle": "^3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Our code is not yet compatible with doctrine/persistence v3, compatibility will be added in 6.x