### PR TITLE
[AllBundles] Revert: "Add php 8.2 to build matrix"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2']
+                php: ['8.0', '8.1']
                 deps: ['stable']
                 symfony: [''] # Don't lock to a specific symfony version by default
                 include:

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/ListWidgetTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/FormWidgets/ListWidgetTest.php
@@ -2,23 +2,31 @@
 
 namespace Kunstmaan\AdminBundle\Tests\Helper\FormWidgets;
 
+use ArrayIterator;
 use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\FormWidget;
 use Kunstmaan\AdminBundle\Helper\FormWidgets\ListWidget;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 
 class ListWidgetTest extends TestCase
 {
     public function testWidget()
     {
+        $views = new ArrayIterator();
+        $views->vars = ['errors' => [new FormError('bang')]];
+        $view = new FakeView();
+        $view->offsetSet('a', $views);
+
         $widget = $this->createMock(FormWidget::class);
         $builder = $this->createMock(FormBuilder::class);
         $em = $this->createMock(EntityManager::class);
 
         $widget->expects($this->exactly(2))->method('bindRequest')->willReturn(true);
         $widget->expects($this->exactly(2))->method('persist')->willReturn(true);
+        $widget->expects($this->exactly(2))->method('getFormErrors')->willReturn(['error' => 'argh']);
         $widget->expects($this->exactly(2))->method('getExtraParams')->willReturn(['x' => 'y']);
         $widget->expects($this->exactly(2))->method('buildForm')->willReturn(true);
 
@@ -31,6 +39,7 @@ class ListWidgetTest extends TestCase
         $listWidget->buildForm($builder);
         $listWidget->persist($em);
 
+        $this->assertCount(1, $listWidget->getFormErrors($view));
         $this->assertEquals('@KunstmaanAdmin/FormWidgets/ListWidget/widget.html.twig', $listWidget->getTemplate());
         $this->assertCount(1, $listWidget->getExtraParams(new Request()));
     }

--- a/src/Kunstmaan/TranslatorBundle/Tests/Service/Translator/LoaderTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Service/Translator/LoaderTest.php
@@ -14,9 +14,6 @@ class LoaderTest extends TestCase
     const TEST_DATA_KEYWORD = 'validation.ok';
     const TEST_DATA_TEXT = 'Everything ok';
 
-    /** @var Loader */
-    private $loader;
-
     public function setUp(): void
     {
         $translation = new Translation();


### PR DESCRIPTION
Reverts Kunstmaan/KunstmaanBundlesCMS#3193 as the openspout dependency in 6.x doesn't allow php 8.2 yet and this will always make this build fail