### PR TITLE
[AdminBundle] Fix PHP Deprecated:  trim(): Passing null to parameter #1

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
+++ b/src/Kunstmaan/AdminBundle/Form/MediaTokenTransformer.php
@@ -14,7 +14,7 @@ class MediaTokenTransformer implements DataTransformerInterface
      */
     public function transform($content)
     {
-        if (!trim($content)) {
+        if (!$content || !trim($content)) {
             return '';
         }
 


### PR DESCRIPTION
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in PHP 8.2.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | none.
