### PR TITLE
[RedirectBundle] Add order by to redirect admin list

### DIFF
--- a/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
+++ b/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
@@ -3,6 +3,7 @@
 namespace Kunstmaan\RedirectBundle\AdminList;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
@@ -90,5 +91,11 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     public function getEntityName()
     {
         return 'Redirect';
+    }
+
+    public function adaptQueryBuilder(QueryBuilder $queryBuilder)
+    {
+        parent::adaptQueryBuilder($queryBuilder);
+        $queryBuilder->orderBy('b.id', 'ASC');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

If you have 52 results then page 6 will display the first 2 results instead of the last 2.

Other option is to set fetchJoinCollection to false for the redirect overview. This requires some extra work because this is not configurable inside AbstractDoctrineORMAdminListConfigurator.