### PR TITLE
[AdminListBundle] Fix response return type

### DIFF
--- a/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
+++ b/src/Kunstmaan/AdminListBundle/Event/AdminListEvent.php
@@ -25,7 +25,7 @@ final class AdminListEvent extends Event
     protected $request;
 
     /**
-     * @var Response
+     * @var Response|null
      */
     protected $response;
 
@@ -54,7 +54,7 @@ final class AdminListEvent extends Event
         return $this->form;
     }
 
-    public function getResponse(): Response
+    public function getResponse(): ?Response
     {
         return $this->response;
     }

--- a/src/Kunstmaan/AdminListBundle/Tests/Event/AdminListEventTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/Event/AdminListEventTest.php
@@ -21,6 +21,7 @@ class AdminListEventTest extends TestCase
         $this->assertInstanceOf(Form::class, $event->getForm());
         $this->assertInstanceOf(\DateTime::class, $event->getEntity());
         $this->assertInstanceOf(Request::class, $event->getRequest());
+        $this->assertNull($event->getResponse());
 
         $event->setResponse(new Response());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR


Kunstmaan\AdminListBundle\Event\AdminListEvent::getResponse(): Return value must be of type Symfony\Component\HttpFoundation\Response, null returned