### PR TITLE
[MediaBundle] Fix pdf handler priority override of parent service value

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/PdfHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/PdfHandler.php
@@ -19,18 +19,6 @@ class PdfHandler extends FileHandler
     protected $pdfTransformer;
 
     /**
-     * Inject the root dir so we know the full path where we need to store the file.
-     *
-     * @param string $kernelRootDir
-     */
-    public function setMediaPath($kernelRootDir)
-    {
-        parent::setMediaPath($kernelRootDir);
-
-        $this->setWebPath(realpath(str_replace('/', DIRECTORY_SEPARATOR, $kernelRootDir . '/public/') . DIRECTORY_SEPARATOR));
-    }
-
-    /**
      * @param string $webPath
      */
     public function setWebPath($webPath)

--- a/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/pdf_preview.yml
@@ -9,9 +9,10 @@ services:
     kunstmaan_media.media_handlers.pdf:
         class: Kunstmaan\MediaBundle\Helper\File\PdfHandler
         parent: kunstmaan_media.media_handlers.file
-        arguments: [1, '@mime_types']
+        arguments:
+            index_0: 1 # Override the priority value of the parent service
         calls:
-            - [ setMediaPath, [ '%kernel.project_dir%' ] ]
+            - [ setWebPath, [ '%kernel.project_dir%/public' ] ]
             - [ setPdfTransformer, [ '@kunstmaan_media.pdf_transformer' ]]
         tags:
             -  { name: 'kunstmaan_media.media_handler' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Service definition was not setup correctly so the priority value was not set on the pdf handler