### PR TITLE
[AllBundles] Fix fixture deprecations

### DIFF
--- a/src/Kunstmaan/FixturesBundle/Loader/FixtureLoader.php
+++ b/src/Kunstmaan/FixturesBundle/Loader/FixtureLoader.php
@@ -24,7 +24,7 @@ abstract class FixtureLoader implements FixtureInterface, ContainerAwareInterfac
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $this->manager = $manager;
         $options = $this->getOptions();

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
@@ -19,7 +19,7 @@ class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $group1 = $this->createGroup($manager, 'Administrators', [
             $this->getReference(RoleFixtures::REFERENCE_PERMISSIONMANAGER_ROLE),

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
@@ -22,7 +22,7 @@ class RoleFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $role1 = $this->createRole($manager, 'ROLE_PERMISSIONMANAGER');
         $role2 = $this->createRole($manager, 'ROLE_ADMIN');

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
@@ -28,7 +28,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $password = substr(rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '='), 0, 8);
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/DataFixtures/ORM/ArticleGenerator/ArticleFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/DataFixtures/ORM/ArticleGenerator/ArticleFixtures.php
@@ -49,7 +49,7 @@ class {{ entity_class }}ArticleFixtures extends AbstractFixture implements Order
      *
      * @param ObjectManager $manager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         if ($this->isMultiLanguage) {
             $languages = explode('|', $this->requiredLocales);

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
@@ -84,7 +84,7 @@ class DefaultSiteFixtures extends AbstractFixture implements OrderedFixtureInter
      *
      * @param ObjectManager $manager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $this->manager = $manager;
 

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
@@ -41,7 +41,7 @@ class SearchFixtures extends AbstractFixture implements OrderedFixtureInterface,
      *
      * @param ObjectManager $manager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         if ($this->isMultiLanguage) {
             $languages = explode('|', $this->requiredLocales);

--- a/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
+++ b/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
@@ -16,7 +16,7 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $gal = new Folder();
         $gal->setRel(Folder::TYPE_MEDIA);

--- a/src/Kunstmaan/TranslatorBundle/DataFixtures/ORM/TranslationFixtures.php
+++ b/src/Kunstmaan/TranslatorBundle/DataFixtures/ORM/TranslationFixtures.php
@@ -22,7 +22,7 @@ class TranslationFixtures extends AbstractFixture implements OrderedFixtureInter
     /**
      * Load data fixtures with the passed EntityManager
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $this->repo = $manager->getRepository(Entity::class);
 

--- a/src/Kunstmaan/TranslatorBundle/Tests/Fixtures/TranslationDataFixture.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/Fixtures/TranslationDataFixture.php
@@ -23,7 +23,7 @@ final class TranslationDataFixture implements FixtureInterface
         $this->faker = FakerFactory::create();
     }
 
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $this->errorKeys($manager);
         $this->exceptionKeys($manager);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | comma separated list of tickets fixed by the PR

Method "Doctrine\Common\DataFixtures\FixtureInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Kunstmaan\GeneratorBundle\DataFixtures\ORM\GroupFixtures" now to avoid errors or add an explicit @return annotation to suppress this message.