### PR TITLE
[RedirectBundle] Improve performance of the redirect router

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -6,6 +6,39 @@ General
 
 - The supported Symfony version is 5.4.
 
+RedirectBundle
+--------------
+
+- The redirect-bundle has now some improved logic in the router itself. Using the old router logic is deprecated and the new will be the default in 7.0.
+  To enable the new and improved router, set the `kunstmaan_redirect.enable_improved_router` config to `true`.
+
+  This improved router has the following changes:
+  - Huge speed improvement with larger sets of cms redirects. See [#3239](https://github.com/Kunstmaan/KunstmaanBundlesCMS/pull/3239)
+  - Each redirect path in the database should start with a `/` so the improved redirect lookup will work. When migrating an existing website
+    to the new router setup, execute the following queries to prefix all redirects.
+    ```sql
+    UPDATE kuma_redirects SET origin = CONCAT('/', origin) WHERE origin NOT LIKE '/%';
+    UPDATE kuma_redirects SET target = CONCAT('/', target) WHERE target NOT LIKE '/%' AND target NOT LIKE '%://%';
+    ```
+  - Changed the wildcard redirect to be more correct for all usecases. See this comparisson in behaviour
+
+Old:
+
+| Origin  | Target  | Request url    | Result           |
+|---------|---------|----------------|------------------|
+| /news/* | /blog   | /news/article1 | /blog/article1   |
+| /news/* | /blog/* | /news/article1 | /blog/*/article1 |
+| /news   | /blog   | /news          | /blog            |
+
+New:
+
+| Origin  | Target  | Request url    | Result         |
+|---------|---------|----------------|----------------|
+| /news/* | /blog   | /news/article1 | /blog          |
+| /news/* | /blog/* | /news/article1 | /blog/article1 |
+| /news   | /blog   | /news          | /blog          |
+
+
 UtilitiesBundle
 ---------------
 

--- a/src/Kunstmaan/RedirectBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/RedirectBundle/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('redirect_entity')->defaultValue(Redirect::class)->end()
+                ->booleanNode('enable_improved_router')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/Kunstmaan/RedirectBundle/DependencyInjection/KunstmaanRedirectExtension.php
+++ b/src/Kunstmaan/RedirectBundle/DependencyInjection/KunstmaanRedirectExtension.php
@@ -18,5 +18,14 @@ class KunstmaanRedirectExtension extends Extension
         $loader->load('services.yml');
 
         $container->setParameter('kunstmaan_redirect.redirect.class', $config['redirect_entity']);
+
+        $enableImprovedRouter = $config['enable_improved_router'] ?? false;
+        $container->setParameter('.kunstmaan_redirect.enable_improved_router', $enableImprovedRouter);
+
+        if (!$enableImprovedRouter) {
+            trigger_deprecation('kunstmaan/redirect-bundle', '6.3', 'Not setting the "kunstmaan_redirect.enable_improved_router" config to true is deprecated, it will always be true in 7.0.');
+        }
+
+        $container->findDefinition('kunstmaan_redirect.redirectrouter')->addMethodCall('enableImprovedRouter', [$enableImprovedRouter]);
     }
 }

--- a/src/Kunstmaan/RedirectBundle/Form/EventSubscriber/RedirectPathNormalizerFormEventSubscriber.php
+++ b/src/Kunstmaan/RedirectBundle/Form/EventSubscriber/RedirectPathNormalizerFormEventSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kunstmaan\RedirectBundle\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Event\PreSubmitEvent;
+use Symfony\Component\Form\FormEvents;
+
+final class RedirectPathNormalizerFormEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FormEvents::PRE_SUBMIT => 'normalizeRedirectPath',
+        ];
+    }
+
+    public function normalizeRedirectPath(PreSubmitEvent $event): void
+    {
+        $path = $event->getData();
+        if (!$path) {
+            return;
+        }
+
+        if (null !== parse_url($path, \PHP_URL_SCHEME)) {
+            return;
+        }
+
+        $event->setData('/' . ltrim(trim($path), '/'));
+    }
+}

--- a/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
+++ b/src/Kunstmaan/RedirectBundle/Form/RedirectAdminType.php
@@ -2,6 +2,7 @@
 
 namespace Kunstmaan\RedirectBundle\Form;
 
+use Kunstmaan\RedirectBundle\Form\EventSubscriber\RedirectPathNormalizerFormEventSubscriber;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -54,6 +55,9 @@ class RedirectAdminType extends AbstractType
             'label' => 'redirect.form.redirect.note.label',
             'required' => false,
         ]);
+
+        $builder->get('origin')->addEventSubscriber(new RedirectPathNormalizerFormEventSubscriber());
+        $builder->get('target')->addEventSubscriber(new RedirectPathNormalizerFormEventSubscriber());
     }
 
     /**

--- a/src/Kunstmaan/RedirectBundle/Repository/RedirectRepository.php
+++ b/src/Kunstmaan/RedirectBundle/Repository/RedirectRepository.php
@@ -3,7 +3,30 @@
 namespace Kunstmaan\RedirectBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Kunstmaan\RedirectBundle\Entity\Redirect;
 
 class RedirectRepository extends EntityRepository
 {
+    public function findByRequestPathAndDomain(string $path, string $domain): ?Redirect
+    {
+        $conn = $this->_em->getConnection();
+        $qb = $conn->createQueryBuilder();
+
+        $qb
+            ->select('redirect.id')
+            ->from('kuma_redirects', 'redirect')
+            // This allows to easily match the current request path with wildcard origin values in the redirect table.
+            ->where(':path LIKE REPLACE(redirect.origin, \'*\', \'%\')')
+            ->andWhere($qb->expr()->or('redirect.domain IS NULL', 'redirect.domain = \'\'', 'redirect.domain = :domain'))
+            ->setParameter('path', $path)
+            ->setParameter('domain', $domain)
+        ;
+
+        $redirectId = method_exists($qb, 'executeQuery') ? $qb->executeQuery()->fetchOne() : $qb->execute()->fetchColumn();
+        if (null === $redirectId) {
+            return null;
+        }
+
+        return $this->find($redirectId);
+    }
 }

--- a/src/Kunstmaan/RedirectBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,8 +21,13 @@ class ConfigurationTest extends TestCase
 
     public function testProcessedValueContainsRequiredValue()
     {
-        $array = [];
+        $array = [
+            'enable_improved_router' => true,
+        ];
 
-        $this->assertProcessedConfigurationEquals([$array], ['redirect_entity' => Redirect::class]);
+        $this->assertProcessedConfigurationEquals([$array], [
+            'redirect_entity' => Redirect::class,
+            'enable_improved_router' => true,
+        ]);
     }
 }

--- a/src/Kunstmaan/RedirectBundle/Tests/DependencyInjection/KunstmaanRedirectExtensionTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/DependencyInjection/KunstmaanRedirectExtensionTest.php
@@ -22,15 +22,28 @@ class KunstmaanRedirectExtensionTest extends AbstractExtensionTestCase
 
     public function testRedirectClassParameterWithConfigValue()
     {
-        $this->load(['redirect_entity' => 'RedirectTestEntity']);
+        $this->load([
+            'redirect_entity' => 'RedirectTestEntity',
+            'enable_improved_router' => true,
+        ]);
 
         $this->assertContainerBuilderHasParameter('kunstmaan_redirect.redirect.class', 'RedirectTestEntity');
     }
 
     public function testDefaultRedirectClassParameter()
     {
-        $this->load();
+        $this->load(['enable_improved_router' => true]);
 
         $this->assertContainerBuilderHasParameter('kunstmaan_redirect.redirect.class', Redirect::class);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testImprovedRouterConfigDeprecation()
+    {
+        $this->expectDeprecation('Since kunstmaan/redirect-bundle 6.3: Not setting the "kunstmaan_redirect.enable_improved_router" config to true is deprecated, it will always be true in 7.0.');
+
+        $this->load();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #3228 

I've tested this with a fresh demo site setup in production mode and with a set of 100 000 redirects and this resulted in a huge improvement in both request time and memory usage.

Overview:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/1374857/208511236-71c0922a-c523-4c3f-bb51-b08888600b87.png">

Request time:
<img width="154" alt="image" src="https://user-images.githubusercontent.com/1374857/208511418-8ecc14ae-8be3-46ae-a820-07b5aedfb020.png">

Memory usage:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/1374857/208511338-af71f7ae-ea63-4f57-ab20-5c33bb736a4b.png">
