### PR TITLE
[TranslatorBundle] Fixed MessageCatalogue strict type (string) parameters in Translator Loader

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/Service/Translator/Loader.php
+++ b/src/Kunstmaan/TranslatorBundle/Service/Translator/Loader.php
@@ -24,7 +24,11 @@ class Loader implements LoaderInterface
             $catalogue = new MessageCatalogue($locale);
             $translations = $this->translationRepository->findBy(['locale' => $locale]);
             foreach ($translations as $translation) {
-                $catalogue->set($translation->getKeyword(), $translation->getText(), $translation->getDomain());
+                $catalogue->set(
+                    (string) $translation->getKeyword(),
+                    (string) $translation->getText(),
+                    (string) $translation->getDomain()
+                );
             }
             $this->catalogues[$locale] = $catalogue;
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

As the `\Symfony\Component\Translation\MessageCatalogue`[ `set` function is strict typed to (native) string.](https://github.com/symfony/translation/commit/b70eb704bc81212cbe8a1f6d4c426f947e93491d#diff-b1e036016b19f0d2bd016107e5f736b6f2b1ebba161706b13588ef461af2fdfaR83) Entries from the database with values NULL will throw an error on 

```
 $catalogue->set($translation->getKeyword(), $translation->getText(), $translation->getDomain());
```

Casting them to `string` will resolve this.

_\Symfony\Component\Translation\MessageCatalogue::set()_
```
    /**
     * @return void
     */
    public function set(string $id, string $translation, string $domain = 'messages')
    {
        $this->add([$id => $translation], $domain);
    }
```


