### PR TITLE
[TranslatorBundle] change in doctrine querybuilder on php8 systems caused our faulty expression to generate a non working query

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -243,6 +243,7 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
 
             // Apply text filter
             if (!\is_null($textValue) && !\is_null($textComparator)) {
+                $orExpressions = [];
                 foreach ($this->locales as $key => $locale) {
                     $uniqueId = 'txt_' . $key;
                     $expr = null;
@@ -287,9 +288,13 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
                             break;
                     }
 
-                    if (null !== $expr) {
-                        $this->queryBuilder->andWhere($this->queryBuilder->expr()->or($expr));
+                    if ($expr !== null) {
+                        $orExpressions[] = $expr;
                     }
+                }
+
+                if ($orExpressions !== []) {
+                    $this->queryBuilder->andWhere($this->queryBuilder->expr()->or(...$orExpressions));
                 }
             }
 

--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -288,7 +288,7 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
                             break;
                     }
 
-                    if ($expr !== null) {
+                    if (null !== $expr) {
                         $orExpressions[] = $expr;
                     }
                 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
