### PR TITLE
[AdminBundle] AsMenuAdaptor attribute to easily define menu adaptors with custom priorities

### DIFF
--- a/src/Kunstmaan/AdminBundle/Attribute/AsMenuAdaptor.php
+++ b/src/Kunstmaan/AdminBundle/Attribute/AsMenuAdaptor.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kunstmaan\AdminBundle\Attribute;
+
+/**
+ * Service tag to autoconfigure menu adaptors.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsMenuAdaptor
+{
+    public function __construct(
+        public int $priority = 0,
+    ) {
+    }
+}

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -3,12 +3,14 @@
 namespace Kunstmaan\AdminBundle\DependencyInjection;
 
 use InvalidArgumentException;
+use Kunstmaan\AdminBundle\Attribute\AsMenuAdaptor;
 use Kunstmaan\AdminBundle\Helper\Menu\MenuAdaptorInterface;
 use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService;
 use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService;
 use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -73,6 +75,11 @@ class KunstmaanAdminExtension extends Extension
 
         $container->registerForAutoconfiguration(MenuAdaptorInterface::class)
             ->addTag('kunstmaan_admin.menu.adaptor');
+
+        $container->registerAttributeForAutoconfiguration(AsMenuAdaptor::class, static function (ChildDefinition $definition, AsMenuAdaptor $attribute, \Reflector $reflector) {
+            $tagAttributes = get_object_vars($attribute);
+            $definition->addTag('kunstmaan_admin.menu.adaptor', $tagAttributes);
+        });
 
         if (!empty($config['enable_console_exception_listener']) && $config['enable_console_exception_listener']) {
             $loader->load('console_listener.yml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

With the new attribute you can control the menu priority without the need to add a service definition for it.

```php
#[AsMenuAdaptor(priority: 100)]
class MenuAdaptor implements MenuAdaptorInterface
{
//...
}
```