### PR TITLE
[MenuBundle] Override getPathByConvention function in MenuItemAdminListConfigurator

### DIFF
--- a/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
+++ b/src/Kunstmaan/MenuBundle/AdminList/MenuItemAdminListConfigurator.php
@@ -137,4 +137,18 @@ class MenuItemAdminListConfigurator extends AbstractDoctrineORMAdminListConfigur
     {
         return 1000;
     }
+
+    /**
+     * @param string|null $suffix
+     *
+     * @return string
+     */
+    public function getPathByConvention($suffix = null)
+    {
+        if (null === $suffix || $suffix === '') {
+            return 'kunstmaanmenubundle_admin_menuitem';
+        }
+
+        return sprintf('kunstmaanmenubundle_admin_menuitem_%s', $suffix);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Fixed tickets | 

Override `getPathByConvention` function in `MenuItemAdminListConfigurator.php` so it returns the correct path.