### PR TITLE
[AdminListBundle] Deprecate configurator getBundleName/getEntityName methods

### DIFF
--- a/src/Kunstmaan/AdminBundle/AdminList/ExceptionAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminBundle/AdminList/ExceptionAdminListConfigurator.php
@@ -105,11 +105,20 @@ class ExceptionAdminListConfigurator extends AbstractDoctrineORMAdminListConfigu
 
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/admin-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanAdminBundle';
     }
 
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/admin-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Exception';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Exception::class;
     }
 }

--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractPageAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractPageAdminListConfigurator.php
@@ -174,6 +174,11 @@ abstract class AbstractPageAdminListConfigurator extends AbstractDoctrineDBALAdm
      */
     public function getRepositoryName()
     {
+        // NEXT_MAJOR remove if and old sprintf return
+        if (!method_exists($this, 'getEntityClass')) {
+            return parent::getRepositoryName();
+        }
+
         return sprintf('%s:%s\%s', $this->getBundleName(), 'Pages', $this->getEntityName());
     }
 

--- a/src/Kunstmaan/AdminListBundle/Controller/AbstractAdminListController.php
+++ b/src/Kunstmaan/AdminListBundle/Controller/AbstractAdminListController.php
@@ -19,6 +19,7 @@ use Kunstmaan\AdminListBundle\Event\AdminListEvent;
 use Kunstmaan\AdminListBundle\Event\AdminListEvents;
 use Kunstmaan\AdminListBundle\Service\EntityVersionLockService;
 use Kunstmaan\AdminListBundle\Service\ExportService;
+use Kunstmaan\AdminListBundle\Utils\EntityDetails;
 use Kunstmaan\NodeBundle\Entity\HasNodeInterface;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
@@ -345,7 +346,7 @@ abstract class AbstractAdminListController extends AbstractController
         /** @var SlugifierInterface $slugifier */
         $slugifier = $this->container->get('kunstmaan_utilities.slugifier');
 
-        if (!$this->isCsrfTokenValid('delete-' . $slugifier->slugify($configurator->getEntityName()), $request->request->get('token'))) {
+        if (!$this->isCsrfTokenValid('delete-' . $slugifier->slugify(method_exists($configurator, 'getEntityClass') ? EntityDetails::getEntityPart($configurator->getEntityClass()) : $configurator->getEntityName()), $request->request->get('token'))) {
             $indexUrl = $configurator->getIndexUrl();
 
             return new RedirectResponse($this->generateUrl($indexUrl['path'], $indexUrl['params'] ?? []));

--- a/src/Kunstmaan/AdminListBundle/Resources/doc/PageAdminListBundle.md
+++ b/src/Kunstmaan/AdminListBundle/Resources/doc/PageAdminListBundle.md
@@ -12,8 +12,8 @@ You will need to create 2 classes. A pageAdminListConfigurator and a pageAdminst
 ##### Configurator
 
 
-Create your ProjectPageAdminListConfigurator class in the AdminList folder in your Bundle and extend from the AbstractPageAdminListConfigurator. Override the 3 abstract methods :
-getBundleName, getEntityName and getReadableName
+Create your ProjectPageAdminListConfigurator class in the AdminList folder in your Bundle and extend from the AbstractPageAdminListConfigurator. Override the 2 abstract methods :
+getEntityClass and getReadableName
 
 ```PHP
 <?php
@@ -27,27 +27,10 @@ use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractPageAdminListConfig
  */
 class ProjectPageAdminListConfigurator extends AbstractPageAdminListConfigurator
 {
-
-    /**
-     * Get bundle name
-     *
-     * @return string
-     */
-    public function getBundleName()
+    public function getEntityClass() : string
     {
-        return 'YourProjectWebsiteBundle';
+        return App\Your\Entity::class;
     }
-
-    /**
-     * Get entity name
-     *
-     * @return string
-     */
-    public function getEntityName()
-    {
-        return 'ProjectPage';
-    }
-
 
     /**
      *  Get readable name
@@ -58,8 +41,6 @@ class ProjectPageAdminListConfigurator extends AbstractPageAdminListConfigurator
     {
         return 'Project page';
     }
-
-
 }
 
 ```

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineDBALAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineDBALAdminListConfiguratorTest.php
@@ -35,37 +35,36 @@ class AbstractDoctrineDBALAdminListConfiguratorTest extends TestCase
 
     public function testGetEditUrl()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
-        $editUrl = $abstractMock->getEditUrlFor(['id' => 888]);
+        $editUrl = $adminlistConfigurator->getEditUrlFor(['id' => 888]);
         $this->assertIsArray($editUrl);
         $this->assertArrayHasKey('path', $editUrl);
         $this->assertArrayHasKey('params', $editUrl);
-        $this->assertEquals('bundle_admin_myentity_' . AbstractDoctrineDBALadminListConfigurator::SUFFIX_EDIT, $editUrl['path']);
+        $this->assertEquals('app_admin_user_' . AbstractDoctrineDBALadminListConfigurator::SUFFIX_EDIT, $editUrl['path']);
         $this->assertContains(888, $editUrl['params']);
     }
 
     public function testGetDeleteUrl()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
-        $editUrl = $abstractMock->getDeleteUrlFor(['id' => 888]);
+        $editUrl = $adminlistConfigurator->getDeleteUrlFor(['id' => 888]);
         $this->assertIsArray($editUrl);
         $this->assertArrayHasKey('path', $editUrl);
         $this->assertArrayHasKey('params', $editUrl);
-        $this->assertEquals('bundle_admin_myentity_' . AbstractDoctrineDBALAdminListConfigurator::SUFFIX_DELETE, $editUrl['path']);
+        $this->assertEquals('app_admin_user_' . AbstractDoctrineDBALAdminListConfigurator::SUFFIX_DELETE, $editUrl['path']);
         $this->assertContains(888, $editUrl['params']);
     }
 
     public function testGetPagerFanta()
     {
-        $abstractMock = $this->setUpAbstractMock();
-        $this->assertInstanceOf(Pagerfanta::class, $abstractMock->getPagerfanta());
+        $this->assertInstanceOf(Pagerfanta::class, $this->setUpAdminlistConfigurator()->getPagerfanta());
     }
 
     public function testGetQueryBuilderAndIterator()
     {
-        $abstractMock = $this->setUpAbstractMock(['getFilterBuilder']);
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
         $abstractDBALFilterTypeMock = $this->createMock(AbstractDBALFilterType::class);
 
@@ -78,11 +77,7 @@ class AbstractDoctrineDBALAdminListConfiguratorTest extends TestCase
             ])
         ;
 
-        $abstractMock
-            ->expects($this->any())
-            ->method('getFilterBuilder')
-            ->willReturn($filterBuilderMock)
-        ;
+        $adminlistConfigurator->setFilterBuilder($filterBuilderMock);
 
         $requestMock = $this->getMockBuilder(Request::class)
             ->setConstructorArgs([['page' => 1], [], ['_route' => 'testroute']])
@@ -109,42 +104,56 @@ class AbstractDoctrineDBALAdminListConfiguratorTest extends TestCase
             ->willReturn($sessionMock)
         ;
 
-        $abstractMock->bindRequest($requestMock);
-        $this->assertInstanceOf(QueryBuilder::class, $abstractMock->getQueryBuilder());
-        $this->assertInstanceOf(\Traversable::class, $abstractMock->getIterator());
+        $adminlistConfigurator->bindRequest($requestMock);
+        $this->assertInstanceOf(QueryBuilder::class, $adminlistConfigurator->getQueryBuilder());
+        $this->assertInstanceOf(\Traversable::class, $adminlistConfigurator->getIterator());
     }
 
     public function testSetGetCountField()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
-        $this->assertInstanceOf(AbstractDoctrineDBALAdminListConfigurator::class, $abstractMock->setCountField('foo'));
-        $this->assertIsString($abstractMock->getCountField());
+        $this->assertInstanceOf(AbstractDoctrineDBALAdminListConfigurator::class, $adminlistConfigurator->setCountField('foo'));
+        $this->assertIsString($adminlistConfigurator->getCountField());
     }
 
     public function testSetGetDistinctCount()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
-        $this->assertInstanceOf(AbstractDoctrineDBALAdminListConfigurator::class, $abstractMock->setUseDistinctCount(false));
-        $this->assertFalse($abstractMock->getUseDistinctCount());
+        $this->assertInstanceOf(AbstractDoctrineDBALAdminListConfigurator::class, $adminlistConfigurator->setUseDistinctCount(false));
+        $this->assertFalse($adminlistConfigurator->getUseDistinctCount());
     }
 
-    public function setUpAbstractMock(array $methods = [])
+    public function setUpAdminlistConfigurator(): AbstractDoctrineDBALAdminListConfigurator
     {
-        /** @var AbstractDoctrineDBALAdminListConfigurator $abstractMock */
-        $abstractMock = $this->getMockForAbstractClass(AbstractDoctrineDBALAdminListConfigurator::class, [$this->connectionMock], '', true, true, true, $methods);
-        $abstractMock
-            ->expects($this->any())
-            ->method('getBundleName')
-            ->willReturn('Bundle')
-        ;
-        $abstractMock
-            ->expects($this->any())
-            ->method('getEntityName')
-            ->willReturn('MyEntity')
-        ;
+        return new class($this->connectionMock) extends AbstractDoctrineDBALAdminListConfigurator {
+            public function buildFields()
+            {
+                $this->addField('hello', 'hello', true);
+                $this->addField('world', 'world', true);
+            }
 
-        return $abstractMock;
+            public function getEntityClass(): string
+            {
+                return \App\Entity\User::class;
+            }
+
+            public function getBundleName()
+            {
+                return 'App';
+            }
+
+            public function getEntityName()
+            {
+                return 'User';
+            }
+        };
     }
+}
+
+namespace App\Entity;
+
+class User
+{
 }

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineORMAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineORMAdminListConfiguratorTest.php
@@ -60,7 +60,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
         $this->emMock
             ->expects($this->any())
             ->method('getRepository')
-            ->with('Bundle:MyEntity')
+            ->with('App\\Entity\\Blog')
             ->willReturn($entityRepositoryMock)
         ;
         $this->emMock
@@ -72,7 +72,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
 
     public function testGetEditUrl()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         $item = new class() {
             public function getId()
@@ -85,13 +85,13 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
         $this->assertIsArray($editUrl);
         $this->assertArrayHasKey('path', $editUrl);
         $this->assertArrayHasKey('params', $editUrl);
-        $this->assertEquals('bundle_admin_myentity_' . AbstractDoctrineORMAdminListConfigurator::SUFFIX_EDIT, $editUrl['path']);
+        $this->assertEquals('app_admin_blog_' . AbstractDoctrineORMAdminListConfigurator::SUFFIX_EDIT, $editUrl['path']);
         $this->assertContains(747, $editUrl['params']);
     }
 
     public function testGetDeleteUrl()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         $item = new class() {
             public function getId()
@@ -104,20 +104,20 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
         $this->assertIsArray($editUrl);
         $this->assertArrayHasKey('path', $editUrl);
         $this->assertArrayHasKey('params', $editUrl);
-        $this->assertEquals('bundle_admin_myentity_' . AbstractDoctrineORMAdminListConfigurator::SUFFIX_DELETE, $editUrl['path']);
+        $this->assertEquals('app_admin_blog_' . AbstractDoctrineORMAdminListConfigurator::SUFFIX_DELETE, $editUrl['path']);
         $this->assertContains(747, $editUrl['params']);
     }
 
     public function testGetPagerFanta()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         $this->assertInstanceOf(Pagerfanta::class, $abstractMock->getPagerfanta());
     }
 
     public function testGetQueryDefault()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         // default
         $this->assertInstanceOf(AbstractQuery::class, $abstractMock->getQuery());
@@ -142,22 +142,16 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
             ])
         ;
 
-        /** @var AbstractDoctrineORMAdminListConfigurator $abstractMock */
-        $abstractMock = $this->setUpAbstractMock(['getFilterBuilder']);
-        $abstractMock
-            ->expects($this->any())
-            ->method('getFilterBuilder')
-            ->willReturn($filterBuilderMock)
-        ;
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator(['getFilterBuilder']);
+        $adminlistConfigurator->setFilterBuilder($filterBuilderMock);
 
-        $abstractMock->addFilter('foo');
-        $this->assertInstanceOf(AbstractQuery::class, $abstractMock->getQuery());
+        $adminlistConfigurator->addFilter('foo');
+        $this->assertInstanceOf(AbstractQuery::class, $adminlistConfigurator->getQuery());
     }
 
     public function testGetQueryWithOrderBy()
     {
-        /** @var AbstractDoctrineORMAdminListConfigurator $abstractMock */
-        $abstractMock = $this->setUpAbstractMock(['getFilterBuilder']);
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator(['getFilterBuilder']);
 
         $filterBuilderMock = $this->createMock(FilterBuilder::class);
         $filterBuilderMock
@@ -170,11 +164,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
             ->willReturn([])
         ;
 
-        $abstractMock
-            ->expects($this->exactly(2))
-            ->method('getFilterBuilder')
-            ->willReturn($filterBuilderMock)
-        ;
+        $adminlistConfigurator->setFilterBuilder($filterBuilderMock);
 
         $requestMock = $this->getMockBuilder(Request::class)
             ->setConstructorArgs([['page' => 1], [], ['_route' => 'testroute']])
@@ -201,13 +191,13 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
             ->willReturn($sessionMock)
         ;
 
-        $abstractMock->bindRequest($requestMock);
-        $this->assertInstanceOf(AbstractQuery::class, $abstractMock->getQuery());
+        $adminlistConfigurator->bindRequest($requestMock);
+        $this->assertInstanceOf(AbstractQuery::class, $adminlistConfigurator->getQuery());
     }
 
     public function testGetQueryWithPermissionDefAndAcl()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         /** @var PermissionDefinition $permissionDefinitionMock */
         $permissionDefinitionMock = $this->createMock(PermissionDefinition::class);
@@ -217,7 +207,7 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
 
     public function testSetGetPermissionDefinition()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $abstractMock = $this->setUpAdminlistConfigurator();
 
         /** @var PermissionDefinition $permissionDefinitionMock */
         $permissionDefinitionMock = $this->createMock(PermissionDefinition::class);
@@ -227,29 +217,43 @@ class AbstractDoctrineORMAdminListConfiguratorTest extends TestCase
 
     public function testSetGetEntityManager()
     {
-        $abstractMock = $this->setUpAbstractMock();
+        $adminlistConfigurator = $this->setUpAdminlistConfigurator();
 
         /** @var EntityManagerInterface $emMock */
         $emMock = $this->createMock(EntityManagerInterface::class);
-        $this->assertInstanceOf(AbstractDoctrineORMAdminListConfigurator::class, $abstractMock->setEntityManager($emMock));
-        $this->assertInstanceOf(EntityManagerInterface::class, $abstractMock->getEntityManager());
+        $this->assertInstanceOf(AbstractDoctrineORMAdminListConfigurator::class, $adminlistConfigurator->setEntityManager($emMock));
+        $this->assertInstanceOf(EntityManagerInterface::class, $adminlistConfigurator->getEntityManager());
     }
 
-    public function setUpAbstractMock(array $methods = [])
+    public function setUpAdminlistConfigurator(): AbstractDoctrineORMAdminListConfigurator
     {
-        /** @var AbstractDoctrineORMAdminListConfigurator $abstractMock */
-        $abstractMock = $this->getMockForAbstractClass(AbstractDoctrineORMAdminListConfigurator::class, [$this->emMock], '', true, true, true, $methods);
-        $abstractMock
-            ->expects($this->any())
-            ->method('getBundleName')
-            ->willReturn('Bundle')
-        ;
-        $abstractMock
-            ->expects($this->any())
-            ->method('getEntityName')
-            ->willReturn('MyEntity')
-        ;
+        return new class($this->emMock) extends AbstractDoctrineORMAdminListConfigurator {
+            public function buildFields()
+            {
+                $this->addField('hello', 'hello', true);
+                $this->addField('world', 'world', true);
+            }
 
-        return $abstractMock;
+            public function getEntityClass(): string
+            {
+                return \App\Entity\Blog::class;
+            }
+
+            public function getBundleName()
+            {
+                return 'App';
+            }
+
+            public function getEntityName()
+            {
+                return 'Blog';
+            }
+        };
     }
+}
+
+namespace App\Entity;
+
+class Blog
+{
 }

--- a/src/Kunstmaan/AdminListBundle/Utils/EntityDetails.php
+++ b/src/Kunstmaan/AdminListBundle/Utils/EntityDetails.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Utils;
+
+/**
+ * @internal
+ */
+final class EntityDetails
+{
+    public static function getRootNamespace(string $classname): string
+    {
+        $parts = explode('Entity', $classname);
+
+        return rtrim($parts[0], '\\');
+    }
+
+    public static function getEntityPart(string $classname): string
+    {
+        $parts = explode('Entity', $classname);
+
+        return ltrim($parts[1], '\\');
+    }
+
+    public static function getEntityName(string $classname): string
+    {
+        $parts = explode('\\', $classname);
+
+        return array_pop($parts);
+    }
+}

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticleAuthorAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticleAuthorAdminListConfigurator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
+use Kunstmaan\ArticleBundle\Entity\AbstractAuthor;
 
 /**
  * The AdminList configurator for the AbstractArticleAuthor
@@ -32,23 +33,36 @@ class AbstractArticleAuthorAdminListConfigurator extends AbstractDoctrineORMAdmi
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * Return current bundle name.
      *
      * @return string
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/article-bundle', '6.4', 'Method "%s" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanArticleBundle';
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * Return current entity name.
      *
      * @return string
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/article-bundle', '6.4', 'Method "%s" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'AbstractArticleAuthor';
+    }
+
+    public function getEntityClass(): string
+    {
+        return AbstractAuthor::class;
     }
 
     /**

--- a/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
+++ b/src/Kunstmaan/ArticleBundle/AdminList/AbstractArticlePageAdminListConfigurator.php
@@ -11,6 +11,7 @@ use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\BooleanFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\DateFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
 use Kunstmaan\ArticleBundle\Entity\AbstractArticleOverviewPage;
+use Kunstmaan\ArticleBundle\Entity\AbstractArticlePage;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
@@ -43,23 +44,36 @@ abstract class AbstractArticlePageAdminListConfigurator extends AbstractDoctrine
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * Return current bundle name.
      *
      * @return string
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/article-bundle', '6.4', 'Method "%s" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanArticleBundle';
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * Return current entity name.
      *
      * @return string
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/article-bundle', '6.4', 'Method "%s" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'AbstractArticlePage';
+    }
+
+    public function getEntityClass(): string
+    {
+        return AbstractArticlePage::class;
     }
 
     /**

--- a/src/Kunstmaan/ArticleBundle/Tests/AdminList/AbstractArticleAuthorAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/AdminList/AbstractArticleAuthorAdminListConfiguratorTest.php
@@ -5,10 +5,14 @@ namespace Kunstmaan\ArticleBundle\Tests\AdminList;
 use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\ArticleBundle\AdminList\AbstractArticleAuthorAdminListConfigurator;
+use Kunstmaan\ArticleBundle\Entity\AbstractAuthor;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class AbstractArticleAuthorAdminListConfiguratorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var AbstractArticleAuthorAdminListConfigurator
      */
@@ -26,10 +30,21 @@ class AbstractArticleAuthorAdminListConfiguratorTest extends TestCase
         $this->object = new AbstractArticleAuthorAdminListConfigurator($em, $acl, 'nl');
     }
 
-    public function testGetters()
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedGetters()
     {
+        $this->expectDeprecation('Since kunstmaan/article-bundle 6.4: Method "Kunstmaan\ArticleBundle\AdminList\AbstractArticleAuthorAdminListConfigurator::getBundleName" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+        $this->expectDeprecation('Since kunstmaan/article-bundle 6.4: Method "Kunstmaan\ArticleBundle\AdminList\AbstractArticleAuthorAdminListConfigurator::getEntityName" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+
         $this->assertEquals('KunstmaanArticleBundle', $this->object->getBundleName());
         $this->assertEquals('AbstractArticleAuthor', $this->object->getEntityName());
+    }
+
+    public function testGetters()
+    {
+        $this->assertEquals(AbstractAuthor::class, $this->object->getEntityClass());
     }
 
     public function testBuildFields()

--- a/src/Kunstmaan/ArticleBundle/Tests/AdminList/AbstractArticlePageAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/ArticleBundle/Tests/AdminList/AbstractArticlePageAdminListConfiguratorTest.php
@@ -7,11 +7,13 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\ArticleBundle\AdminList\AbstractArticlePageAdminListConfigurator;
+use Kunstmaan\ArticleBundle\Entity\AbstractArticlePage;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Helper\NodeMenu;
 use Kunstmaan\NodeBundle\Helper\NodeMenuItem;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class Configurator extends AbstractArticlePageAdminListConfigurator
 {
@@ -24,9 +26,6 @@ class Configurator extends AbstractArticlePageAdminListConfigurator
         $this->repo = $repo;
     }
 
-    /**
-     * @return bool
-     */
     public function getOverviewPageRepository()
     {
         return $this->repo;
@@ -35,6 +34,8 @@ class Configurator extends AbstractArticlePageAdminListConfigurator
 
 class AbstractArticlePageAdminListConfiguratorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var AbstractArticlePageAdminListConfigurator
      */
@@ -66,12 +67,23 @@ class AbstractArticlePageAdminListConfiguratorTest extends TestCase
         $this->object = new Configurator($em, $acl, 'nl', 'admin', $repo);
     }
 
-    public function testGetters()
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedGetters()
     {
+        $this->expectDeprecation('Since kunstmaan/article-bundle 6.4: Method "Kunstmaan\ArticleBundle\AdminList\AbstractArticlePageAdminListConfigurator::getBundleName" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+        $this->expectDeprecation('Since kunstmaan/article-bundle 6.4: Method "Kunstmaan\ArticleBundle\AdminList\AbstractArticlePageAdminListConfigurator::getEntityName" deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+
         $this->assertEquals('KunstmaanArticleBundle', $this->object->getBundleName());
         $this->assertEquals('AbstractArticlePage', $this->object->getEntityName());
+    }
+
+    public function testGetters()
+    {
+        $this->assertEquals(AbstractArticlePage::class, $this->object->getEntityClass());
         $this->assertEquals('@KunstmaanArticle/AbstractArticlePageAdminList/list.html.twig', $this->object->getListTemplate());
-        $this->assertEquals('KunstmaanArticleBundle:AbstractArticlePage', $this->object->getRepositoryName());
+        $this->assertEquals(AbstractArticlePage::class, $this->object->getRepositoryName());
     }
 
     public function testBuildFields()

--- a/src/Kunstmaan/CookieBundle/AdminList/CookieAdminListConfigurator.php
+++ b/src/Kunstmaan/CookieBundle/AdminList/CookieAdminListConfigurator.php
@@ -11,6 +11,7 @@ use Kunstmaan\AdminListBundle\AdminList\FieldAlias;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\EnumerationFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
 use Kunstmaan\AdminListBundle\Entity\OverviewNavigationInterface;
+use Kunstmaan\CookieBundle\Entity\Cookie;
 use Kunstmaan\CookieBundle\Entity\CookieType;
 use Kunstmaan\CookieBundle\Form\CookieAdminType;
 
@@ -97,23 +98,36 @@ class CookieAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurat
     }
 
     /**
+     * @deprecated since 6.4 and will be removed in 7.0. Use the `getEntityClass` method instead.
+     *
      * Get bundle name
      *
      * @return string
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/cookie-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanCookieBundle';
     }
 
     /**
+     * @deprecated since 6.4 and will be removed in 7.0. Use the `getEntityClass` method instead.
+     *
      * Get entity name
      *
      * @return string
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/cookie-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Cookie';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Cookie::class;
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/AdminList/FormPageAdminListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormPageAdminListConfigurator.php
@@ -10,6 +10,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionDefinition;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\BooleanFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
 /**
  * Adminlist configuration to list all the form pages
@@ -146,6 +147,8 @@ class FormPageAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/form-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanNodeBundle';
     }
 
@@ -154,7 +157,14 @@ class FormPageAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/form-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'NodeTranslation';
+    }
+
+    public function getEntityClass(): string
+    {
+        return NodeTranslation::class;
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/AdminList/FormSubmissionAdminListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormSubmissionAdminListConfigurator.php
@@ -8,6 +8,7 @@ use Kunstmaan\AdminBundle\Entity\EntityInterface;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\DateFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
+use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 
 /**
@@ -176,6 +177,8 @@ class FormSubmissionAdminListConfigurator extends AbstractDoctrineORMAdminListCo
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/form-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanFormBundle';
     }
 
@@ -184,7 +187,14 @@ class FormSubmissionAdminListConfigurator extends AbstractDoctrineORMAdminListCo
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/form-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'FormSubmission';
+    }
+
+    public function getEntityClass(): string
+    {
+        return FormSubmission::class;
     }
 
     /**

--- a/src/Kunstmaan/FormBundle/Tests/AdminList/FormPageAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/AdminList/FormPageAdminListConfiguratorTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\FormBundle\AdminList\FormPageAdminListConfigurator;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use PHPUnit\Framework\TestCase;
 
 class FormPageAdminListConfiguratorTest extends TestCase
@@ -75,9 +76,7 @@ class FormPageAdminListConfiguratorTest extends TestCase
         $item->method('getId')->willReturn(123);
 
         $this->assertEquals('', $this->object->getAddUrlFor([]));
-        $this->assertEquals('KunstmaanNodeBundle', $this->object->getBundleName());
-        $this->assertEquals('NodeTranslation', $this->object->getEntityName());
-        $this->assertEquals('KunstmaanFormBundle:FormSubmissions', $this->object->getControllerPath());
+        $this->assertEquals(NodeTranslation::class, $this->object->getEntityClass());
         $this->assertCount(0, $this->object->getDeleteUrlFor($item));
         $this->assertCount(1, $this->object->getIndexUrl());
         $this->assertCount(2, $this->object->getEditUrlFor($item));

--- a/src/Kunstmaan/FormBundle/Tests/AdminList/FormSubmissionAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/AdminList/FormSubmissionAdminListConfiguratorTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminListBundle\AdminList\ItemAction\SimpleItemAction;
 use Kunstmaan\FormBundle\AdminList\FormSubmissionAdminListConfigurator;
+use Kunstmaan\FormBundle\Entity\FormSubmission;
 use Kunstmaan\NodeBundle\Entity\AbstractPage;
 use Kunstmaan\NodeBundle\Entity\Node;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
@@ -81,8 +82,7 @@ class FormSubmissionAdminListConfiguratorTest extends TestCase
         $item->method('getId')->willReturn(123);
 
         $this->assertEquals('', $this->object->getAddUrlFor([]));
-        $this->assertEquals('KunstmaanFormBundle', $this->object->getBundleName());
-        $this->assertEquals('FormSubmission', $this->object->getEntityName());
+        $this->assertEquals(FormSubmission::class, $this->object->getEntityClass());
         $this->assertCount(0, $this->object->getDeleteUrlFor($item));
         $this->assertCount(2, $this->object->getIndexUrl());
         $this->assertCount(2, $this->object->getEditUrlFor($item));

--- a/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
+++ b/src/Kunstmaan/GeneratorBundle/Generator/AdminListGenerator.php
@@ -20,6 +20,9 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
 
     private $questionHelper;
 
+    /** @var class-string */
+    private $entityFqcn;
+
     /**
      * @param string $skeletonDir The directory of the skeleton
      */
@@ -43,6 +46,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
      */
     public function generate(BundleInterface $bundle, $entity, ClassMetadata $metadata, OutputInterface $output, $sortField)
     {
+        $this->entityFqcn = $entity;
         $parts = explode('\\', $entity);
         $entityName = array_pop($parts);
         $generateAdminType = !method_exists($entity, 'getAdminType');
@@ -106,6 +110,7 @@ class AdminListGenerator extends \Sensio\Bundle\GeneratorBundle\Generator\Genera
                 'namespace' => $bundle->getNamespace(),
                 'bundle' => $bundle,
                 'entity_class' => $entityName,
+                'entity_fqcn' => $this->entityFqcn,
                 'fields' => $this->getFieldsWithFilterTypeFromMetadata($metadata),
                 'generate_admin_type' => $generateAdminType,
                 'sortField' => $sortField,

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/AdminList/AdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/adminlist/AdminList/AdminListConfigurator.php
@@ -4,6 +4,7 @@ namespace {{ namespace }}\AdminList;
 
 use Doctrine\ORM\EntityManager;
 
+use {{ entity_fqcn }};
 use {{ namespace }}\Form\{{ entity_class }}AdminType;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
@@ -36,14 +37,9 @@ class {{ entity_class }}AdminListConfigurator extends AbstractDoctrineORMAdminLi
 {% endfor %}
     }
 
-    public function getBundleName(): string
+    public function getEntityClass(): string
     {
-        return '{{ bundle.getName() }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return '{{ entity_class }}';
+        return {{ entity_class }}::class;
     }
 {% if sortField %}
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/AuthorAdminListConfigurator.php
@@ -2,17 +2,13 @@
 
 namespace {{ namespace }}\AdminList;
 
+use {{ namespace }}\Entity\{{ entity_class }}Author;
 use Kunstmaan\ArticleBundle\AdminList\AbstractArticleAuthorAdminListConfigurator;
 
 class {{ entity_class }}AuthorAdminListConfigurator extends AbstractArticleAuthorAdminListConfigurator
 {
-    public function getBundleName(): string
+    public function getEntityClass(): string
     {
-        return '{{ bundle.getName() }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return '{{ entity_class }}Author';
+        return {{ entity_class }}Author::class;
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/CategoryAdminListConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }}\AdminList;
 
+use {{ namespace }}\Entity\{{ entity_class }}Category;
 use {{ namespace }}\Form\{{ entity_class }}CategoryAdminType;
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
@@ -15,13 +16,8 @@ class {{ entity_class }}CategoryAdminListConfigurator extends AbstractArticleCat
         $this->setAdminType({{ entity_class }}CategoryAdminType::class);
     }
 
-    public function getBundleName(): string
-    {
-        return '{{ bundle.getName() }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return '{{ entity_class }}Category';
+    public function getEntityClass(): string
+{
+    return {{ entity_class }}Category::class;
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/PageAdminListConfigurator.php
@@ -9,14 +9,9 @@ use Kunstmaan\ArticleBundle\AdminList\AbstractArticlePageAdminListConfigurator;
 
 class {{ entity_class }}PageAdminListConfigurator extends AbstractArticlePageAdminListConfigurator
 {
-    public function getBundleName(): string
+    public function getEntityClass(): string
     {
-        return '{{ bundle.getName() }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return 'Pages\{{ entity_class }}Page';
+        return {{ entity_class }}Page::class;
     }
 
     public function adaptQueryBuilder(QueryBuilder $queryBuilder): void

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/AdminList/TagAdminListConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace {{ namespace }}\AdminList;
 
+use {{ namespace }}\Entity\{{ entity_class }}Tag;
 use {{ namespace }}\Form\{{ entity_class }}TagAdminType;
 use Doctrine\ORM\EntityManagerInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
@@ -15,13 +16,8 @@ class {{ entity_class }}TagAdminListConfigurator extends AbstractArticleTagAdmin
         $this->setAdminType({{ entity_class }}TagAdminType::class);
     }
 
-    public function getBundleName(): string
+    public function getEntityClass(): string
     {
-        return '{{ bundle.getName() }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return '{{ entity_class }}Tag';
+        return {{ entity_class }}Tag::class;
     }
 }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/AdminList/BikeAdminListConfigurator.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/AdminList/BikeAdminListConfigurator.php
@@ -35,14 +35,9 @@ class BikeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
         $this->addFilter('price', new ORM\NumberFilterType('price'), 'Price');
     }
 
-    public function getBundleName(): string
+    public function getEntityClass()
     {
-        return '{{ bundle_name }}';
-    }
-
-    public function getEntityName(): string
-    {
-        return 'Bike';
+        return Bike::class;
     }
 
     public function getSortableField(): string

--- a/src/Kunstmaan/LeadGenerationBundle/AdminList/PopupAdminListConfigurator.php
+++ b/src/Kunstmaan/LeadGenerationBundle/AdminList/PopupAdminListConfigurator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
+use Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup;
 
 class PopupAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
 {
@@ -50,6 +51,8 @@ class PopupAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/lead-generation-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanLeadGenerationBundle';
     }
 
@@ -60,7 +63,14 @@ class PopupAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/lead-generation-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Popup\AbstractPopup';
+    }
+
+    public function getEntityClass(): string
+    {
+        return AbstractPopup::class;
     }
 
     /**

--- a/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
+++ b/src/Kunstmaan/LeadGenerationBundle/AdminList/RulesAdminListConfigurator.php
@@ -8,6 +8,7 @@ use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
 use Kunstmaan\LeadGenerationBundle\Entity\Popup\AbstractPopup;
+use Kunstmaan\LeadGenerationBundle\Entity\Rule\AbstractRule;
 
 class RulesAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
 {
@@ -119,6 +120,8 @@ class RulesAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/lead-generation-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanLeadGenerationBundle';
     }
 
@@ -129,7 +132,14 @@ class RulesAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/lead-generation-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Rule\AbstractRule';
+    }
+
+    public function getEntityClass(): string
+    {
+        return AbstractRule::class;
     }
 
     /**

--- a/src/Kunstmaan/MediaBundle/AdminList/MediaAdminListConfigurator.php
+++ b/src/Kunstmaan/MediaBundle/AdminList/MediaAdminListConfigurator.php
@@ -12,6 +12,7 @@ use Kunstmaan\MediaBundle\AdminList\ItemAction\MediaDeleteItemAction;
 use Kunstmaan\MediaBundle\AdminList\ItemAction\MediaEditItemAction;
 use Kunstmaan\MediaBundle\AdminList\ItemAction\MediaSelectItemAction;
 use Kunstmaan\MediaBundle\Entity\Folder;
+use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Form\Type\MediaType;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
 use Kunstmaan\MediaBundle\Helper\RemoteAudio\RemoteAudioHandler;
@@ -133,6 +134,8 @@ class MediaAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/media-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanMediaBundle';
     }
 
@@ -143,7 +146,14 @@ class MediaAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurato
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/media-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Media';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Media::class;
     }
 
     public function adaptQueryBuilder(QueryBuilder $queryBuilder)

--- a/src/Kunstmaan/MenuBundle/AdminList/MenuAdminListConfigurator.php
+++ b/src/Kunstmaan/MenuBundle/AdminList/MenuAdminListConfigurator.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
+use Kunstmaan\MenuBundle\Entity\Menu;
 
 class MenuAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
 {
@@ -55,6 +56,8 @@ class MenuAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/menu-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanMenuBundle';
     }
 
@@ -65,7 +68,14 @@ class MenuAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/menu-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Menu';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Menu::class;
     }
 
     /**

--- a/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
+++ b/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
@@ -45,6 +45,8 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/menu-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanMenuBundle';
     }
 
@@ -55,7 +57,14 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/menu-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'MenuItem';
+    }
+
+    public function getEntityClass(): string
+    {
+        return MenuItem::class;
     }
 
     public function adaptQueryBuilder(QueryBuilder $qb)

--- a/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
+++ b/src/Kunstmaan/NodeBundle/AdminList/NodeAdminListConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\NodeBundle\AdminList;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Kunstmaan\AdminBundle\Entity\EntityInterface;
 use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
@@ -15,6 +15,7 @@ use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\DateFilterType;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM\StringFilterType;
 use Kunstmaan\AdminListBundle\AdminList\ListAction\SimpleListAction;
 use Kunstmaan\NodeBundle\Entity\Node;
+use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -50,14 +51,10 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     private ?Node $node = null;
 
     /**
-     * @param EntityManager $em         The entity
-     *                                  manager
-     * @param AclHelper     $aclHelper  The ACL helper
-     * @param string        $locale     The current
-     *                                  locale
-     * @param string        $permission The permission
+     * @param string $locale     The current locale
+     * @param string $permission The permission
      */
-    public function __construct(EntityManager $em, AclHelper $aclHelper, $locale, $permission, AuthorizationCheckerInterface $authorizationChecker, ?Node $node = null)
+    public function __construct(EntityManagerInterface $em, AclHelper $aclHelper, $locale, $permission, AuthorizationCheckerInterface $authorizationChecker, ?Node $node = null)
     {
         parent::__construct($em, $aclHelper);
         $this->locale = $locale;
@@ -222,19 +219,32 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * @return string
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/node-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanNodeBundle';
     }
 
     /**
+     * @deprecated since 6.4. Use the `getEntityClass` method instead.
+     *
      * @return string
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/node-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'NodeTranslation';
+    }
+
+    public function getEntityClass(): string
+    {
+        return NodeTranslation::class;
     }
 
     /**
@@ -246,14 +256,16 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getPathByConvention($suffix = null)
     {
-        if (empty($suffix)) {
-            return sprintf('%s_nodes', $this->getBundleName());
+        if (null === $suffix || $suffix === '') {
+            return 'KunstmaanNodeBundle_nodes';
         }
 
-        return sprintf('%s_nodes_%s', $this->getBundleName(), $suffix);
+        return sprintf('KunstmaanNodeBundle_nodes_%s', $suffix);
     }
 
     /**
+     * @deprecated since 6.4. There is no replacement for this method.
+     *
      * Override controller path (because actions for different entities are
      * defined in a single Settings controller).
      *
@@ -261,6 +273,8 @@ class NodeAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getControllerPath()
     {
+        trigger_deprecation('kunstmaan/node-bundle', '6.4', 'Method deprecated and will be removed in 7.0. There is no replacement for this method.');
+
         return 'KunstmaanNodeBundle:NodeAdmin';
     }
 

--- a/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeVersionLockHelper.php
+++ b/src/Kunstmaan/NodeBundle/Helper/NodeAdmin/NodeVersionLockHelper.php
@@ -7,22 +7,17 @@ use Kunstmaan\AdminBundle\Entity\BaseUser;
 use Kunstmaan\NodeBundle\Entity\NodeTranslation;
 use Kunstmaan\NodeBundle\Entity\NodeVersionLock;
 use Kunstmaan\NodeBundle\Repository\NodeVersionLockRepository;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class NodeVersionLockHelper implements ContainerAwareInterface
+class NodeVersionLockHelper
 {
-    use ContainerAwareTrait;
-
-    /**
-     * @var ObjectManager
-     */
+    /** @var ObjectManager */
     private $objectManager;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container, ObjectManager $em)
     {
-        $this->setContainer($container);
+        $this->container = $container;
         $this->setObjectManager($em);
     }
 

--- a/src/Kunstmaan/NodeBundle/Tests/AdminList/NodeAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/AdminList/NodeAdminListConfiguratorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AdminList;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
+use Kunstmaan\AdminBundle\Helper\Security\Acl\Permission\PermissionMap;
+use Kunstmaan\NodeBundle\AdminList\NodeAdminListConfigurator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class NodeAdminListConfiguratorTest extends TestCase
+{
+    private NodeAdminListConfigurator $adminlist;
+
+    protected function setUp(): void
+    {
+        $this->adminlist = new NodeAdminListConfigurator(
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(AclHelper::class),
+            'en',
+            PermissionMap::PERMISSION_VIEW,
+            $this->createMock(AuthorizationCheckerInterface::class)
+        );
+    }
+
+    public function testgetPathByConventionWithoutSuffix()
+    {
+        $this->assertSame('KunstmaanNodeBundle_nodes', $this->adminlist->getPathByConvention());
+    }
+
+    public function testgetPathByConventionWithSuffix()
+    {
+        $this->assertSame('KunstmaanNodeBundle_nodes_examplesuffix', $this->adminlist->getPathByConvention('examplesuffix'));
+    }
+}

--- a/src/Kunstmaan/NodeBundle/composer.json
+++ b/src/Kunstmaan/NodeBundle/composer.json
@@ -17,7 +17,7 @@
         "doctrine/dbal": "^2.13.1|^3.4",
         "gedmo/doctrine-extensions": "^2.4.34|^3.1.0",
         "kunstmaan/admin-bundle": "^6.1",
-        "kunstmaan/adminlist-bundle": "^5.9|^6.0",
+        "kunstmaan/adminlist-bundle": "^6.4",
         "stof/doctrine-extensions-bundle": "^1.3",
         "symfony/expression-language": "^5.4",
         "symfony-cmf/routing-bundle": "^2.1"

--- a/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
+++ b/src/Kunstmaan/RedirectBundle/AdminList/RedirectAdminListConfigurator.php
@@ -8,6 +8,7 @@ use Kunstmaan\AdminBundle\Helper\DomainConfigurationInterface;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
+use Kunstmaan\RedirectBundle\Entity\Redirect;
 use Kunstmaan\RedirectBundle\Form\RedirectAdminType;
 
 class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
@@ -80,6 +81,8 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/redirect-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanRedirectBundle';
     }
 
@@ -90,12 +93,28 @@ class RedirectAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/redirect-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Redirect';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Redirect::class;
     }
 
     public function adaptQueryBuilder(QueryBuilder $queryBuilder)
     {
         parent::adaptQueryBuilder($queryBuilder);
         $queryBuilder->orderBy('b.id', 'ASC');
+    }
+
+    public function getPathByConvention($suffix = null)
+    {
+        if (null === $suffix || $suffix === '') {
+            return 'kunstmaanredirectbundle_admin_redirect';
+        }
+
+        return sprintf('kunstmaanredirectbundle_admin_redirect_%s', $suffix);
     }
 }

--- a/src/Kunstmaan/RedirectBundle/Tests/AdminList/RedirectAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/RedirectBundle/Tests/AdminList/RedirectAdminListConfiguratorTest.php
@@ -6,10 +6,14 @@ use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Field;
 use Kunstmaan\RedirectBundle\AdminList\RedirectAdminListConfigurator;
+use Kunstmaan\RedirectBundle\Entity\Redirect;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class RedirectAdminListConfiguratorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var EntityManager
      */
@@ -68,13 +72,28 @@ class RedirectAdminListConfiguratorTest extends TestCase
         $this->object->buildFilters();
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetBundleName()
     {
+        $this->expectDeprecation('Since kunstmaan/redirect-bundle 6.4: The "Kunstmaan\RedirectBundle\AdminList\RedirectAdminListConfigurator::getBundleName" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+
         $this->assertEquals('KunstmaanRedirectBundle', $this->object->getBundleName());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetEntityName()
     {
+        $this->expectDeprecation('Since kunstmaan/redirect-bundle 6.4: The "Kunstmaan\RedirectBundle\AdminList\RedirectAdminListConfigurator::getEntityName" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.');
+
         $this->assertEquals('Redirect', $this->object->getEntityName());
+    }
+
+    public function testGetEntityClass()
+    {
+        $this->assertSame(Redirect::class, $this->object->getEntityClass());
     }
 }

--- a/src/Kunstmaan/TaggingBundle/AdminList/TagAdminListConfigurator.php
+++ b/src/Kunstmaan/TaggingBundle/AdminList/TagAdminListConfigurator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManager;
 use Kunstmaan\AdminBundle\Helper\Security\Acl\AclHelper;
 use Kunstmaan\AdminListBundle\AdminList\Configurator\AbstractDoctrineORMAdminListConfigurator;
 use Kunstmaan\AdminListBundle\AdminList\FilterType\ORM;
+use Kunstmaan\TaggingBundle\Entity\Tag;
 use Kunstmaan\TaggingBundle\Form\TagAdminType;
 
 class TagAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
@@ -45,6 +46,8 @@ class TagAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/tagging-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanTaggingBundle';
     }
 
@@ -55,6 +58,13 @@ class TagAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
      */
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/tagging-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Tag';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Tag::class;
     }
 }

--- a/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
+++ b/src/Kunstmaan/TranslatorBundle/AdminList/TranslationAdminListConfigurator.php
@@ -138,11 +138,11 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
      */
     public function getPathByConvention($suffix = null)
     {
-        if (empty($suffix)) {
-            return sprintf('%s_settings_%ss', $this->getBundleName(), strtolower($this->getEntityName()));
+        if (null === $suffix || $suffix === '') {
+            return 'KunstmaanTranslatorBundle_settings_translations';
         }
 
-        return sprintf('%s_settings_%ss_%s', $this->getBundleName(), strtolower($this->getEntityName()), $suffix);
+        return sprintf('KunstmaanTranslatorBundle_settings_translations_%s', $suffix);
     }
 
     public function getAdminType($item)
@@ -152,12 +152,21 @@ class TranslationAdminListConfigurator extends AbstractDoctrineDBALAdminListConf
 
     public function getBundleName()
     {
+        trigger_deprecation('kunstmaan/translator-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'KunstmaanTranslatorBundle';
     }
 
     public function getEntityName()
     {
+        trigger_deprecation('kunstmaan/translator-bundle', '6.4', 'The "%s" method is deprecated and will be removed in 7.0. Use the "getEntityClass" method instead.', __METHOD__);
+
         return 'Translation';
+    }
+
+    public function getEntityClass(): string
+    {
+        return Translation::class;
     }
 
     public function getControllerPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

This PR deprecates the `getBundleName/getEntityName` on the AdminlistConfigurator class and replaces it with an getEntityClass method. This new method is necessary to provide compatibility with newer versions of the doctrine dependencies and the getBundleName became redundant because no bundle are used in the src directory anymore.

TODO:
- [x] Replace deprecated methods in configurators in other bundles
- [x] Test new code in demo app