### PR TITLE
[MultidomainBundle] Improve domain based locale router performance

### DIFF
--- a/UPGRADE-7.2.md
+++ b/UPGRADE-7.2.md
@@ -10,3 +10,10 @@ PagePartBundle
 --------------
 
 - Not passing a HasPagePartsInterface as second parameter in PagePartEvent is deprecated and will be required in 8.0.
+
+
+NodeBundle
+-----------------
+
+- The node-bundle/multidomain-bundle has now some improved logic in the router itself. Using the old router logic is deprecated and the new will be the default in 8.0.
+  To enable the new and improved router, set the `kunstmaan_node.enable_improved_router` config to `true`.

--- a/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/MultiDomainBundle/DependencyInjection/Configuration.php
@@ -52,6 +52,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
                 ->end()
             ->end();
 

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -9,14 +9,10 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class DomainBasedLocaleRouter extends SlugRouter
 {
-    /** @var RouteCollection */
-    protected $routeCollectionMultiLanguage;
-
     /**
      * @var array|null
      */
@@ -172,17 +168,6 @@ class DomainBasedLocaleRouter extends SlugRouter
      */
     public function getRouteCollection(): RouteCollection
     {
-        if (($this->otherSite && $this->isMultiLanguage($this->otherSite['host'])) || (!$this->otherSite && $this->isMultiLanguage())) {
-            if (!$this->routeCollectionMultiLanguage) {
-                $this->routeCollectionMultiLanguage = new RouteCollection();
-
-                $this->addMultiLangPreviewRoute();
-                $this->addMultiLangSlugRoute();
-            }
-
-            return $this->routeCollectionMultiLanguage;
-        }
-
         if (!$this->routeCollection) {
             $this->routeCollection = new RouteCollection();
 
@@ -200,39 +185,6 @@ class DomainBasedLocaleRouter extends SlugRouter
     {
         $routeParameters = $this->getSlugRouteParameters();
         $this->addRoute('_slug', $routeParameters);
-    }
-
-    /**
-     * Add the slug route to the route collection
-     */
-    protected function addMultiLangPreviewRoute()
-    {
-        $routeParameters = $this->getPreviewRouteParameters();
-        $this->addMultiLangRoute('_slug_preview', $routeParameters);
-    }
-
-    /**
-     * Add the slug route to the route collection multilanguage
-     */
-    protected function addMultiLangSlugRoute()
-    {
-        $routeParameters = $this->getSlugRouteParameters();
-        $this->addMultiLangRoute('_slug', $routeParameters);
-    }
-
-    /**
-     * @param string $name
-     */
-    protected function addMultiLangRoute($name, array $parameters = [])
-    {
-        $this->routeCollectionMultiLanguage->add(
-            $name,
-            new Route(
-                $parameters['path'],
-                $parameters['defaults'],
-                $parameters['requirements']
-            )
-        );
     }
 
     /**
@@ -258,7 +210,7 @@ class DomainBasedLocaleRouter extends SlugRouter
         // If other site provided and multilingual, get the locales from the host config.
         if ($this->otherSite && $this->isMultiLanguage($this->otherSite['host'])) {
             $locales = $this->getHostLocales();
-        } elseif ($this->isMultiLanguage() && !$this->otherSite) {
+        } elseif (!$this->otherSite && $this->isMultiLanguage()) {
             $locales = $this->getFrontendLocales();
         }
 

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -32,7 +32,7 @@ class DomainBasedLocaleRouter extends SlugRouter
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        if ('_slug' === $name && $this->isMultiLanguage() && $this->isMultiDomainHost()) {
+        if ('_slug' === $name && $this->isMultiDomainHost() && $this->isMultiLanguage()) {
             $locale = isset($parameters['_locale']) ? $parameters['_locale'] : $this->getRequestLocale();
 
             $reverseLocaleMap = $this->getReverseLocaleMap();
@@ -96,13 +96,7 @@ class DomainBasedLocaleRouter extends SlugRouter
      */
     protected function getRequestLocale()
     {
-        $request = $this->getMasterRequest();
-        $locale = $this->getDefaultLocale();
-        if (!\is_null($request)) {
-            $locale = $request->getLocale();
-        }
-
-        return $locale;
+        return $this->getMasterRequest()?->getLocale() ?: $this->getDefaultLocale();
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -157,7 +157,7 @@ class DomainBasedLocaleRouter extends SlugRouter
     public function getRouteCollection(): RouteCollection
     {
         if (!$this->enabledImprovedRouter) {
-            trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'Not enabling the improved router is deprecated and the changed and improved router will be the default in 8.0. Set the "kunstmaan_multi_domain.enable_improved_domain_based_local_router" config to true.');
+            trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'Not enabling the improved router is deprecated and the changed and improved router will be the default in 8.0. Set the "kunstmaan_node.enable_improved_router" config to true.');
 
             if (($this->otherSite && $this->isMultiLanguage($this->otherSite['host'])) || (!$this->otherSite && $this->isMultiLanguage())) {
                 if (!$this->routeCollectionMultiLanguage) {

--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -9,10 +9,18 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class DomainBasedLocaleRouter extends SlugRouter
 {
+    /**
+     * @var RouteCollection
+     *
+     * @deprecated routeCollectionMultiLanguage property is deprecated in 7.2 and will be removed in 8.0. There is no replacement for this property.
+     */
+    protected $routeCollectionMultiLanguage;
+
     private ?array $otherSite = null;
     private array $cachedNodeTranslations = [];
 
@@ -148,6 +156,21 @@ class DomainBasedLocaleRouter extends SlugRouter
      */
     public function getRouteCollection(): RouteCollection
     {
+        if (!$this->enabledImprovedRouter) {
+            trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'Not enabling the improved router is deprecated and the changed and improved router will be the default in 8.0. Set the "kunstmaan_multi_domain.enable_improved_domain_based_local_router" config to true.');
+
+            if (($this->otherSite && $this->isMultiLanguage($this->otherSite['host'])) || (!$this->otherSite && $this->isMultiLanguage())) {
+                if (!$this->routeCollectionMultiLanguage) {
+                    $this->routeCollectionMultiLanguage = new RouteCollection();
+
+                    $this->addMultiLangPreviewRoute();
+                    $this->addMultiLangSlugRoute();
+                }
+
+                return $this->routeCollectionMultiLanguage;
+            }
+        }
+
         if (!$this->routeCollection) {
             $this->routeCollection = new RouteCollection();
 
@@ -165,6 +188,45 @@ class DomainBasedLocaleRouter extends SlugRouter
     {
         $routeParameters = $this->getSlugRouteParameters();
         $this->addRoute('_slug', $routeParameters);
+    }
+
+    /**
+     * Add the slug route to the route collection
+     */
+    protected function addMultiLangPreviewRoute()
+    {
+        trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'This method is deprecated and will be removed in 8.0.');
+
+        $routeParameters = $this->getPreviewRouteParameters();
+        $this->addMultiLangRoute('_slug_preview', $routeParameters);
+    }
+
+    /**
+     * Add the slug route to the route collection multilanguage
+     */
+    protected function addMultiLangSlugRoute()
+    {
+        trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'This method is deprecated and will be removed in 8.0.');
+
+        $routeParameters = $this->getSlugRouteParameters();
+        $this->addMultiLangRoute('_slug', $routeParameters);
+    }
+
+    /**
+     * @param string $name
+     */
+    protected function addMultiLangRoute($name, array $parameters = [])
+    {
+        trigger_deprecation('kunstmaan/multidomain-bundle', '7.2', 'This method is deprecated and will be removed in 8.0.');
+
+        $this->routeCollectionMultiLanguage->add(
+            $name,
+            new Route(
+                $parameters['path'],
+                $parameters['defaults'],
+                $parameters['requirements']
+            )
+        );
     }
 
     /**

--- a/src/Kunstmaan/MultiDomainBundle/Tests/Router/DomainBasedLocaleRouterTest.php
+++ b/src/Kunstmaan/MultiDomainBundle/Tests/Router/DomainBasedLocaleRouterTest.php
@@ -97,6 +97,7 @@ class DomainBasedLocaleRouterTest extends TestCase
         $request = $this->getRequest('http://singlelangdomain.tld/');
 
         $object = new DomainBasedLocaleRouter($domainConfiguration, $this->getRequestStack($request), $this->getEntityManager(new NodeTranslation()), 'admin');
+        $object->enabledImprovedRouter(true);
 
         $mirror = new \ReflectionClass(DomainBasedLocaleRouter::class);
         $property = $mirror->getProperty('otherSite');
@@ -140,6 +141,7 @@ class DomainBasedLocaleRouterTest extends TestCase
 
         /** @var Container $container */
         $object = new DomainBasedLocaleRouter($domainConfiguration, $this->getRequestStack($request), $this->getEntityManager(new NodeTranslation()), 'admin');
+        $object->enabledImprovedRouter(true);
         $mirror = new \ReflectionClass(DomainBasedLocaleRouter::class);
         $property = $mirror->getProperty('otherSite');
         $property->setAccessible(true);
@@ -216,6 +218,9 @@ class DomainBasedLocaleRouterTest extends TestCase
 
     private function getDomainBasedLocaleRouter($request, $nodeTranslation = null)
     {
-        return new DomainBasedLocaleRouter($this->getDomainConfiguration(), $this->getRequestStack($request), $this->getEntityManager($nodeTranslation), 'admin');
+        $router = new DomainBasedLocaleRouter($this->getDomainConfiguration(), $this->getRequestStack($request), $this->getEntityManager($nodeTranslation), 'admin');
+        $router->enabledImprovedRouter(true);
+
+        return $router;
     }
 }

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultFalse()->end()
                     ->end()
                 ->end()
+                ->booleanNode('enable_improved_router')->defaultFalse()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
+++ b/src/Kunstmaan/NodeBundle/DependencyInjection/KunstmaanNodeExtension.php
@@ -42,6 +42,13 @@ class KunstmaanNodeExtension extends Extension implements PrependExtensionInterf
 
         $loader->load('services.yml');
         $loader->load('commands.yml');
+
+        $enableImprovedRouter = $config['enable_improved_router'] ?? false;
+        if (!$enableImprovedRouter) {
+            trigger_deprecation('kunstmaan/node-bundle', '7.2', 'Not setting the "kunstmaan_node.enable_improved_router" config to true is deprecated, it will always be true in 8.0.');
+        }
+        $slugRouter = $container->findDefinition('kunstmaan_node.slugrouter');
+        $slugRouter->addMethodCall('enabledImprovedRouter', [$enableImprovedRouter]);
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -182,7 +182,6 @@ class SlugRouter implements RouterInterface
             '_controller' => SlugController::class . '::slugAction',
             'preview' => true,
             'url' => '',
-            '_locale' => $this->getDefaultLocale(),
         ];
         $previewRequirements = [
             'url' => $this->getSlugPattern(),
@@ -190,8 +189,9 @@ class SlugRouter implements RouterInterface
 
         if ($this->isMultiLanguage()) {
             $previewPath = '/{_locale}' . $previewPath;
-            unset($previewDefaults['_locale']);
             $previewRequirements['_locale'] = $this->getEscapedLocales($this->getBackendLocales());
+        } else {
+            $previewDefaults['_locale'] = $this->getDefaultLocale();
         }
 
         return [
@@ -213,7 +213,6 @@ class SlugRouter implements RouterInterface
             '_controller' => SlugController::class . '::slugAction',
             'preview' => false,
             'url' => '',
-            '_locale' => $this->getDefaultLocale(),
         ];
         $slugRequirements = [
             'url' => $this->getSlugPattern(),
@@ -221,8 +220,9 @@ class SlugRouter implements RouterInterface
 
         if ($this->isMultiLanguage()) {
             $slugPath = '/{_locale}' . $slugPath;
-            unset($slugDefaults['_locale']);
             $slugRequirements['_locale'] = $this->getEscapedLocales($this->getFrontendLocales());
+        } else {
+            $slugDefaults['_locale'] = $this->getDefaultLocale();
         }
 
         return [

--- a/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
+++ b/src/Kunstmaan/NodeBundle/Router/SlugRouter.php
@@ -52,6 +52,13 @@ class SlugRouter implements RouterInterface
     /** @var string */
     protected $slugPattern;
 
+    /**
+     * NEXT_MAJOR: Remove property
+     *
+     * @internal
+     */
+    protected bool $enabledImprovedRouter = false;
+
     public function __construct(
         DomainConfigurationInterface $domainConfiguration,
         RequestStack $requestStack,
@@ -340,5 +347,15 @@ class SlugRouter implements RouterInterface
         }
 
         return implode('|', $escapedLocales);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove method
+     *
+     * @interal
+     */
+    public function enabledImprovedRouter(bool $enabled): void
+    {
+        $this->enabledImprovedRouter = $enabled;
     }
 }

--- a/src/Kunstmaan/NodeBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,6 +30,7 @@ class ConfigurationTest extends TestCase
                 'threshold' => 35,
             ],
             'enable_permissions' => true,
+            'enable_improved_router' => false,
         ];
 
         $this->assertProcessedConfigurationEquals([$array], $array);

--- a/src/Kunstmaan/NodeBundle/Tests/DependencyInjection/KunstmaanNodeExtensionTest.php
+++ b/src/Kunstmaan/NodeBundle/Tests/DependencyInjection/KunstmaanNodeExtensionTest.php
@@ -4,10 +4,13 @@ namespace Kunstmaan\NodeBundle\Tests\DependencyInjection;
 
 use Kunstmaan\NodeBundle\DependencyInjection\KunstmaanNodeExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class KunstmaanNodeExtensionTest extends AbstractExtensionTestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @return ExtensionInterface[]
      */
@@ -19,7 +22,7 @@ class KunstmaanNodeExtensionTest extends AbstractExtensionTestCase
     public function testCorrectParametersHaveBeenSet()
     {
         $this->container->setParameter('twig.form.resources', []);
-        $this->load();
+        $this->load(['enable_improved_router' => true]);
 
         $this->assertContainerBuilderHasParameter('twig.form.resources');
         $this->assertContainerBuilderHasParameter('kunstmaan_node.show_add_homepage', true);
@@ -29,5 +32,15 @@ class KunstmaanNodeExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_node.lock_enabled', false);
         $this->assertContainerBuilderHasParameter('kunstmaan_node.version_timeout', 3600);
         $this->assertContainerBuilderHasParameter('kunstmaan_node.url_chooser.lazy_increment', 2);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testImprovedRouterConfigDeprecation()
+    {
+        $this->expectDeprecation('Since kunstmaan/node-bundle 7.2: Not setting the "kunstmaan_node.enable_improved_router" config to true is deprecated, it will always be true in 8.0.');
+        $this->container->setParameter('twig.form.resources', []);
+        $this->load();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes?
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

This line https://github.com/Kunstmaan/KunstmaanBundlesCMS/blob/7.x/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php#L175 decrease performance when you have many links. The "isMultiLanguage" check is also done inside "getSlugRouteParameters" so it is not necessary to perform that inside the "getRouteCollection" for every link. Runtime checks inside "getRouteCollection" are slow (https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Routing/RouterInterface.php#L29)

We have about 20/25% profit on a page with only a menu and footer.

The only BC break is as the removed methods are overridden. We can solve it maybe with an config setting to switch to the improved router? Is this needed to implement?
