### PR TITLE
[GeneratorBundle] Only enable tty on platforms supporting it

### DIFF
--- a/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
+++ b/src/Kunstmaan/GeneratorBundle/Command/InstallCommand.php
@@ -160,7 +160,9 @@ final class InstallCommand extends GeneratorCommand
         try {
             if ($separateProcess) {
                 $process = new Process(array_merge(['bin/console', $command], array_keys($options)));
-                $process->setTty(true);
+                if (Process::isTtySupported()) {
+                    $process->setTty(true);
+                }
                 $process->run();
 
                 if (!$process->isSuccessful()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | related to Kunstmaan/cms-skeleton#13

@brabo-dan can you check if this solves the error you got with the installer on windows?