### PR TITLE
[UtilitiesBundle] Fix instanceof proxy

### DIFF
--- a/src/Kunstmaan/UtilitiesBundle/Helper/ClassLookup.php
+++ b/src/Kunstmaan/UtilitiesBundle/Helper/ClassLookup.php
@@ -2,7 +2,7 @@
 
 namespace Kunstmaan\UtilitiesBundle\Helper;
 
-use Doctrine\Common\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 
 /**
  * Helper for looking up the classname, not the ORM proxy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

When fixing this deprecation (https://github.com/doctrine/orm/pull/10837) then the getClass method returns the proxy class instead of the real class. This check works for both enable_lazy_ghost_objects true/false.