### PR TITLE
[GeneratorBundle] Add support for php8 attributes in generators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
         "kunstmaan/sensio-generator-bundle": "^3.2",
         "doctrine/collections": "^1.6",
         "symfony/deprecation-contracts": "^2.5|^3.0",
-        "pagerfanta/doctrine-dbal-adapter": "^2.7"
+        "pagerfanta/doctrine-dbal-adapter": "^2.7",
+        "symfony/maker-bundle": "^1.39"
     },
     "require-dev": {
         "symfony/error-handler": "^4.4|^5.3",

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateArticleCommand.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Command;
 
 use Kunstmaan\GeneratorBundle\Generator\ArticleGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -55,6 +56,15 @@ class GenerateArticleCommand extends KunstmaanGenerateCommand
      * @var bool
      */
     private $dummydata;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct();
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * @see Command
@@ -101,7 +111,7 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
         $registry = $this->getContainer()->get('doctrine');
 
-        return new ArticleGenerator($filesystem, $registry, '/article', $this->parentPages, $this->assistant, $this->getContainer());
+        return new ArticleGenerator($filesystem, $registry, '/article', $this->parentPages, $this->assistant, $this->getContainer(), $this->doctrineHelper);
     }
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultPagePartsCommand.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Command;
 
 use Kunstmaan\GeneratorBundle\Generator\DefaultPagePartGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -30,6 +31,15 @@ class GenerateDefaultPagePartsCommand extends KunstmaanGenerateCommand
      * @var bool
      */
     private $behatTest;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct();
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * @see Command
@@ -156,6 +166,6 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
         $registry = $this->getContainer()->get('doctrine');
 
-        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer());
+        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer(), $this->doctrineHelper);
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateDefaultSiteCommand.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Command;
 
 use Kunstmaan\GeneratorBundle\Generator\DefaultSiteGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -32,6 +33,16 @@ class GenerateDefaultSiteCommand extends KunstmaanGenerateCommand
      * @var bool
      */
     private $groundcontrol;
+
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct();
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * @see Command
@@ -172,6 +183,6 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
         $registry = $this->getContainer()->get('doctrine');
 
-        return new DefaultSiteGenerator($filesystem, $registry, '/defaultsite', $this->assistant, $this->getContainer());
+        return new DefaultSiteGenerator($filesystem, $registry, '/defaultsite', $this->assistant, $this->getContainer(), $this->doctrineHelper);
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateFormPagePartsCommand.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Command;
 
 use Kunstmaan\GeneratorBundle\Generator\DefaultPagePartGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -20,6 +21,15 @@ class GenerateFormPagePartsCommand extends KunstmaanGenerateCommand
      * @var string
      */
     private $prefix;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct();
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * @see Command
@@ -114,6 +124,6 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
         $registry = $this->getContainer()->get('doctrine');
 
-        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer());
+        return new DefaultPagePartGenerator($filesystem, $registry, '/pagepart', $this->assistant, $this->getContainer(), $this->doctrineHelper);
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/GenerateSearchPageCommand.php
@@ -7,6 +7,7 @@ use Kunstmaan\GeneratorBundle\Helper\GeneratorUtils;
 use Kunstmaan\GeneratorBundle\Helper\Sf4AppBundle;
 use Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineCommand;
 use Sensio\Bundle\GeneratorBundle\Command\Validators;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,6 +18,16 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class GenerateSearchPageCommand extends GenerateDoctrineCommand
 {
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct();
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
+
     /**
      * @see Command
      */
@@ -123,6 +134,6 @@ EOT
 
     protected function createGenerator()
     {
-        return new SearchPageGenerator($this->getContainer()->get('filesystem'), '/searchpage', $this->getContainer()->getParameter('kernel.project_dir'));
+        return new SearchPageGenerator($this->getContainer()->get('filesystem'), '/searchpage', $this->getContainer()->getParameter('kernel.project_dir'), $this->doctrineHelper);
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
@@ -145,6 +145,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
                 'export_extensions' => $extensions,
                 'sortField' => $sortField,
                 'isV4' => Kernel::VERSION_ID >= 40000,
+                'canUseAttributes' => version_compare(\PHP_VERSION, '8alpha', '>=') && Kernel::VERSION_ID >= 50200,
             ]
         );
     }

--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultPagePartGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultPagePartGenerator.php
@@ -2,7 +2,13 @@
 
 namespace Kunstmaan\GeneratorBundle\Generator;
 
+use Doctrine\Persistence\ManagerRegistry;
+use Kunstmaan\GeneratorBundle\Helper\CommandAssistant;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -29,6 +35,14 @@ class DefaultPagePartGenerator extends KunstmaanGenerator
      * @var array
      */
     private $sections;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(Filesystem $filesystem, ManagerRegistry $registry, $skeletonDir, CommandAssistant $assistant, ContainerInterface $container, DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct($filesystem, $registry, $skeletonDir, $assistant, $container);
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * Generate the pagepart.
@@ -74,6 +88,8 @@ class DefaultPagePartGenerator extends KunstmaanGenerator
             'underscoreName' => strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $this->entity)),
             'prefix' => $this->prefix,
             'isV4' => $this->isSymfony4(),
+            'canUseAttributes' => version_compare(\PHP_VERSION, '8alpha', '>=') && Kernel::VERSION_ID >= 50200,
+            'canUseEntityAttributes' => $this->doctrineHelper->doesClassUsesAttributes('App\\Entity\\Unkown'.uniqid()),
         ];
 
         $this->renderSingleFile(

--- a/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/DefaultSiteGenerator.php
@@ -2,8 +2,14 @@
 
 namespace Kunstmaan\GeneratorBundle\Generator;
 
+use Doctrine\Persistence\ManagerRegistry;
+use Kunstmaan\GeneratorBundle\Helper\CommandAssistant;
 use Kunstmaan\GeneratorBundle\Helper\GeneratorUtils;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -35,6 +41,14 @@ class DefaultSiteGenerator extends KunstmaanGenerator
      * @var bool
      */
     private $groundControl;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
+
+    public function __construct(Filesystem $filesystem, ManagerRegistry $registry, $skeletonDir, CommandAssistant $assistant, ContainerInterface $container, DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct($filesystem, $registry, $skeletonDir, $assistant, $container);
+        $this->doctrineHelper = $doctrineHelper;
+    }
 
     /**
      * Generate the website.
@@ -60,6 +74,8 @@ class DefaultSiteGenerator extends KunstmaanGenerator
             'multilanguage' => $this->isMultiLangEnvironment(),
             'isV4' => $this->isSymfony4(),
             'groundcontrol' => $this->groundControl,
+            'canUseAttributes' => version_compare(\PHP_VERSION, '8alpha', '>=') && Kernel::VERSION_ID >= 50200,
+            'canUseEntityAttributes' => $this->doctrineHelper->doesClassUsesAttributes('App\\Entity\\Unkown'.uniqid()),
         ];
 
         $this->generateControllers($parameters);

--- a/src/Kunstmaan/GeneratorBundle/Generator/SearchPageGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/SearchPageGenerator.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\GeneratorBundle\Generator;
 
 use Kunstmaan\GeneratorBundle\Helper\GeneratorUtils;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -28,16 +29,19 @@ class SearchPageGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Gener
      * @var string
      */
     private $rootDir;
+    /** @var DoctrineHelper */
+    private $doctrineHelper;
 
     /**
      * @param Filesystem $filesystem  The filesytem
      * @param string     $skeletonDir The skeleton directory
      */
-    public function __construct(Filesystem $filesystem, $skeletonDir, $rootDir = null)
+    public function __construct(Filesystem $filesystem, $skeletonDir, $rootDir, DoctrineHelper $doctrineHelper)
     {
         $this->filesystem = $filesystem;
         $this->skeletonDir = $skeletonDir;
         $this->rootDir = $rootDir;
+        $this->doctrineHelper = $doctrineHelper;
     }
 
     /**
@@ -58,6 +62,8 @@ class SearchPageGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Gener
             'bundle' => $bundle,
             'prefix' => GeneratorUtils::cleanPrefix($prefix),
             'isV4' => Kernel::VERSION_ID >= 40000,
+            'canUseAttributes' => version_compare(\PHP_VERSION, '8alpha', '>=') && Kernel::VERSION_ID >= 50200,
+            'canUseEntityAttributes' => $this->doctrineHelper->doesClassUsesAttributes('App\\Entity\\Unkown'.uniqid()),
         ];
 
         $this->generateEntities($bundle, $parameters, $output);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/Controller/EntityAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/Controller/EntityAdminListController.php
@@ -10,19 +10,20 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 {% if isV4 %}
-
+{% if canUseAttributes %}
+#[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}
 /**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower }}", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
+{% endif %}
 class {{ entity_class }}AdminListController extends AbstractAdminListController
 {
-    /**
-     * @var AdminListConfiguratorInterface
-     */
+    /** @var {{ entity_class }}AdminListConfigurator */
     private $configurator;
 
-    public function getAdminListConfigurator(): AdminListConfiguratorInterface
+    public function getAdminListConfigurator(): {{ entity_class }}AdminListConfigurator
     {
         if (!isset($this->configurator)) {
             $this->configurator = new {{ entity_class }}AdminListConfigurator($this->getEntityManager());
@@ -31,66 +32,98 @@ class {{ entity_class }}AdminListController extends AbstractAdminListController
         return $this->configurator;
     }
 
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}')]
+{% else %}
     /**
      * @Route("/", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}")
      */
+{% endif %}
     public function indexAction(Request $request): Response
     {
         return parent::doIndexAction($this->getAdminListConfigurator(), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_add", methods={"GET", "POST"})
      */
+{% endif %}
     public function addAction(Request $request): Response
     {
         return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_edit", methods={"GET", "POST"})
      */
+{% endif %}
     public function editAction(Request $request, int $id): Response
     {
         return parent::doEditAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/view', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_view', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/view", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_view", methods={"GET"})
      */
+{% endif %}
     public function viewAction(Request $request, int $id): Response
     {
         return parent::doViewAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_delete", methods={"GET", "POST"})
      */
+{% endif %}
     public function deleteAction(Request $request, int $id): Response
     {
         return parent::doDeleteAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => '{{ export_extensions }}'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "{{ export_extensions }}"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_export", methods={"GET", "POST"})
      */
+{% endif %}
     public function exportAction(Request $request, string $_format): Response
     {
         return parent::doExportAction($this->getAdminListConfigurator(), $_format, $request);
     }
 {% if sortField %}
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-up', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_up', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_up", methods={"GET"})
      */
+{% endif %}
     public function moveUpAction(Request $request, int $id): Response
     {
     return parent::doMoveUpAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-down', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_down', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}_move_down", methods={"GET"})
      */
+{% endif %}
     public function moveDownAction(Request $request, int $id): Response
     {
     return parent::doMoveDownAction($this->getAdminListConfigurator(), $id, $request);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/AuthorAdminListController.php
@@ -11,9 +11,13 @@ use Symfony\Component\HttpFoundation\Response;
 use {{ namespace }}\AdminList\{{ entity_class }}AuthorAdminListConfigurator;
 {% if isV4 %}
 
+{% if canUseAttributes %}
+#[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-author', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}
 /**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-author", requirements={"_locale"="%requiredlocales%"})
  */
+{% endif %}
 {% endif %}
 class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorAdminListController
 {
@@ -22,41 +26,61 @@ class {{ entity_class }}AuthorAdminListController extends AbstractArticleAuthorA
         return new {{ entity_class }}AuthorAdminListConfigurator($this->getEntityManager(), $this->aclHelper, $this->locale, PermissionMap::PERMISSION_EDIT);
     }
 
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author')]
+{% else %}
     /**
      * @Route("/", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author")
      */
+{% endif %}
     public function indexAction(Request $request): Response
     {
         return parent::doIndexAction($this->getAdminListConfigurator($request), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_add", methods={"GET", "POST"})
      */
+{% endif %}
     public function addAction(Request $request): Response
     {
         return parent::doAddAction($this->getAdminListConfigurator($request), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_edit", methods={"GET", "POST"})
      */
+{% endif %}
     public function editAction(Request $request, int $id): Response
     {
         return parent::doEditAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_delete", methods={"GET", "POST"})
      */
+{% endif %}
     public function deleteAction(Request $request, int $id): Response
     {
         return parent::doDeleteAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => 'csv'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}author_export", methods={"GET", "POST"})
      */
+{% endif %}
     public function exportAction(Request $request, string $_format): Response
     {
         return parent::doExportAction($this->getAdminListConfigurator($request), $_format, $request);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/CategoryAdminListController.php
@@ -9,71 +9,107 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 {% if isV4 %}
 
+{% if canUseAttributes %}
+#[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-category', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}
 /**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-category", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
+{% endif %}
 class {{ entity_class }}CategoryAdminListController extends AbstractArticleCategoryAdminListController
 {
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category')]
+{% else %}
     /**
      * @Route("/", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category")
      */
+{% endif %}
     public function indexAction(Request $request): Response
     {
         return parent::doIndexAction($this->getAdminListConfigurator($request), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_add", methods={"GET", "POST"})
      */
+{% endif %}
     public function addAction(Request $request): Response
     {
         return parent::doAddAction($this->getAdminListConfigurator($request), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_edit", methods={"GET", "POST"})
      */
+{% endif %}
     public function editAction(Request $request, int $id): Response
     {
         return parent::doEditAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/view', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_view', methods: ['GET'])]
+{% else %}
     /**
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_view", methods={"GET"})
+     * @Route("/{id}/view", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_view", methods={"GET"})
      */
+{% endif %}
     public function viewAction(Request $request, int $id): Response
     {
         return parent::doViewAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_delete", methods={"GET", "POST"})
      */
+{% endif %}
     public function deleteAction(Request $request, int $id): Response
     {
         return parent::doDeleteAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => 'csv|xlsx|ods'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_export", methods={"GET", "POST"})
      */
+{% endif %}
     public function exportAction(Request $request, string $_format): Response
     {
         return parent::doExportAction($this->getAdminListConfigurator($request), $_format, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-up', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_up', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_up", methods={"GET"})
      */
+{% endif %}
     public function moveUpAction(Request $request, int $id): Response
     {
         return parent::doMoveUpAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-down', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_down', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}category_move_down", methods={"GET"})
      */
+{% endif %}
     public function moveDownAction(Request $request, int $id): Response
     {
         return parent::doMoveDownAction($this->getAdminListConfigurator($request), $id, $request);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/PageAdminListController.php
@@ -11,9 +11,13 @@ use Symfony\Component\HttpFoundation\Request;
 use {{ namespace }}\AdminList\{{ entity_class }}PageAdminListConfigurator;
 {% if isV4 %}
 
+{% if canUseAttributes %}
+    #[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-page', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}
 /**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-page", requirements={"_locale"="%requiredlocales%"})
  */
+{% endif %}
 {% endif %}
 class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdminListController
 {
@@ -22,41 +26,61 @@ class {{ entity_class }}PageAdminListController extends AbstractArticlePageAdmin
         return new {{ entity_class }}PageAdminListConfigurator($this->getEntityManager(), $this->aclHelper, $this->locale, PermissionMap::PERMISSION_EDIT);
     }
 
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page')]
+{% else %}
     /**
      * @Route("/", name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page")
      */
+{% endif %}
     public function indexAction(Request $request): Response
     {
         return parent::doIndexAction($this->getAdminListConfigurator($request), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/add", name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_add", methods={"GET", "POST"})
      */
+{% endif %}
     public function addAction(Request $request): Response
     {
         return parent::doAddAction($this->getAdminListConfigurator($request), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_edit", methods={"GET", "POST"})
      */
+{% endif %}
     public function editAction(Request $request, int $id): Response
     {
         return parent::doEditAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_delete", methods={"GET", "POST"})
      */
+{% endif %}
     public function deleteAction(Request $request, int $id): Response
     {
         return parent::doDeleteAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => 'csv'], name: '{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle.getName()|lower }}_admin_pages_{{ entity_class|lower }}page_export", methods={"GET", "POST"})
      */
+{% endif %}
     public function exportAction(Request $request, string $_format): Response
     {
         return parent::doExportAction($this->getAdminListConfigurator($request), $_format, $request);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Controller/TagAdminListController.php
@@ -9,71 +9,107 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 {% if isV4 %}
 
+{% if canUseAttributes %}
+#[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-tag', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}
 /**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/{{ entity_class|lower}}-tag", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
+{% endif %}
 class {{ entity_class }}TagAdminListController extends AbstractArticleTagAdminListController
 {
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag')]
+{% else %}
     /**
      * @Route("/", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag")
      */
+{% endif %}
     public function indexAction(Request $request): Response
     {
         return parent::doIndexAction($this->getAdminListConfigurator($request), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/add", name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_add", methods={"GET", "POST"})
      */
+{% endif %}
     public function addAction(Request $request): Response
     {
         return parent::doAddAction($this->getAdminListConfigurator($request), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_edit", methods={"GET", "POST"})
      */
+{% endif %}
     public function editAction(Request $request, int $id): Response
     {
         return parent::doEditAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/view', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_view', methods: ['GET'])]
+{% else %}
     /**
-     * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_view", methods={"GET"})
+     * @Route("/{id}/view", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_view", methods={"GET"})
      */
+{% endif %}
     public function viewAction(Request $request, int $id): Response
     {
         return parent::doViewAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_delete", methods={"GET", "POST"})
      */
+{% endif %}
     public function deleteAction(Request $request, int $id): Response
     {
         return parent::doDeleteAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => 'csv|xlsx|ods'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "csv|xlsx|ods"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_export", methods={"GET", "POST"})
      */
+{% endif %}
     public function exportAction(Request $request, string $_format): Response
     {
         return parent::doExportAction($this->getAdminListConfigurator($request), $_format, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-up', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_up', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_up", methods={"GET"})
      */
+{% endif %}
     public function moveUpAction(Request $request, int $id): Response
     {
         return parent::doMoveUpAction($this->getAdminListConfigurator($request), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-down', requirements: ['id' => '\d+'], name: '{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_down', methods: ['GET'])]
+{% else %}
     /**
      * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle.getName()|lower }}_admin_{{ entity_class|lower }}tag_move_down", methods={"GET"})
      */
+{% endif %}
     public function moveDownAction(Request $request, int $id): Response
     {
         return parent::doMoveDownAction($this->getAdminListConfigurator($request), $id, $request);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Author.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Author.php
@@ -6,10 +6,15 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\ArticleBundle\Entity\AbstractAuthor;
 use {{ namespace }}\Form\{{ entity_class }}AuthorAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ entity_class|lower }}_authors')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_authors")
  */
+{% endif %}
 class {{ entity_class }}Author extends AbstractAuthor
 {
     public function getAdminType(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
@@ -7,11 +7,18 @@ use Gedmo\Mapping\Annotation as Gedmo;
 use Kunstmaan\ArticleBundle\Entity\AbstractCategory;
 use {{ namespace }}\Form\{{ entity_class }}CategoryAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ entity_class|lower }}_categories')]
+#[ORM\UniqueConstraint(name: '{{ entity_class|lower }}_category_name_idx', columns: ['name'])]
+#[Gedmo\SoftDeleteable(fieldName: 'deletedAt')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_categories", uniqueConstraints={@ORM\UniqueConstraint(name="{{ entity_class|lower }}_category_name_idx", columns={"name"})})
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
+{% endif %}
 class {{ entity_class }}Category extends AbstractCategory
 {
     public function getAdminType(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/OverviewPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/OverviewPage.php
@@ -3,18 +3,23 @@
 namespace {{ namespace }}\Entity\Pages;
 
 use {{ namespace }}\Form\Pages\{{ entity_class }}OverviewPageAdminType;
+use {{ namespace }}\Repository\{{ entity_class }}OverviewPageRepository;
 use {{ namespace }}\ViewDataProvider\{{ entity_class }}PageViewDataProvider;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\ArticleBundle\Entity\AbstractArticleOverviewPage;
 use Kunstmaan\NodeBundle\Entity\CustomViewDataProviderInterface;
 use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
-use Kunstmaan\PagePartBundle\PagePartAdmin\AbstractPagePartAdminConfigurator;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity(repositoryClass: {{ entity_class }}OverviewPageRepository::class)]
+#[ORM\Table(name: '{{ prefix }}{{ entity_class|lower }}_overview_pages')]
+{% else %}
 /**
  * @ORM\Entity(repositoryClass="{{ namespace }}\Repository\{{ entity_class }}OverviewPageRepository")
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_overview_pages")
  */
+{% endif %}
 class {{ entity_class }}OverviewPage extends AbstractArticleOverviewPage implements HasPageTemplateInterface, SearchTypeInterface, CustomViewDataProviderInterface
 {
     public function getPagePartAdminConfigurations(): array
@@ -34,7 +39,7 @@ class {{ entity_class }}OverviewPage extends AbstractArticleOverviewPage impleme
      */
     public function getArticleRepository($em)
     {
-        return $em->getRepository('{{ bundle.getName() }}:Pages\{{ entity_class }}Page');
+        return $em->getRepository({{ entity_class }}Page::class);
     }
 
     public function getDefaultView(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/Page.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/Page.php
@@ -2,19 +2,26 @@
 
 namespace {{ namespace }}\Entity\Pages;
 
+use {{ namespace }}\Form\Pages\{{ entity_class }}PageAdminType;
+use {{ namespace }}\Repository\{{ entity_class }}PageRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\ArticleBundle\Entity\AbstractArticlePage;
 use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Kunstmaan\NodeBundle\Entity\HideSidebarInNodeEditInterface;
-use {{ namespace }}\Form\Pages\{{ entity_class }}PageAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity(repositoryClass: {{ entity_class }}PageRepository::class)]
+#[ORM\Table(name: '{{ prefix }}{{ entity_class|lower }}_pages')]
+#[ORM\HasLifecycleCallbacks]
+{% else %}
 /**
  * @ORM\Entity(repositoryClass="{{ namespace }}\Repository\{{ entity_class }}PageRepository")
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_pages")
  * @ORM\HasLifecycleCallbacks
  */
+{% endif %}
 class {{ entity_class }}Page extends AbstractArticlePage implements HasPageTemplateInterface, SearchTypeInterface, HideSidebarInNodeEditInterface
 {
     //%PagePartial.php.twig%
@@ -54,9 +61,14 @@ class {{ entity_class }}Page extends AbstractArticlePage implements HasPageTempl
     /**
      * Before persisting this entity, check the date.
      * When no date is present, fill in current date and time.
+{% if canUseEntityAttributes == false%}
      *
      * @ORM\PrePersist
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\PrePersist]
+{% endif %}
     public function _prePersist()
     {
         // Set date to now when none is set

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/PagePartial.php.twig
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Pages/PagePartial.php.twig
@@ -1,20 +1,35 @@
-    {% if type == 'Author' %}
-    /**
+{% if type == 'Author' %}
+/**
      * @var \{{ namespace }}\Entity\{{ entity_class }}{{ type }}
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="{{ namespace }}\Entity\{{ entity_class }}{{ type }}")
      * @ORM\JoinColumn(name="{{ entity_class|lower }}_{{ type|lower }}_id", referencedColumnName="id")
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: '{{ namespace }}\Entity\{{ entity_class }}{{ type }}')]
+    #[ORM\JoinColumn(name: '{{ entity_class|lower }}_{{ type|lower }}_id', referencedColumnName: 'id')]
+{% endif %}
     protected ${{ type|lower }};
-    {% else %}
+
+{% else %}
     /**
      * @var ArrayCollection
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToMany(targetEntity="{{ namespace }}\Entity\{{ entity_class }}{{ type }}")
      * @ORM\JoinTable(name="{{ prefix }}{{ entity_class|lower }}_{{ type|lower }}_page_{{ pluralType }}",
      *     joinColumns={@ORM\JoinColumn(name="{{ entity_class|lower }}_page_id", referencedColumnName="id")},
      *     inverseJoinColumns={@ORM\JoinColumn(name="{{ entity_class|lower }}_{{ type|lower }}_id", referencedColumnName="id")}
      * )
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToMany(targetEntity: '{{ namespace }}\Entity\{{ entity_class }}{{ type }}')]
+    #[ORM\JoinTable(name: '{{ prefix }}{{ entity_class|lower }}_{{ type|lower }}_page_{{ pluralType }}')]
+    #[ORM\JoinColumn(name: '{{ entity_class|lower }}_page_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: '{{ entity_class|lower }}_{{ type|lower }}_id', referencedColumnName: 'id')]
+{% endif %}
     protected ${{ pluralType }};
-    {% endif %}
+{% endif %}

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
@@ -7,11 +7,18 @@ use Gedmo\Mapping\Annotation as Gedmo;
 use Kunstmaan\ArticleBundle\Entity\AbstractTag;
 use {{ namespace }}\Form\{{ entity_class }}TagAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ entity_class|lower }}_tags')]
+#[ORM\UniqueConstraint(name: '{{ entity_class|lower }}_tag_name_idx', columns: ['name'])]
+#[Gedmo\SoftDeleteable(fieldName: 'deletedAt')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_tags", uniqueConstraints={@ORM\UniqueConstraint(name="{{ entity_class|lower }}_tag_name_idx", columns={"name"})})
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */
+{% endif %}
 class {{ entity_class }}Tag extends AbstractTag
 {
     public function getAdminType(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/BikeAdminListController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/BikeAdminListController.php
@@ -2,119 +2,114 @@
 
 namespace {{ namespace }}\Controller;
 
-use Kunstmaan\AdminListBundle\AdminList\Configurator\AdminListConfiguratorInterface;
+use {{ namespace }}\AdminList\BikeAdminListConfigurator;
 use Kunstmaan\AdminListBundle\Controller\AbstractAdminListController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
-use {{ namespace }}\AdminList\BikeAdminListConfigurator;
 
 {% if isV4 %}
-
-/**
+{% if canUseAttributes %}#[Route('/{_locale}/%kunstmaan_admin.admin_prefix%/bike', requirements: ['_locale' => '%requiredlocales%'])]
+{% else %}/**
  * @Route("/{_locale}/%kunstmaan_admin.admin_prefix%/bike", requirements={"_locale"="%requiredlocales%"})
  */
 {% endif %}
+{% endif %}
 class BikeAdminListController extends AbstractAdminListController
 {
-    /**
-     * @var AdminListConfiguratorInterface
-     */
+    /** @var BikeAdminListConfigurator */
     private $configurator;
 
-    /**
-     * @return AdminListConfiguratorInterface
-     */
-    public function getAdminListConfigurator()
+    public function getAdminListConfigurator(): BikeAdminListConfigurator
     {
-	if (!isset($this->configurator)) {
-	    $this->configurator = new BikeAdminListConfigurator($this->getEntityManager());
-	}
+        if (!isset($this->configurator)) {
+            $this->configurator = new BikeAdminListConfigurator($this->getEntityManager());
+        }
 
-	return $this->configurator;
+        return $this->configurator;
     }
 
+{% if canUseAttributes %}
+    #[Route('/', name: '{{ bundle_name|lower }}_admin_bike')]
+{% else %}
     /**
-     * The index action
-     *
      * @Route("/", name="{{ bundle_name|lower }}_admin_bike")
      */
-    public function indexAction(Request $request)
+{% endif %}
+    public function indexAction(Request $request): Response
     {
-	return parent::doIndexAction($this->getAdminListConfigurator(), $request);
+	    return parent::doIndexAction($this->getAdminListConfigurator(), $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/add', name: '{{ bundle_name|lower }}_admin_bike_add', methods: ['GET', 'POST'])]
+{% else %}
     /**
-     * The add action
-     *
      * @Route("/add", name="{{ bundle_name|lower }}_admin_bike_add", methods={"GET", "POST"})
-     * @return array
      */
-    public function addAction(Request $request)
+{% endif %}
+    public function addAction(Request $request): Response
     {
-	return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
+	    return parent::doAddAction($this->getAdminListConfigurator(), null, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}', requirements: ['id' => '\d+'], name: '{{ bundle_name|lower }}_admin_bike_edit', methods: ['GET', 'POST'])]
+{% else %}
     /**
-     * The edit action
-     *
-     * @param int $id
-     *
      * @Route("/{id}", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_edit", methods={"GET", "POST"})
-     *
-     * @return array
      */
-    public function editAction(Request $request, $id)
+{% endif %}
+    public function editAction(Request $request, int $id): Response
     {
-	return parent::doEditAction($this->getAdminListConfigurator(), $id, $request);
+	    return parent::doEditAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: '{{ bundle_name|lower }}_admin_bike_delete', methods: ['GET', 'POST'])]
+{% else %}
     /**
-     * The delete action
-     *
-     * @param int $id
-     *
      * @Route("/{id}/delete", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_delete", methods={"GET", "POST"})
-     *
-     * @return array
      */
-    public function deleteAction(Request $request, $id)
+{% endif %}
+    public function deleteAction(Request $request, int $id): Response
     {
-	return parent::doDeleteAction($this->getAdminListConfigurator(), $id, $request);
+	    return parent::doDeleteAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/export.{_format}', requirements: ['_format' => 'csv'], name: '{{ bundle_name|lower }}_admin_bike_export', methods: ['GET', 'POST'])]
+{% else %}
     /**
      * @Route("/export.{_format}", requirements={"_format" = "csv"}, name="{{ bundle_name|lower }}_admin_bike_export", methods={"GET", "POST"})
-     * @return array
      */
-    public function exportAction(Request $request, $_format)
+{% endif %}
+    public function exportAction(Request $request, $_format): Response
     {
-	return parent::doExportAction($this->getAdminListConfigurator(), $_format, $request);
+	    return parent::doExportAction($this->getAdminListConfigurator(), $_format, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-up', requirements: ['id' => '\d+'], name: '{{ bundle_name|lower }}_admin_bike_move_up', methods: ['GET'])]
+{% else %}
     /**
-     * The move up action
-     *
-     * @param int $id
-     *
      * @Route("/{id}/move-up", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_up", methods={"GET"})
-     *
-     * @return array
      */
-    public function moveUpAction(Request $request, $id)
+{% endif %}
+    public function moveUpAction(Request $request, int $id): RedirectResponse
     {
         return parent::doMoveUpAction($this->getAdminListConfigurator(), $id, $request);
     }
 
+{% if canUseAttributes %}
+    #[Route('/{id}/move-down', requirements: ['id' => '\d+'], name: '{{ bundle_name|lower }}_admin_bike_move_down', methods: ['GET'])]
+{% else %}
     /**
-     * The move down action
-     *
-     * @param int $id
-     *
      * @Route("/{id}/move-down", requirements={"id" = "\d+"}, name="{{ bundle_name|lower }}_admin_bike_move_down", methods={"GET"})
-     *
-     * @return array
      */
-    public function moveDownAction(Request $request, $id)
+{% endif %}
+    public function moveDownAction(Request $request, int $id): RedirectResponse
     {
         return parent::doMoveDownAction($this->getAdminListConfigurator(), $id, $request);
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Controller/DefaultController.php
@@ -9,14 +9,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 class DefaultController extends AbstractController
 {
-    {% if multilanguage %}
-    /**
+{% if multilanguage %}
+{% if canUseAttributes %}
+    #[Route('/')]
+{% else %}/**
      * @Route("/")
-     * @param Request $request
-     * @return RedirectResponse
-     * @throws \InvalidArgumentException
      */
-    public function indexAction(Request $request)
+{% endif %}
+    public function indexAction(Request $request): RedirectResponse
     {
         return $this->redirectToRoute('_slug', array_merge($request->query->all(), [
             'url' => '',
@@ -24,18 +24,12 @@ class DefaultController extends AbstractController
         ]));
     }
 
-    /**
-     * @param Request $request
-     * @return string
-     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     */
-    private function getLocale(Request $request)
+    private function getLocale(Request $request): ?string
     {
         $locales = array_filter(
             explode('|', $this->getParameter('requiredlocales'))
         );
         return $request->getPreferredLanguage($locales);
     }
-    {% endif %}
-
+{% endif %}
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Bike.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Bike.php
@@ -5,64 +5,112 @@ namespace {{ namespace }}\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}bike')]
+{% else %}
 /**
- * Bike
- *
  * @ORM\Table(name="{{ prefix }}bike")
  * @ORM\Entity
  */
+{% endif %}
 class Bike extends \Kunstmaan\AdminBundle\Entity\AbstractEntity
 {
-    const TYPE_CITY_BIKE = 'city_bike';
-    const TYPE_MOUNTAIN_BIKE = 'mountain_bike';
-    const TYPE_RACING_BIKE = 'racing_bike';
+    public const TYPE_CITY_BIKE = 'city_bike';
+    public const TYPE_MOUNTAIN_BIKE = 'mountain_bike';
+    public const TYPE_RACING_BIKE = 'racing_bike';
 
     /**
      * @var array Supported bike types
      */
-    public static $types = array(
-	self::TYPE_CITY_BIKE,
-	self::TYPE_MOUNTAIN_BIKE,
-	self::TYPE_RACING_BIKE
-    );
+    public static $types = [
+        self::TYPE_CITY_BIKE,
+        self::TYPE_MOUNTAIN_BIKE,
+        self::TYPE_RACING_BIKE,
+    ];
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="type", type="string", length=20, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'type', type: 'string', length: 20, nullable: true)]
+{% endif %}
     private $type;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="model", type="string", length=100, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'model', type: 'string', length: 100, nullable: true)]
+{% endif %}
     private $model;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="brand", type="string", length=100, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'brand', type: 'string', length: 100, nullable: true)]
+{% endif %}
     private $brand;
 
     /**
-     * @var double
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="price", type="decimal", precision=8, scale=2, nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'price', type: 'decimal', precision: 8, scale: 2, nullable: true)]
+{% endif %}
     private $price;
 
     /**
-     * @ORM\Column(type="smallint", nullable=true)
-     * @Assert\Type(type = "numeric")
-     *
      * @var integer
+{% if canUseEntityAttributes == false %}
+     *
+     * @ORM\Column(type="smallint", nullable=true)
+{% if canUseAttributes == false %}
+     * @Assert\Type(type = "numeric")
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\Type(type: 'numeric')]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'weight', type: 'smallint', nullable: true)]
+{% endif %}
     private $weight;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/BikesListPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/BikesListPagePart.php
@@ -4,12 +4,15 @@ namespace {{ namespace }}\Entity\PageParts;
 
 use Doctrine\ORM\Mapping as ORM;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}bikes_list_page_parts')]
+{% else %}
 /**
- * BikesListPagePart
- *
  * @ORM\Table(name="{{ prefix }}bikes_list_page_parts")
  * @ORM\Entity
  */
+{% endif %}
 class BikesListPagePart extends AbstractPagePart
 {
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/PageBannerPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/PageBannerPagePart.php
@@ -6,58 +6,97 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}page_banner_page_parts')]
+{% else %}
 /**
- * PageBannerPagePart
- *
  * @ORM\Table(name="{{ prefix }}page_banner_page_parts")
  * @ORM\Entity
  */
+{% endif %}
 class PageBannerPagePart extends AbstractPagePart
 {
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="title", type="string", length=255, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'title', type: 'string', length: 255, nullable: true)]
+{% endif %}
     private $title;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="description", type="text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'description', type: 'text', nullable: true)]
+{% endif %}
     private $description;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="button_url", type="string", nullable=true)
-     */
+{% if canUseEntityAttributes == false %}
+    *
+    * @ORM\Column(name="button_url", type="string", nullable=true)
+{% endif %}
+    */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'button_url', type: 'string', nullable: true)]
+{% endif %}
     private $buttonUrl;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="button_text", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'button_text', type: 'string', nullable: true)]
+{% endif %}
     private $buttonText;
 
     /**
      * @var boolean
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="button_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'button_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $buttonNewWindow;
 
     /**
-     * @var \Kunstmaan\MediaBundle\Entity\Media
+     * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="background_id", referencedColumnName="id")
      * })
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'background_id', referencedColumnName: 'id')]
+{% endif %}
     private $backgroundImage;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/ServicePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/ServicePagePart.php
@@ -6,16 +6,20 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\Validator\Constraints as Assert;
 
+
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}service_page_parts')]
+{% else %}
 /**
- * ServicePagePart
- *
  * @ORM\Table(name="{{ prefix }}service_page_parts")
  * @ORM\Entity
  */
+{% endif %}
 class ServicePagePart extends AbstractPagePart
 {
-    const IMAGE_POSITION_LEFT = 'left';
-    const IMAGE_POSITION_RIGHT = 'right';
+    public const IMAGE_POSITION_LEFT = 'left';
+    public const IMAGE_POSITION_RIGHT = 'right';
 
     /**
      * @var array Supported positions
@@ -27,56 +31,102 @@ class ServicePagePart extends AbstractPagePart
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="title", type="string", length=255, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'title', type: 'string', length: 255, nullable: true)]
+{% endif %}
     private $title;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="description", type="text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'description', type: 'text', nullable: true)]
+{% endif %}
     private $description;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_url", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_url', type: 'string', nullable: true)]
+{% endif %}
     private $linkUrl;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_text", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_text', type: 'string', nullable: true)]
+{% endif %}
     private $linkText;
 
     /**
      * @var boolean
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $linkNewWindow;
 
     /**
-     * @var \Kunstmaan\MediaBundle\Entity\Media
+     * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="image_id", referencedColumnName="id")
      * })
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'image_id', referencedColumnName: 'id')]
+{% endif %}
     private $image;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="image_position", type="string", length=15, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'image_position', type: 'string', length: 15, nullable: true)]
+{% endif %}
     private $imagePosition;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/UspPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/PageParts/UspPagePart.php
@@ -8,21 +8,36 @@ use Kunstmaan\AdminBundle\Entity\DeepCloneInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use {{ namespace }}\Entity\UspItem;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}usp_page_parts')]
+{% else %}
 /**
  * @ORM\Table(name="{{ prefix }}usp_page_parts")
  * @ORM\Entity
  */
+{% endif %}
 class UspPagePart extends AbstractPagePart implements DeepCloneInterface
 {
     /**
      * @var ArrayCollection
+{% if canUseEntityAttributes == false %}
      *
+{% if canUseAttributes == false %}
      * @Assert\Valid()
+{% endif %}
      * @ORM\OneToMany(targetEntity="\{{ namespace }}\Entity\UspItem", mappedBy="uspPagePart", cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\OrderBy({"weight" = "ASC"})
-     **/
+{% endif %}
+     */
+{% if canUseAttributes %}
+    #[Assert\Valid]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\OneToMany(targetEntity: UspItem::class, mappedBy: 'uspPagePart', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    #[ORM\OrderBy(['weight' => 'ASC'])]
+{% endif %}
     private $items;
-
 
     public function __construct()
     {

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/BehatTestPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/BehatTestPage.php
@@ -9,12 +9,15 @@ use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\BehatTestPageAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}behat_test_pages')]
+{% else %}
 /**
- * BehatTestPage
- *
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}behat_test_pages")
  */
+{% endif %}
 class BehatTestPage extends AbstractPage implements HasPageTemplateInterface
 {
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/ContentPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/ContentPage.php
@@ -2,39 +2,55 @@
 
 namespace {{ namespace }}\Entity\Pages;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
 use Kunstmaan\NodeSearchBundle\Helper\SearchTypeInterface;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\ContentPageAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}content_pages')]
+{% else %}
 /**
- * ContentPage
- *
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}content_pages")
  */
+{% endif %}
 class ContentPage extends AbstractPage implements HasPageTemplateInterface, SearchTypeInterface
 {
 {% if demosite %}
     /**
-     * @var \Kunstmaan\MediaBundle\Entity\Media
+     * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="menu_image_id", referencedColumnName="id")
      * })
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+{% endif %}
     private $menuImage;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="menu_description", type="text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'menu_description', type: Types::TEXT, nullable: true)]
+{% endif %}
     private $menuDescription;
 {% endif %}
+
     /**
      * Returns the default backend form type for this page
      *
@@ -60,7 +76,7 @@ class ContentPage extends AbstractPage implements HasPageTemplateInterface, Sear
 
 {% if demosite %}
     /**
-     * @param \Kunstmaan\MediaBundle\Entity\Media $icon
+     * @param Media $icon
      */
     public function setMenuImage($image)
     {
@@ -68,7 +84,7 @@ class ContentPage extends AbstractPage implements HasPageTemplateInterface, Sear
     }
 
     /**
-     * @return \Kunstmaan\MediaBundle\Entity\Media
+     * @return Media
      */
     public function getMenuImage()
     {

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/FormPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/FormPage.php
@@ -8,10 +8,15 @@ use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\FormPageAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}form_pages')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}form_pages")
  */
+{% endif %}
 class FormPage extends AbstractFormPage implements HasPageTemplateInterface
 {
     public function getDefaultAdminType(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/HomePage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/HomePage.php
@@ -10,10 +10,15 @@ use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Symfony\Component\Form\AbstractType;
 use {{ namespace }}\Form\Pages\HomePageAdminType;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}home_pages')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}home_pages")
  */
+{% endif %}
 class HomePage extends AbstractPage implements HasPageTemplateInterface, SearchTypeInterface, HomePageInterface
 {
     public function getDefaultAdminType(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/SearchPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/Pages/SearchPage.php
@@ -9,10 +9,15 @@ use Kunstmaan\NodeSearchBundle\Search\AbstractElasticaSearcher;
 use Kunstmaan\PagePartBundle\Helper\HasPageTemplateInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity()]
+#[ORM\Table(name: '{{ prefix }}search_pages')]
+{% else %}
 /**
  * @ORM\Entity()
  * @ORM\Table(name="{{ prefix }}search_pages")
  */
+{% endif %}
 class SearchPage extends AbstractSearchPage implements HasPageTemplateInterface
 {
     public function getDefaultView(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/UspItem.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/Entity/UspItem.php
@@ -4,57 +4,107 @@ namespace {{ namespace }}\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\AdminBundle\Entity\AbstractEntity;
+use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\Validator\Constraints as Assert;
 use {{ namespace }}\Entity\PageParts\UspPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}usp_item')]
+{% else %}
 /**
  * @ORM\Table(name="{{ prefix }}usp_item")
  * @ORM\Entity
  */
+{% endif %}
 class UspItem extends AbstractEntity
 {
     /**
-     * @var \Kunstmaan\MediaBundle\Entity\Media
+     * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="icon_id", referencedColumnName="id")
      * })
+{% if canUseAttributes == false %}
      * @Assert\NotNull()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotNull]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'icon_id', referencedColumnName: 'id')]
+{% endif %}
     private $icon;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="title", type="string", length=255, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'title', type: 'string', length: 255, nullable: true)]
+{% endif %}
     private $title;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="description", type="text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'description', type: 'text', nullable: true)]
+{% endif %}
     private $description;
 
     /**
      * @var integer
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="weight", type="integer", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'weight', type: 'integer', nullable: true)]
+{% endif %}
     private $weight;
 
     /**
+     * @var UspPagePart
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\ManyToOne(targetEntity="\{{ namespace }}\Entity\PageParts\UspPagePart", inversedBy="items")
      * @ORM\JoinColumn(name="usp_pp_id", referencedColumnName="id")
-     **/
+{% endif %}
+     */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: UspPagePart::class, inversedBy: 'items')]
+    #[ORM\JoinColumn(name: 'usp_pp_id', referencedColumnName: 'id')]
+{% endif %}
     private $uspPagePart;
 
     /**
-     * @param \Kunstmaan\MediaBundle\Entity\Media $icon
+     * @param Media $icon
      */
     public function setIcon($icon)
     {
@@ -62,7 +112,7 @@ class UspItem extends AbstractEntity
     }
 
     /**
-     * @return \Kunstmaan\MediaBundle\Entity\Media
+     * @return Media
      */
     public function getIcon()
     {

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractFormPagePart/AbstractFormPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractFormPagePart/AbstractFormPagePart.php
@@ -14,11 +14,21 @@ use Symfony\Component\Validator\Constraints as Assert;
 abstract class {{ pagepart }} extends AbstractPagePart implements FormAdaptorInterface
 {
     /**
-     * The label
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
-     * @ORM\Column(type="string")
+     * @ORM\Column(name="label", type="string")
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'label', type: 'string')]
+{% endif %}
     protected $label;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractPagePart/AbstractPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AbstractPagePart/AbstractPagePart.php
@@ -2,10 +2,9 @@
 
 namespace {{ namespace }}\Entity\PageParts;
 
-/**
- * {{ pagepart }}
- */
-abstract class {{ pagepart }} extends \Kunstmaan\PagePartBundle\Entity\AbstractPagePart
+use Kunstmaan\PagePartBundle\Entity\AbstractPagePart as BaseAbstractPagePart;
+
+abstract class {{ pagepart }} extends BaseAbstractPagePart
 {
 
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AudioPagePart/AudioPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/AudioPagePart/AudioPagePart.php
@@ -5,18 +5,29 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 
+
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var Media
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumn(name="media_id", referencedColumnName="id")
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+{% endif %}
     protected $media;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ButtonPagePart/ButtonPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ButtonPagePart/ButtonPagePart.php
@@ -5,59 +5,117 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_text", type="string", length=255, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_text', type: 'string', length: 255, nullable: true)]
+{% endif %}
     private $linkText;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_url", type="string", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_url', type: 'string', nullable: true)]
+{% endif %}
     private $linkUrl;
 
     /**
-     * @var boolean
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="link_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $linkNewWindow;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="type", type="string", length=15, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'type', type: 'string', length: 15, nullable: true)]
+{% endif %}
     private $type;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="size", type="string", length=15, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'size', type: 'string', length: 15, nullable: true)]
+{% endif %}
     private $size;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(name="position", type="string", length=15, nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'position', type: 'string', length: 15, nullable: true)]
+{% endif %}
     private $position;
 
     const TYPE_PRIMARY = 'primary';
@@ -80,34 +138,34 @@ class {{ pagepart }} extends AbstractPagePart
     /**
      * @var array Supported types
      */
-    public static $types = array(
+    public static $types = [
         self::TYPE_PRIMARY,
         self::TYPE_SECONDARY,
         self::TYPE_TERTIARY,
         self::TYPE_QUATERNARY,
-        self::TYPE_LINK
-    );
+        self::TYPE_LINK,
+    ];
 
     /**
      * @var array Supported sizes
      */
-    public static $sizes = array(
+    public static $sizes = [
         self::SIZE_EXTRA_LARGE,
         self::SIZE_LARGE,
         self::SIZE_DEFAULT,
         self::SIZE_SMALL,
-        self::SIZE_EXTRA_SMALL
-    );
+        self::SIZE_EXTRA_SMALL,
+    ];
 
     /**
      * @var array Supported positions
      */
-    public static $positions = array(
+    public static $positions = [
         self::POSITION_LEFT,
         self::POSITION_CENTER,
         self::POSITION_RIGHT,
-        self::POSITION_BLOCK
-    );
+        self::POSITION_BLOCK,
+    ];
 
     public function __construct()
     {

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/CheckboxPagePart/CheckboxPagePart.php
@@ -10,33 +10,57 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
      *
-     * @ORM\Column(type="string", name="error_message_required", nullable=true)
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
+     * @ORM\Column(name="error_message_required", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
-     * @ORM\Column(type="string", name="internal_name", nullable=true)
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
+     * @ORM\Column(name="internal_name", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ChoicePagePart/ChoicePagePart.php
@@ -10,20 +10,30 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
      * If set to true, radio buttons or checkboxes will be rendered (depending on the multiple value). If false,
      * a select element will be rendered.
      *
+     * @var bool
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $expanded = false;
 
     /**
@@ -31,15 +41,29 @@ class {{ pagepart }} extends AbstractFormPagePart
      * Depending on the value of the expanded option, this will render either a select tag or checkboxes
      * if true and a select tag or radio buttons if false. The returned value will be an array.
      *
+     * @var bool
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $multiple = false;
 
     /**
      * The choices that should be used by this field. The choices can be entered separated by a new line.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'text', nullable: true)]
+{% endif %}
     protected $choices;
 
     /**
@@ -47,29 +71,57 @@ class {{ pagepart }} extends AbstractFormPagePart
      * will appear at the top of a select widget. This option only applies if both the expanded and
      * multiple options are set to false.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="empty_value", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'empty_value', type: 'string', nullable: true)]
+{% endif %}
     protected $emptyValue;
 
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="internal_name", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/DownloadPagePart/DownloadPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/DownloadPagePart/DownloadPagePart.php
@@ -5,18 +5,29 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var Media
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumn(name="media_id", referencedColumnName="id")
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id')]
+{% endif %}
     protected $media;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EditableImagePagePart/EditableImagePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EditableImagePagePart/EditableImagePagePart.php
@@ -6,39 +6,83 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\EditableMediaWrapper;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var EditableMediaWrapper
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\EditableMediaWrapper", cascade={"persist"})
      * @ORM\JoinColumn(name="media_wrapper_id", referencedColumnName="id")
+{% if canUseAttributes == false %}
      * @Assert\Valid()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\Valid]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: EditableMediaWrapper::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'media_wrapper_id', referencedColumnName: 'id')]
+{% endif %}
     private $mediaWrapper;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="caption", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'caption', type: 'string', nullable: true)]
+{% endif %}
     private $caption;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="alt_text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'alt_text', type: 'string', nullable: true)]
+{% endif %}
     private $altText;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="link", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link', type: 'string', nullable: true)]
+{% endif %}
     private $link;
 
     /**
+     * @var bool
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="open_in_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'open_in_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $openInNewWindow;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/EmailPagePart/EmailPagePart.php
@@ -11,40 +11,71 @@ use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
-     * Error message shows when the value is invalid
+     * Error message shows when the value is invalid.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_invalid", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageInvalid;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="internal_name", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ExtraFunctions.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ExtraFunctions.php
@@ -1,19 +1,9 @@
-    /**
-     * Get the twig view.
-     *
-     * @return string
-     */
-    public function getDefaultView()
+    public function getDefaultView(): string
     {
         return '{% if not isV4 %}{{ bundle }}:{%endif%}PageParts/{{ pagepart }}{% if not isV4 %}:{% else %}/{% endif %}view.html.twig';
     }
 
-    /**
-     * Get the admin form type.
-     *
-     * @return string
-     */
-    public function getDefaultAdminType()
+    public function getDefaultAdminType(): string
     {
         return {{ adminType }}::class;
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/FileUploadPagePart/FileUploadPagePart.php
@@ -10,33 +10,57 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="internal_name", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/HeaderPagePart/HeaderPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/HeaderPagePart/HeaderPagePart.php
@@ -5,30 +5,57 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="niv", type="integer", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank(message="headerpagepart.niv.not_blank")
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank(message: 'headerpagepart.niv.not_blank')]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'niv', type: 'integer', nullable: true)]
+{% endif %}
     private $niv;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="title", type="string", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank(message="headerpagepart.title.not_blank")
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank(message: 'headerpagepart.title.not_blank')]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'title', type: 'string', nullable: true)]
+{% endif %}
     private $title;
 
     /**
      * @var array Supported header sizes
      */
-    public static $supportedHeaders = array(1, 2, 3, 4, 5, 6);
+    public static $supportedHeaders = [1, 2, 3, 4, 5, 6];
 
     /**
      * Set niv

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ImagePagePart/ImagePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ImagePagePart/ImagePagePart.php
@@ -6,39 +6,83 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var Media
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumn(name="media_id", referencedColumnName="id")
+{% if canUseAttributes == false %}
      * @Assert\NotNull()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotNull]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id')]
+{% endif %}
     private $media;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="caption", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'caption', type: 'string', nullable: true)]
+{% endif %}
     private $caption;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="alt_text", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'alt_text', type: 'string', nullable: true)]
+{% endif %}
     private $altText;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="link", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'link', type: 'string', nullable: true)]
+{% endif %}
     private $link;
 
     /**
+     * @var bool
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="open_in_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'open_in_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $openInNewWindow;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/IntroTextPagePart/IntroTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/IntroTextPagePart/IntroTextPagePart.php
@@ -5,20 +5,33 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
-     * @ORM\Column(name="content", type="text", nullable=false)
+     * @ORM\Column(name="content", type="text")
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'content', type: 'text')]
+{% endif %}
     private $content;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/LinePagePart/LinePagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/LinePagePart/LinePagePart.php
@@ -4,12 +4,15 @@ namespace {{ namespace }}\Entity\PageParts;
 
 use Doctrine\ORM\Mapping as ORM;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/LinkPagePart/LinkPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/LinkPagePart/LinkPagePart.php
@@ -5,29 +5,63 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="url", type="string", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'url', type: 'string', nullable: true)]
+{% endif %}
     private $url;
 
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="text", type="string", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'text', type: 'string', nullable: true)]
+{% endif %}
     private $text;
 
     /**
+     * @var bool
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(name="open_in_new_window", type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'open_in_new_window', type: 'boolean', nullable: true)]
+{% endif %}
     private $openInNewWindow;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/MultiLineTextPagePart/MultiLineTextPagePart.php
@@ -11,47 +11,85 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
+     *
+     * @var string
+    {% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
-     * If set the entered value will be matched with this regular expression
+     * If set the entered value will be matched with this regular expression.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'string', nullable: true)]
+{% endif %}
     protected $regex;
 
     /**
-     * If a regular expression is set and it doesn't match with the given value, this error message will be shown
+     * If a regular expression is set and it doesn't match with the given value, this error message will be shown.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_regex', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRegex;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="internal_name", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/RawHtmlPagePart/RawHtmlPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/RawHtmlPagePart/RawHtmlPagePart.php
@@ -5,18 +5,33 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="text", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'text', nullable: true)]
+{% endif %}
     protected $content;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SingleLineTextPagePart/SingleLineTextPagePart.php
@@ -11,47 +11,85 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 use Kunstmaan\FormBundle\Entity\PageParts\AbstractFormPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractFormPagePart
 {
     /**
-     * If set to true, you are obligated to fill in this page part
+     * If set to true, you are obligated to fill in this page part.
+     *
+     * @var bool
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="boolean", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'boolean', nullable: true)]
+{% endif %}
     protected $required = false;
 
     /**
-     * Error message shows when the page part is required and nothing is filled in
+     * Error message shows when the page part is required and nothing is filled in.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_required", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_required', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRequired;
 
     /**
-     * If set the entered value will be matched with this regular expression
+     * If set the entered value will be matched with this regular expression.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'string', nullable: true)]
+{% endif %}
     protected $regex;
 
     /**
-     * If a regular expression is set and it doesn't match with the given value, this error message will be shown
+     * If a regular expression is set and it doesn't match with the given value, this error message will be shown.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", name="error_message_regex", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'error_message_regex', type: 'string', nullable: true)]
+{% endif %}
     protected $errorMessageRegex;
 
     /**
      * Internal name that can be used with form submission subscribers.
      *
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="string", name="internal_name", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'internal_name', type: 'string', nullable: true)]
+{% endif %}
     protected $internalName;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SubmitButtonPagePart/SubmitButtonPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/SubmitButtonPagePart/SubmitButtonPagePart.php
@@ -5,20 +5,30 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\PagePartBundle\Entity\AbstractPagePart;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
 
     /**
-     * The label on the submit button
+     * The label on the submit button.
+     *
+     * @var string
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\Column(type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'string', nullable: true)]
+{% endif %}
     protected $label;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/TextPagePart/TextPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/TextPagePart/TextPagePart.php
@@ -5,18 +5,33 @@ namespace {{ namespace }}\Entity\PageParts;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
+     * @var string
+{% if canUseEntityAttributes == false %}
+     *
      * @ORM\Column(type="text", nullable=true)
+{% if canUseAttributes == false %}
      * @Assert\NotBlank()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotBlank]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\Column(type: 'text', nullable: true)]
+{% endif %}
     private $content;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ToTopPagePart/ToTopPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/ToTopPagePart/ToTopPagePart.php
@@ -4,12 +4,15 @@ namespace {{ namespace }}\Entity\PageParts;
 
 use Doctrine\ORM\Mapping as ORM;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/TocPagePart/TocPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/TocPagePart/TocPagePart.php
@@ -4,12 +4,15 @@ namespace {{ namespace }}\Entity\PageParts;
 
 use Doctrine\ORM\Mapping as ORM;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
- * {{ pagepart }}
- *
- * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  * @ORM\Entity
+ * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/VideoPagePart/VideoPagePart.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/pagepart/Entity/PageParts/VideoPagePart/VideoPagePart.php
@@ -6,36 +6,63 @@ use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\MediaBundle\Entity\Media;
 use Symfony\Component\Validator\Constraints as Assert;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}{{ underscoreName }}s')]
+{% else %}
 /**
  * @ORM\Entity
  * @ORM\Table(name="{{ prefix }}{{ underscoreName }}s")
  */
+{% endif %}
 class {{ pagepart }} extends AbstractPagePart
 {
     /**
      * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumn(name="video_media_id", referencedColumnName="id")
+{% if canUseAttributes == false %}
      * @Assert\NotNull()
+{% endif %}
+{% endif %}
      */
+{% if canUseAttributes %}
+    #[Assert\NotNull]
+{% endif %}
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'video_media_id', referencedColumnName: 'id')]
+{% endif %}
     protected $video;
 
     /**
      * @var string
+{% if canUseEntityAttributes == false %}
      *
-     * @ORM\Column(type="string", name="caption", nullable=true)
+     * @ORM\Column(name="caption", type="string", nullable=true)
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\Column(name: 'caption', type: 'string', nullable: true)]
+{% endif %}
     protected $caption;
 
     /**
      * @var Media
+{% if canUseEntityAttributes == false %}
      *
      * @ORM\ManyToOne(targetEntity="Kunstmaan\MediaBundle\Entity\Media")
      * @ORM\JoinColumns({
      *   @ORM\JoinColumn(name="thumbnail_media_id", referencedColumnName="id")
      * })
+{% endif %}
      */
+{% if canUseEntityAttributes %}
+    #[ORM\ManyToOne(targetEntity: Media::class)]
+    #[ORM\JoinColumn(name: 'thumbnail_media_id', referencedColumnName: 'id')]
+{% endif %}
     protected $thumbnail;
 
     /**

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/Entity/Pages/SearchPage.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/Entity/Pages/SearchPage.php
@@ -5,10 +5,15 @@ namespace {{ namespace }}\Entity\Pages;
 use Doctrine\ORM\Mapping as ORM;
 use Kunstmaan\NodeSearchBundle\Entity\AbstractSearchPage;
 
+{% if canUseEntityAttributes %}
+#[ORM\Entity]
+#[ORM\Table(name: '{{ prefix }}search_pages')]
+{% else %}
 /**
  * @ORM\Entity()
- * @ORM\Table(name="{{ prefix }}search_page")
+ * @ORM\Table(name="{{ prefix }}search_pages")
  */
+{% endif %}
 class SearchPage extends AbstractSearchPage
 {
     public function getDefaultView(): string

--- a/src/Kunstmaan/GeneratorBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/GeneratorBundle/Resources/config/services.yml
@@ -4,14 +4,20 @@ services:
             - { name: console.command }
 
     Kunstmaan\GeneratorBundle\Command\GenerateDefaultSiteCommand:
+        arguments:
+            - '@maker.doctrine_helper'
         tags:
             - { name: console.command }
 
     Kunstmaan\GeneratorBundle\Command\GenerateDefaultPagePartsCommand:
+        arguments:
+            - '@maker.doctrine_helper'
         tags:
             - { name: console.command }
 
     Kunstmaan\GeneratorBundle\Command\GenerateArticleCommand:
+        arguments:
+            - '@maker.doctrine_helper'
         tags:
             - { name: console.command }
 
@@ -28,10 +34,14 @@ services:
             - { name: console.command }
 
     Kunstmaan\GeneratorBundle\Command\GenerateFormPagePartsCommand:
+        arguments:
+            - '@maker.doctrine_helper'
         tags:
             - { name: console.command }
 
     Kunstmaan\GeneratorBundle\Command\GenerateSearchPageCommand:
+        arguments:
+            - '@maker.doctrine_helper'
         tags:
             - { name: console.command }
 

--- a/src/Kunstmaan/GeneratorBundle/composer.json
+++ b/src/Kunstmaan/GeneratorBundle/composer.json
@@ -26,7 +26,8 @@
         "kunstmaan/media-pagepart-bundle": "^5.9|^6.0",
         "kunstmaan/node-bundle": "^5.9|^6.0",
         "kunstmaan/pagepart-bundle": "^5.9|^6.0",
-        "kunstmaan/sensio-generator-bundle": "^3.2"
+        "kunstmaan/sensio-generator-bundle": "^3.2",
+        "symfony/maker-bundle": "^1.39"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

`Generate:page` and `generate:pagepart` are not using php8 attributes as they use the Doctrine EntityGenerator (which is deprecated and doesn't support php 8 attributes). We will need to replace them with a maker command where we have move control over the used class templates. Most of the other generated files are updated to support php 8 attributes when they can be used (Symfony constraints/route etc: php8+ and symfony 5.2+ and doctrine mapping type = attribute for entities)