### PR TITLE
[NodeBundle] Temporary disable csrf check on delete because conflict with other page types

### DIFF
--- a/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
+++ b/src/Kunstmaan/NodeBundle/Controller/NodeAdminController.php
@@ -394,10 +394,6 @@ final class NodeAdminController extends Controller
      */
     public function deleteAction(Request $request, $id)
     {
-        if (!$this->isCsrfTokenValid('node-delete', $request->request->get('token'))) {
-            return new RedirectResponse($this->generateUrl('KunstmaanNodeBundle_nodes_edit', ['id' => $id]));
-        }
-
         $this->init($request);
         /* @var Node $node */
         $node = $this->em->getRepository(Node::class)->find($id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

The current implementation/check is incompatible with deleting nodes in a separate adminlist (for example acrticle pages nodes managed in a separate adminlist instead of the page tree). This makes it impossible to use the delete action from an adminlist managing nodes.

So we temporary remove the crsf check there until a correct workaround/implementation is provided