### PR TITLE
[SearchBundle, NodeSearchBundle] : change `nGram` to `ngram`

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -327,7 +327,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
         $ngramDiff = 1;
         if (isset($analysers['tokenizer']) && count($analysers['tokenizer']) > 0) {
             foreach ($analysers['tokenizer'] as $tokenizer) {
-                if ($tokenizer['type'] === 'ngram') {
+                if (\strtolower($tokenizer['type']) === 'ngram') {
                     $diff = $tokenizer['max_gram'] - $tokenizer['min_gram'];
 
                     $ngramDiff = $diff > $ngramDiff ? $diff : $ngramDiff;

--- a/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
+++ b/src/Kunstmaan/NodeSearchBundle/Configuration/NodePagesConfiguration.php
@@ -327,7 +327,7 @@ class NodePagesConfiguration implements SearchConfigurationInterface
         $ngramDiff = 1;
         if (isset($analysers['tokenizer']) && count($analysers['tokenizer']) > 0) {
             foreach ($analysers['tokenizer'] as $tokenizer) {
-                if ($tokenizer['type'] === 'nGram') {
+                if ($tokenizer['type'] === 'ngram') {
                     $diff = $tokenizer['max_gram'] - $tokenizer['min_gram'];
 
                     $ngramDiff = $diff > $ngramDiff ? $diff : $ngramDiff;

--- a/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
+++ b/src/Kunstmaan/SearchBundle/Search/AbstractAnalysisFactory.php
@@ -98,7 +98,7 @@ abstract class AbstractAnalysisFactory implements AnalysisFactoryInterface
     public function addNGramTokenizer()
     {
         $this->tokenizers['kuma_ngram'] = [
-            'type' => 'nGram',
+            'type' => 'ngram',
             'min_gram' => 4,
             'max_gram' => 30,
             'token_chars' => ['letter', 'digit', 'punctuation'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes|
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | NA

When using elastic search 8, elastica throws the following Exception

The [nGram] tokenizer name was deprecated in 7.6. Please use the tokenizer name to [ngram] for indices created in versions 8 or higher instead.

Version 7 uses ngram as well as nGram as can be seen here, https://www.elastic.co/guide/en/elasticsearch/reference/7.14/analysis-ngram-tokenizer.html#_example_output_13 , so this pull request simply lower cases the G's, which allows the search population command to successfully run again
