### PR TITLE
[AllBundles] Fix issues on doctrine/dbal 3 where gedmo TreeRepository class triggers db connection

### DIFF
--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -58,6 +58,9 @@ services:
         class:            Kunstmaan\MediaBundle\Repository\FolderRepository
         factory:          ['@doctrine.orm.entity_manager', getRepository]
         arguments:        ['KunstmaanMediaBundle:Folder']
+        # This is needed to avoid triggering acl listeners that need a db connection,
+        # this caused by \Gedmo\Tree\Entity\Repository\AbstractTreeRepository::__constructor.
+        lazy: true
 
     kunstmaan_media.menu.adaptor:
         class: Kunstmaan\MediaBundle\Helper\Menu\MediaMenuAdaptor

--- a/src/Kunstmaan/MenuBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MenuBundle/Resources/config/services.yml
@@ -24,6 +24,9 @@ services:
         class: Kunstmaan\MenuBundle\Repository\MenuItemRepository
         factory: ['@doctrine.orm.entity_manager', getRepository]
         arguments: ['%kunstmaan_menu.entity.menuitem.class%']
+        # This is needed to avoid triggering acl listeners that need a db connection,
+        # this caused by \Gedmo\Tree\Entity\Repository\AbstractTreeRepository::__constructor.
+        lazy: true
 
     kunstmaan_menu.menu.twig.extension:
         class: Kunstmaan\MenuBundle\Twig\MenuTwigExtension


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

https://github.com/doctrine-extensions/DoctrineExtensions/blob/eba30ae439fe139ebdf7ffa52e7de45390731e34/src/Tree/Entity/Repository/AbstractTreeRepository.php#L44-L52

This triggers the symfony/acl listener which needs a DB connection, by making both repositories lazy an active DB connection is not needed during a cache:clear