### PR TITLE
[MediaPagePartBundle] Fix empty urls

### DIFF
--- a/src/Kunstmaan/MediaPagePartBundle/Entity/AudioPagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/AudioPagePart.php
@@ -51,7 +51,7 @@ class AudioPagePart extends AbstractPagePart
     public function __toString()
     {
         if ($this->getMedia()) {
-            return $this->getMedia()->getUrl();
+            return $this->getMedia()->getUrl() ?? '';
         }
 
         return '';

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/DownloadPagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/DownloadPagePart.php
@@ -51,7 +51,7 @@ class DownloadPagePart extends AbstractPagePart
     public function __toString()
     {
         if ($this->getMedia()) {
-            return $this->getMedia()->getUrl();
+            return $this->getMedia()->getUrl() ?? '';
         }
 
         return '';

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/ImagePagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/ImagePagePart.php
@@ -138,7 +138,7 @@ class ImagePagePart extends AbstractPagePart
     public function __toString()
     {
         if ($this->getMedia()) {
-            return $this->getMedia()->getUrl();
+            return $this->getMedia()->getUrl() ?? '';
         }
 
         return '';

--- a/src/Kunstmaan/MediaPagePartBundle/Entity/SlidePagePart.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Entity/SlidePagePart.php
@@ -51,7 +51,7 @@ class SlidePagePart extends AbstractPagePart
     public function __toString()
     {
         if ($this->getMedia()) {
-            return $this->getMedia()->getUrl();
+            return $this->getMedia()->getUrl() ?? '';
         }
 
         return '';

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/AudioPagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/AudioPagePartTest.php
@@ -43,4 +43,11 @@ class AudioPagePartTest extends TestCase
         $defaultAdminType = $this->object->getDefaultAdminType();
         $this->assertEquals(AudioPagePartAdminType::class, $defaultAdminType);
     }
+
+    public function testEmptyUrl()
+    {
+        $media = new Media();
+        $this->object->setMedia($media);
+        $this->assertEquals('', $this->object->__toString());
+    }
 }

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/DownloadPagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/DownloadPagePartTest.php
@@ -42,4 +42,11 @@ class DownloadPagePartTest extends TestCase
     {
         $this->assertEquals(DownloadPagePartAdminType::class, $this->object->getDefaultAdminType());
     }
+
+    public function testEmptyUrl()
+    {
+        $media = new Media();
+        $this->object->setMedia($media);
+        $this->assertEquals('', $this->object->__toString());
+    }
 }

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/ImagePagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/ImagePagePartTest.php
@@ -62,4 +62,11 @@ class ImagePagePartTest extends TestCase
     {
         $this->assertEquals(ImagePagePartAdminType::class, $this->object->getDefaultAdminType());
     }
+
+    public function testEmptyUrl()
+    {
+        $media = new Media();
+        $this->object->setMedia($media);
+        $this->assertEquals('', $this->object->__toString());
+    }
 }

--- a/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/SlidePagePartTest.php
+++ b/src/Kunstmaan/MediaPagePartBundle/Tests/Entity/SlidePagePartTest.php
@@ -46,4 +46,11 @@ class SlidePagePartTest extends TestCase
         $this->object->setMedia($media);
         $this->assertEquals('https://nasa.gov/spongebob.jpg', $this->object->__toString());
     }
+
+    public function testEmptyUrl()
+    {
+        $media = new Media();
+        $this->object->setMedia($media);
+        $this->assertEquals('', $this->object->__toString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR


Kunstmaan\MediaPagePartBundle\Entity\AudioPagePart::__toString(): Return value must be of type string, null returned