### PR TITLE
[FormBundle] Fix form submission export

### DIFF
--- a/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
+++ b/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php
@@ -125,9 +125,8 @@ class FormSubmissionExportListConfigurator implements ExportListConfiguratorInte
 
         $collection = new ArrayCollection();
         $i = 0;
-        foreach ($iterableResult as $row) {
+        foreach ($iterableResult as $submission) {
             /* @var FormSubmission $submission */
-            $submission = $row[0];
 
             // Write row data
             $data = [

--- a/src/Kunstmaan/FormBundle/Tests/AdminList/FormSubmissionExportListConfiguratorTest.php
+++ b/src/Kunstmaan/FormBundle/Tests/AdminList/FormSubmissionExportListConfiguratorTest.php
@@ -56,9 +56,9 @@ class FormSubmissionExportListConfiguratorTest extends TestCase
         ]));
 
         $submissions = [
-            [$sub],
-            [new FormSubmission()],
-            [new FormSubmission()],
+            $sub,
+            new FormSubmission(),
+            new FormSubmission(),
         ];
         $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')
             ->disableOriginalConstructor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The old "iterate" method returns an array, but "toIterable" returns a object. It triggers now the following error:

Cannot use object of type Kunstmaan\FormBundle\Entity\FormSubmission as array on kunstmaan/bundles-cms/src/Kunstmaan/FormBundle/AdminList/FormSubmissionExportListConfigurator.php line 130