### PR TITLE
[SitemapBundle] Fix return type for hidden from sitemap

### DIFF
--- a/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
+++ b/src/Kunstmaan/SitemapBundle/Twig/SitemapTwigExtension.php
@@ -24,7 +24,7 @@ final class SitemapTwigExtension extends AbstractExtension
     /**
      * Returns true when the item should be hidden from the sitemap
      */
-    public function isHiddenFromSitemap(NodeMenuItem $item): \Kunstmaan\NodeBundle\Helper\NodeMenuItem
+    public function isHiddenFromSitemap(NodeMenuItem $item): bool
     {
         if (is_subclass_of($item->getNode()->getRefEntityName(), 'Kunstmaan\\SitemapBundle\\Helper\\HiddenFromSitemapInterface')) {
             $page = $item->getPage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Kunstmaan\SitemapBundle\Twig\SitemapTwigExtension::isHiddenFromSitemap(): Return value must be of type Kunstmaan\NodeBundle\Helper\NodeMenuItem, bool returned