### PR TITLE
[AdminBundle] Remove session security listener if values are not enabled

### DIFF
--- a/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
+++ b/src/Kunstmaan/AdminBundle/DependencyInjection/KunstmaanAdminExtension.php
@@ -79,6 +79,7 @@ class KunstmaanAdminExtension extends Extension
         }
 
         $this->registerExceptionLoggingConfiguration($config['exception_logging'], $container);
+        $this->removeSessionSecurityListener($config, $container);
 
         $container->setParameter('kunstmaan_admin.default_locale', $config['default_locale']);
         $container->setParameter('kunstmaan_admin.website_title', $config['website_title']);
@@ -135,6 +136,15 @@ class KunstmaanAdminExtension extends Extension
 
         $definition = $container->getDefinition('kunstmaan_admin.menu.adaptor.settings');
         $definition->setArgument(2, false);
+    }
+
+    private function removeSessionSecurityListener(array $config, ContainerBuilder $container): void
+    {
+        if ($config['session_security']['ip_check'] || $config['session_security']['user_agent_check']) {
+            return;
+        }
+
+        $container->removeDefinition('kunstmaan_admin.session_security');
     }
 
     private function configureAuthentication(array $config, ContainerBuilder $container, LoaderInterface $loader): void

--- a/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/DependencyInjection/KunstmaanAdminExtensionTest.php
@@ -91,6 +91,20 @@ class KunstmaanAdminExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('kunstmaan_admin.admin_exception_excludes', ['test_exclude_new_config']);
     }
 
+    public function testRemoveSessionSecurityListener()
+    {
+        $this->assertContainerBuilderNotHasService('kunstmaan_admin.session_security');
+
+        $this->load(array_merge($this->getRequiredConfig(), [
+            'session_security' => [
+                'ip_check' => true,
+                'user_agent_check' => true,
+            ],
+        ]));
+
+        $this->assertContainerBuilderHasService('kunstmaan_admin.session_security');
+    }
+
     private function getRequiredConfig(?string $excludeKey = null)
     {
         $requiredConfig = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3463
