### PR TITLE
[MultiDomainBundle] Prevent duplicate calls for getting node translation

### DIFF
--- a/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
+++ b/src/Kunstmaan/MultiDomainBundle/Router/DomainBasedLocaleRouter.php
@@ -105,24 +105,25 @@ class DomainBasedLocaleRouter extends SlugRouter
     protected function getNodeTranslation($matchResult)
     {
         $key = $matchResult['_controller'] . $matchResult['url'] . $matchResult['_locale'] . $matchResult['_route'];
-        if (!isset($this->cachedNodeTranslations[$key])) {
-            $rootNode = $this->domainConfiguration->getRootNode();
-
-            // Lookup node translation
-            $nodeTranslationRepo = $this->getNodeTranslationRepository();
-
-            /* @var NodeTranslation $nodeTranslation */
-            $nodeTranslation = $nodeTranslationRepo->getNodeTranslationForUrl(
-                $matchResult['url'],
-                $matchResult['_locale'],
-                false,
-                null,
-                $rootNode
-            );
-            $this->cachedNodeTranslations[$key] = $nodeTranslation;
+        if (\array_key_exists($key, $this->cachedNodeTranslations)) {
+            return $this->cachedNodeTranslations[$key];
         }
 
-        return $this->cachedNodeTranslations[$key];
+        $rootNode = $this->domainConfiguration->getRootNode();
+
+        // Lookup node translation
+        $nodeTranslationRepo = $this->getNodeTranslationRepository();
+
+        /* @var NodeTranslation $nodeTranslation */
+        $nodeTranslation = $nodeTranslationRepo->getNodeTranslationForUrl(
+            $matchResult['url'],
+            $matchResult['_locale'],
+            false,
+            null,
+            $rootNode
+        );
+
+        return $this->cachedNodeTranslations[$key] = $nodeTranslation;
     }
 
     private function isMultiDomainHost(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Use array_key_exists instead of isset because the value inside cachedNodeTranslations can be null