### PR TITLE
[AllBundles] Deprecate swiftmailer dependency

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -5,6 +5,16 @@ General
 -------
 
 - The supported Symfony version is 5.4.
+- Make sure to switch your swiftmailer email config to symfony mailer config after upgrading to avoid breaking email sending from the CMS. 
+  To avoid any BC breaks the `Kunstmaan\FormBundle\Helper\FormMailer` still uses swiftmailer as the default mailer. 
+  If you want to supress the deprecation warning, alias `@kunstmaan_mailer` to the symfony mailer service. 
+  In 7.0 `@kunstmaan_mailer` will be removed and the symfony mailer will be used by default.
+
+AdminBundle
+-----------
+
+- The `Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService` authentication mailer service is deprecated, use `Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService` instead.
+- The default value of `kunstmaan_admin.authentication.mailer.service` will change to `Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService` in 7.0.
 
 RedirectBundle
 --------------

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/Configuration.php
@@ -4,7 +4,6 @@ namespace Kunstmaan\AdminBundle\DependencyInjection;
 
 use Kunstmaan\AdminBundle\Entity\Group;
 use Kunstmaan\AdminBundle\Entity\User;
-use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -44,7 +43,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('mailer')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('service')->defaultValue(SwiftmailerService::class)->end()
+                                ->scalarNode('service')->defaultNull()->end() // NEXT_MAJOR: switch default value to SymfonyMailerService::class
                                 ->scalarNode('from_address')->defaultValue('kunstmaancms@myproject.dev')->end()
                                 ->scalarNode('from_name')->defaultValue('Kunstmaan CMS')->end()
                                 ->end()

--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -166,6 +166,12 @@ class KunstmaanAdminExtension extends Extension
 
         $loader->load('authentication.yml');
 
+        if (null === $config['authentication']['mailer']['service']) {
+            trigger_deprecation('kunstmaan/admin-bundle', '6.3', 'The default value of "kunstmaan_admin.authentication.mailer.service" will change from "%s" to "%s" in 7.0, set the config to "%s" to avoid issues when upgrading to 7.0.', SwiftmailerService::class, SymfonyMailerService::class, SymfonyMailerService::class);
+        }
+
+        $config['authentication']['mailer']['service'] ??= SwiftmailerService::class;
+
         $container->setAlias('kunstmaan_admin.authentication.mailer', $config['authentication']['mailer']['service']);
 
         // Validate mailer config
@@ -179,6 +185,10 @@ class KunstmaanAdminExtension extends Extension
 
         if ($config['authentication']['mailer']['service'] === SwiftmailerService::class && !class_exists(SwiftmailerBundle::class)) {
             throw new LogicException('Swiftmailer support for the authentication mailer cannot be enabled as the component is not installed. Try running "composer require symfony/swiftmailer-bundle".');
+        }
+
+        if ($config['authentication']['mailer']['service'] === SwiftmailerService::class) {
+            trigger_deprecation('kunstmaan/admin-bundle', '6.3', 'The swiftmailer service for config "kunstmaan_admin.authentication.mailer.service" is deprecated, use "%s" service instead.', SymfonyMailerService::class);
         }
 
         // Cleanup mailer services

--- a/src/Kunstmaan/AdminBundle/Service/AuthenticationMailer/SwiftmailerService.php
+++ b/src/Kunstmaan/AdminBundle/Service/AuthenticationMailer/SwiftmailerService.php
@@ -8,6 +8,10 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+/**
+ * @deprecated since 6.3, use \Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService instead.
+ * NEXT_MAJOR remove swiftmailer composer dependency.
+ */
 final class SwiftmailerService implements AuthenticationMailerInterface
 {
     /** @var \Swift_Mailer */

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -5,7 +5,6 @@ namespace Kunstmaan\AdminBundle\Tests\DependencyInjection;
 use Kunstmaan\AdminBundle\DependencyInjection\Configuration;
 use Kunstmaan\AdminBundle\Entity\Group;
 use Kunstmaan\AdminBundle\Entity\User;
-use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -49,7 +48,7 @@ class ConfigurationTest extends TestCase
             'user_class' => User::class,
             'group_class' => Group::class,
             'mailer' => [
-                'service' => SwiftmailerService::class,
+                'service' => null,
                 'from_address' => 'kunstmaancms@myproject.dev',
                 'from_name' => 'Kunstmaan CMS',
             ],

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
@@ -3,6 +3,8 @@
 namespace Kunstmaan\AdminBundle\Tests\DependencyInjection;
 
 use Kunstmaan\AdminBundle\DependencyInjection\KunstmaanAdminExtension;
+use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService;
+use Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -42,6 +44,11 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
             'multi_language' => true,
             'required_locales' => 'nl|fr|en',
             'default_locale' => 'nl',
+            'authentication' => [
+                'mailer' => [
+                    'service' => SymfonyMailerService::class, // NEXT_MAJOR remove this config as it will be the default
+                ],
+            ],
         ]);
 
         $this->assertContainerBuilderHasParameter('version_checker.url', 'https://kunstmaancms.be/version-check');
@@ -101,6 +108,27 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
         $this->load(array_merge($this->getRequiredConfig(), ['authentication' => ['enable_new_authentication' => true]]));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedDefaultValueForAuthenticationMailerService()
+    {
+        $this->expectDeprecation('Since kunstmaan/admin-bundle 6.3: The default value of "kunstmaan_admin.authentication.mailer.service" will change from "Kunstmaan\AdminBundle\Service\AuthenticationMailer\SwiftmailerService" to "Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService" in 7.0, set the config to "Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService" to avoid issues when upgrading to 7.0.');
+        $this->expectDeprecation('Since kunstmaan/admin-bundle 6.3: The swiftmailer service for config "kunstmaan_admin.authentication.mailer.service" is deprecated, use "Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService" service instead.');
+
+        $this->load(array_merge($this->getRequiredConfig('authentication')));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedValueForAuthenticationMailerService()
+    {
+        $this->expectDeprecation('Since kunstmaan/admin-bundle 6.3: The swiftmailer service for config "kunstmaan_admin.authentication.mailer.service" is deprecated, use "Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService" service instead.');
+
+        $this->load(array_merge($this->getRequiredConfig(), ['authentication' => ['mailer' => ['service' => SwiftmailerService::class]]]));
+    }
+
     private function getRequiredConfig(string $excludeKey = null)
     {
         $requiredConfig = [
@@ -108,6 +136,11 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
             'multi_language' => true,
             'required_locales' => 'nl|fr|en',
             'default_locale' => 'nl',
+            'authentication' => [
+                'mailer' => [
+                    'service' => SymfonyMailerService::class, // NEXT_MAJOR remove this config as it will be the default
+                ],
+            ],
         ];
 
         if (array_key_exists($excludeKey, $requiredConfig)) {

--- a/src/Kunstmaan/FormBundle/Helper/FormMailer.php
+++ b/src/Kunstmaan/FormBundle/Helper/FormMailer.php
@@ -3,7 +3,9 @@
 namespace Kunstmaan\FormBundle\Helper;
 
 use Kunstmaan\FormBundle\Entity\FormSubmission;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Mailer\MailerInterface;
 use Twig\Environment;
 
 /**
@@ -11,7 +13,7 @@ use Twig\Environment;
  */
 class FormMailer implements FormMailerInterface
 {
-    /** @var \Swift_Mailer */
+    /** @var \Swift_Mailer|MailerInterface */
     private $mailer;
 
     /** @var Environment */
@@ -20,8 +22,16 @@ class FormMailer implements FormMailerInterface
     /** @var RequestStack */
     private $requestStack;
 
-    public function __construct(\Swift_Mailer $mailer, Environment $twig, RequestStack $requestStack)
+    public function __construct($mailer, Environment $twig, RequestStack $requestStack)
     {
+        if ($mailer instanceof \Swift_Mailer) {
+            trigger_deprecation('kunstmaan/form-bundle', '6.3', 'Passing a "\Swift_Mailer" instance for the first parameter in "%s" is deprecated and a Symfony mailer instance will be required in 7.0.', __METHOD__);
+        }
+
+        if (!$mailer instanceof \Swift_Mailer && !$mailer instanceof MailerInterface) {
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be an instance of "%s" or "%s", "%s" given.', __METHOD__, \Swift_Mailer::class, MailerInterface::class, \is_object($mailer) ? \get_class($mailer) : \gettype($mailer)));
+        }
+
         $this->mailer = $mailer;
         $this->twig = $twig;
         $this->requestStack = $requestStack;
@@ -39,19 +49,33 @@ class FormMailer implements FormMailerInterface
 
         $toArr = explode("\r\n", $to);
 
-        $message = (new \Swift_Message($subject))
-            ->setFrom($from)
-            ->setTo($toArr)
-            ->setBody(
-                $this->twig->render(
-                    '@KunstmaanForm/Mailer/mail.html.twig',
-                    [
-                        'submission' => $submission,
-                        'host' => $request->getScheme() . '://' . $request->getHttpHost(),
-                    ]
-                ),
-                'text/html'
-            );
+        if ($this->mailer instanceof \Swift_Mailer) {
+            // NEXT_MAJOR: Remove swiftmailer code
+            $message = (new \Swift_Message($subject))
+                ->setFrom($from)
+                ->setTo($toArr)
+                ->setBody(
+                    $this->twig->render(
+                        '@KunstmaanForm/Mailer/mail.html.twig',
+                        [
+                            'submission' => $submission,
+                            'host' => $request->getScheme() . '://' . $request->getHttpHost(),
+                        ]
+                    ),
+                    'text/html'
+                );
+        } else {
+            $message = (new TemplatedEmail())
+                ->from($from)
+                ->to(...$toArr)
+                ->subject($subject)
+                ->htmlTemplate('@KunstmaanForm/Mailer/mail.html.twig')
+                ->context([
+                    'submission' => $submission,
+                    'host' => null !== $request ? $request->getScheme() . '://' . $request->getHttpHost() : '',
+                ])
+            ;
+        }
         $this->mailer->send($message);
     }
 }

--- a/src/Kunstmaan/FormBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/FormBundle/Resources/config/services.yml
@@ -4,9 +4,11 @@ services:
         tags:
             -  { name: kunstmaan_admin.menu.adaptor }
 
+    kunstmaan_mailer: '@swiftmailer.mailer'
+
     kunstmaan_form.form_mailer:
         class: Kunstmaan\FormBundle\Helper\FormMailer
-        arguments: ['@mailer', '@twig', '@request_stack']
+        arguments: ['@kunstmaan_mailer', '@twig', '@request_stack']
         public: true
 
     kunstmaan_form.form_handler:

--- a/src/Kunstmaan/FormBundle/Tests/Helper/FormMailerTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/Helper/FormMailerTest.php
@@ -5,15 +5,57 @@ namespace Kunstmaan\FormBundle\Tests\Helper;
 use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\FormBundle\Helper\FormMailer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Mailer\MailerInterface;
 use Twig\Environment;
 
 class FormMailerTest extends TestCase
 {
-    public function testSendContactMail()
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testSendContactMailWithSwiftmailer()
     {
+        $this->expectDeprecation('Since kunstmaan/form-bundle 6.3: Passing a "\Swift_Mailer" instance for the first parameter in "Kunstmaan\FormBundle\Helper\FormMailer::__construct" is deprecated and a Symfony mailer instance will be required in 7.0.');
+
         $mailer = $this->createMock(\Swift_Mailer::class);
+        $twig = $this->createMock(Environment::class);
+        $request = $this->createMock(Request::class);
+        $requestStack = $this->createMock(RequestStack::class);
+
+        $mailer->expects($this->once())->method('send');
+        $request->expects($this->once())->method('getScheme')->willReturn('http');
+        $request->expects($this->once())->method('getHttpHost')->willReturn('example.com');
+        $requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
+
+        $formMailer = new FormMailer($mailer, $twig, $requestStack);
+
+        /** @var FormSubmission $formSubmission */
+        $formSubmission = $this->createMock(FormSubmission::class);
+
+        $formMailer->sendContactMail($formSubmission, 'from@example.com', 'to@example.com', 'subject');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSendContactMailWithInvalidMailer()
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument 1 passed to "Kunstmaan\FormBundle\Helper\FormMailer::__construct()" must be an instance of "Swift_Mailer" or "Symfony\Component\Mailer\MailerInterface", "stdClass" given.');
+
+        new FormMailer(new \stdClass(), $this->createMock(Environment::class), new RequestStack());
+    }
+
+    public function testSendContactMailWithSymfonyMailer()
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())->method('send');
+
         $twig = $this->createMock(Environment::class);
         $request = $this->createMock(Request::class);
         $requestStack = $this->createMock(RequestStack::class);

--- a/src/Kunstmaan/FormBundle/composer.json
+++ b/src/Kunstmaan/FormBundle/composer.json
@@ -22,7 +22,8 @@
         "kunstmaan/node-bundle": "^5.9|^6.0",
         "kunstmaan/pagepart-bundle": "^5.9|^6.0",
         "stof/doctrine-extensions-bundle": "^1.3",
-        "symfony/css-selector": "^5.4"
+        "symfony/css-selector": "^5.4",
+        "symfony/mailer": "^5.4"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.2.1",

--- a/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
+++ b/src/Kunstmaan/TranslatorBundle/Tests/app/config/config.yml
@@ -13,6 +13,9 @@ kunstmaan_admin:
     multi_language: true
     required_locales: 'nl|fr|en'
     default_locale: 'nl'
+    authentication:
+        mailer:
+            service: Kunstmaan\AdminBundle\Service\AuthenticationMailer\SymfonyMailerService
 
 kunstmaan_translator:
     managed_locales: ['nl','en','de']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

Swiftmailer is not maintained anymore and it is advised to switch to `symfony/mailer`