### PR TITLE
[RedirectBundle] Save empty domain so redirect router catches all incoming domains for project

### DIFF
--- a/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
+++ b/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
@@ -27,9 +27,8 @@ class RedirectAdminType extends AbstractType
                 'multiple' => false,
             ]);
         } else {
-            $host = $options['domainConfiguration']->getHost();
             $builder->add('domain', HiddenType::class, [
-                'data' => $host,
+                'data' => '',
             ]);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When a website doesn't have a multidomain bundle setup the domain saved in the redirects table should be empty. This will make sure redirects also work for alias domains setup. So that maindomain.tld and aliasdomain.tld will both serve the redirects setup in the cms.