### PR TITLE
[TaggingBundle] fixed base route name

### DIFF
--- a/src/Kunstmaan/TaggingBundle/AdminList/TagAdminListConfigurator.php
+++ b/src/Kunstmaan/TaggingBundle/AdminList/TagAdminListConfigurator.php
@@ -67,4 +67,18 @@ class TagAdminListConfigurator extends AbstractDoctrineORMAdminListConfigurator
     {
         return Tag::class;
     }
+
+    /**
+     * @param string|null $suffix
+     *
+     * @return string
+     */
+    public function getPathByConvention($suffix = null)
+    {
+        if (null === $suffix || $suffix === '') {
+            return 'kunstmaantaggingbundle_admin_tag';
+        }
+
+        return sprintf('kunstmaantaggingbundle_admin_tag_%s', $suffix);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Fixed tickets | 

Fixes the same problem as in #3401 for the TaggingBundle
Wrong admin list route name generated in [AbstractAdminListConfigurator::getPathByConvention](https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/f07cc4584d4005f45126e462609bbf3aeb23fd6a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php#L815)
