### PR TITLE
[AdminBundle] Store original url so images have the correct url when previewing in editor

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
+++ b/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
@@ -74,7 +74,8 @@ class MediaTokenTransformer implements DataTransformerInterface
 
                     return;
                 }
-
+                // keep url for reverse transform.
+                $element->setAttribute('data-' . $attribute, $attributeValue);
                 $element->setAttribute($attribute, $query['token']);
             }
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | #3224 

Refs #3224. Images do not get shown in the editor because the url is reduced to the token (i.e. src="[xxx]"). By storing the original url in data-src this gets handled propperly in the transform stage.

