### PR TITLE
[Dashboardbundle] Explicit int cast to avoid php 8.1 warning

### DIFF
--- a/src/Kunstmaan/DashboardBundle/Command/Helper/Analytics/MetricsCommandHelper.php
+++ b/src/Kunstmaan/DashboardBundle/Command/Helper/Analytics/MetricsCommandHelper.php
@@ -37,6 +37,6 @@ class MetricsCommandHelper extends AbstractAnalyticsCommandHelper
 
         // avg visit duration metric
         $avgVisitDuration = \is_array($rows) && is_numeric($rows[0][4]) ? $rows[0][4] : 0;
-        $overview->setAvgSessionDuration(gmdate('H:i:s', $avgVisitDuration));
+        $overview->setAvgSessionDuration(gmdate('H:i:s', (int) $avgVisitDuration));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Avoid php 8.1 warning `Deprecated: Implicit conversion from float-string "99.71709233791749" to int loses precision`