### PR TITLE
[NodeBundle] Revert mysql groupby query change because of performance issues

### DIFF
--- a/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeRepository.php
@@ -301,11 +301,13 @@ SQL;
             ->where('n.deleted = false')
             ->addGroupBy('n.id');
 
-        $qb->addGroupBy('t.url')
-            ->addGroupby('t.id')
-            ->addGroupby('v.weight')
-            ->addGroupBy('v.title')
-            ->distinct();
+        if ($databasePlatformName === 'postgresql') {
+            $qb->addGroupBy('t.url')
+                ->addGroupby('t.id')
+                ->addGroupby('v.weight')
+                ->addGroupBy('v.title')
+                ->distinct();
+        }
 
         $qb->addOrderBy('weight', 'ASC')
             ->addOrderBy('title', 'ASC');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Revert changes from #3101 as the changes related to the groupBy clauses cause major slowdowns on larger cms sites. The original fix will be redeveloped to avoid these performance issues in a later release.