### PR TITLE
[AdminBundle] fixed base route name for exception admin lists

### DIFF
--- a/src/Kunstmaan/AdminBundle/AdminList/ExceptionAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminBundle/AdminList/ExceptionAdminListConfigurator.php
@@ -121,4 +121,18 @@ class ExceptionAdminListConfigurator extends AbstractDoctrineORMAdminListConfigu
     {
         return Exception::class;
     }
+
+    /**
+     * @param string|null $suffix
+     *
+     * @return string
+     */
+    public function getPathByConvention($suffix = null)
+    {
+        if (null === $suffix || $suffix === '') {
+            return 'kunstmaanadminbundle_admin_exception';
+        }
+
+        return sprintf('kunstmaanadminbundle_admin_exception_%s', $suffix);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

I don't know if this the admin list for exceptions is still used. Or if exceptions are still logged in 7.1. Maybe it's deprecated and there's a config flag to disable it. Haven't found anything on the docs.

Anyway, in our admin UI there's a menu entry for it that throws route-not-found exceptions. So here is a fix for it.
