### PR TITLE
[NodeBundle][MediaBundle] Prepend required stof/doctrine-extensions config instead of manually registering services

### DIFF
--- a/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
+++ b/src/Kunstmaan/MediaBundle/DependencyInjection/KunstmaanMediaExtension.php
@@ -82,6 +82,7 @@ class KunstmaanMediaExtension extends Extension implements PrependExtensionInter
             'orm' => [
                 'default' => [
                     'translatable' => true,
+                    'tree' => true,
                 ],
             ],
         ];

--- a/src/Kunstmaan/MediaBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/MediaBundle/Resources/config/services.yml
@@ -154,12 +154,6 @@ services:
         tags:
             - { name: twig.extension }
 
-    Gedmo\Tree\TreeListener:
-        tags:
-            - { name: doctrine.event_subscriber, connection: default }
-        calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]
-
     Kunstmaan\MediaBundle\DataFixtures\ORM\FolderFixtures:
         tags:
             - { name: doctrine.fixture.orm }

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -58,5 +58,15 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
         $twigConfig['globals']['publish_later_stepping'] = $config['publish_later_stepping'];
         $twigConfig['globals']['unpublish_later_stepping'] = $config['unpublish_later_stepping'];
         $container->prependExtensionConfig('twig', $twigConfig);
+
+        $stofDoctrineExtensionsConfig = [
+            'orm' => [
+                'default' => [
+                    'tree' => true,
+                ],
+            ],
+        ];
+
+        $container->prependExtensionConfig('stof_doctrine_extensions', $stofDoctrineExtensionsConfig);
     }
 }

--- a/src/Kunstmaan/NodeBundle/Resources/config/services.yml
+++ b/src/Kunstmaan/NodeBundle/Resources/config/services.yml
@@ -207,13 +207,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
-    # This doctrine listener needs to be registered so the "kunstmaan_node.node_menu" service works correctly.
-    Gedmo\Tree\TreeListener:
-        tags:
-            - { name: doctrine.event_subscriber, connection: default }
-        calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]
-
     kunstmaan_node.node_menu:
         class: Kunstmaan\NodeBundle\Helper\NodeMenu
         arguments: ['@doctrine.orm.entity_manager', '@security.token_storage', '@kunstmaan_admin.acl.helper', '@kunstmaan_admin.domain_configuration']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Fixes [the Doctrine Lifecycle Subscribers deprecation](https://symfony.com/doc/6.4/doctrine/events.html#doctrine-lifecycle-subscribers) triggered by the media and node bundle