### PR TITLE
[MultidomainBundle] Deprecation logout handler

### DIFF
--- a/UPGRADE-6.3.md
+++ b/UPGRADE-6.3.md
@@ -6,6 +6,11 @@ General
 
 - The supported Symfony version is 5.4.
 
+MultidomainBundle
+-----------------
+
+- The `Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler` class is deprecated and is replaced by the `Kunstmaan\MultiDomainBundle\EventSubscriber\LogoutHostOverrideCleanupEventSubscriber` subscriber with the new authentication system.
+
 RedirectBundle
 --------------
 

--- a/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
+++ b/src/Kunstmaan/MultiDomainBundle/Helper/HostOverrideCleanupHandler.php
@@ -2,11 +2,15 @@
 
 namespace Kunstmaan\MultiDomainBundle\Helper;
 
+use Kunstmaan\MultiDomainBundle\EventSubscriber\LogoutHostOverrideCleanupEventSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 
+/**
+ * @deprecated since 6.3. Will be removed in 7.0, the "Kunstmaan\MultiDomainBundle\EventSubscriber\LogoutHostOverrideCleanupEventSubscriber" will be used instead.
+ */
 class HostOverrideCleanupHandler implements LogoutHandlerInterface
 {
     /**
@@ -16,6 +20,7 @@ class HostOverrideCleanupHandler implements LogoutHandlerInterface
      */
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
+        trigger_deprecation('kunstmaan/multidomain-bundle', '6.3', 'The "%s" class is deprecated and is replaced by the "%s" subscriber with the new authentication system.', self::class, LogoutHostOverrideCleanupEventSubscriber::class);
         // Remove host override
         if ($request->hasPreviousSession() && $request->getSession()->has(DomainConfiguration::OVERRIDE_HOST)) {
             $request->getSession()->remove(DomainConfiguration::OVERRIDE_HOST);

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Helper/HostOverrideCleanupHandlerTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Helper/HostOverrideCleanupHandlerTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\MultiDomainBundle\Tests\Helper;
 use Kunstmaan\MultiDomainBundle\Helper\DomainConfiguration;
 use Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -15,11 +16,15 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
  */
 class HostOverrideCleanupHandlerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testLogoutWithoutOverride()
     {
         if (!interface_exists(\Symfony\Component\Security\Http\Logout\LogoutHandlerInterface::class)) {
             $this->markTestSkipped('This test should only run on symfony 5.4 and lower');
         }
+
+        $this->expectDeprecation('Since kunstmaan/multidomain-bundle 6.3: The "Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler" class is deprecated and is replaced by the "Kunstmaan\MultiDomainBundle\EventSubscriber\LogoutHostOverrideCleanupEventSubscriber" subscriber with the new authentication system.');
 
         $object = new HostOverrideCleanupHandler();
         $request = Request::create('/');
@@ -39,6 +44,8 @@ class HostOverrideCleanupHandlerTest extends TestCase
         if (!interface_exists(\Symfony\Component\Security\Http\Logout\LogoutHandlerInterface::class)) {
             $this->markTestSkipped('This test should only run on symfony 5.4 and lower');
         }
+
+        $this->expectDeprecation('Since kunstmaan/multidomain-bundle 6.3: The "Kunstmaan\MultiDomainBundle\Helper\HostOverrideCleanupHandler" class is deprecated and is replaced by the "Kunstmaan\MultiDomainBundle\EventSubscriber\LogoutHostOverrideCleanupEventSubscriber" subscriber with the new authentication system.');
 
         $object = new HostOverrideCleanupHandler();
         $session = new Session(new MockArraySessionStorage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | Fixes #3182

Correctly deprecate the LogoutHandler class, follow up of #2989