### PR TITLE
[AllBundles] Fix compatibility with doctrine fixtures 2.0

### DIFF
--- a/src/Kunstmaan/CookieBundle/Resources/skeleton/legal/DataFixtures/ORM/LegalGenerator/DefaultFixtures.php
+++ b/src/Kunstmaan/CookieBundle/Resources/skeleton/legal/DataFixtures/ORM/LegalGenerator/DefaultFixtures.php
@@ -476,10 +476,8 @@ class DefaultFixtures extends Fixture implements OrderedFixtureInterface, Fixtur
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 52;
     }

--- a/src/Kunstmaan/FixturesBundle/README.md
+++ b/src/Kunstmaan/FixturesBundle/README.md
@@ -1,8 +1,8 @@
 # How to use the FixturesBundle
 
-You will still use the default doctrine fixtures way but instead of extending from the `Doctrine\Common\DataFixtures\AbstractFixture` class, 
+You will still use the default doctrine fixtures way but instead of extending from the `Doctrine\Common\DataFixtures\AbstractFixture` class,
 you will instead extend from the `Kunstmaan\FixturesBundle\Loader\FixtureLoader` class.
- 
+
 This is what your fixture class will look like:
 
 ```php
@@ -25,10 +25,8 @@ class YamlFixtures extends FixtureLoader implements OrderedFixtureInterface
 
     /**
      * Get the order of this fixture
-     *
-     * @return integer
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 50;
     }
@@ -103,7 +101,7 @@ So how do these yaml files look like?
 
 \Acme\SomeBundle\Entity\PageParts\ContactPagePart:
     contact_pp_{1..5}:
-        contacts: 
+        contacts:
             - @contact_ironman
             - @contact_blackwidow
             - @contact_thor
@@ -115,7 +113,7 @@ So how do these yaml files look like?
             fr: []
 
     contact_pp_{6..10}:
-        contacts: 
+        contacts:
             - @contact_hulk
             - @contact_captainamerica
             - @contact_hawkeye
@@ -147,16 +145,16 @@ to your fixture class and returning an array containing your providers or you ca
 ### Parsers
 
 Parsers are used to translate the yaml data into actual data. So something like ```@content<current()>``` will be transformed to an object by different parsers.
-By default you have the Method and the Reference parser for property data and the Listed and Range parser for specs. If you want to add your 
+By default you have the Method and the Reference parser for property data and the Listed and Range parser for specs. If you want to add your
 own parser, you can simply to that by tagging them with ```kunstmaan_fixtures.parser.property``` or ```kunstmaan_fixtures.parser.spec```
 
 ### Populators
 
-Does exactly what the name says. Populators will populate the entities once all the yaml data is parsed. If you want to add your own populator, 
+Does exactly what the name says. Populators will populate the entities once all the yaml data is parsed. If you want to add your own populator,
 simply tag it with ```kunstmaan_fixtures.populator```
 
 ### Builders
 
 With builders you can manipulate the behaviour during the creation of your entity. This can happen in three stages, preBuild, postBuild and postFlushBuild.
-During these stages you can manipulate your entity or add more entities like we do in the PageBuilder for instance. If you want to add your own builder, 
+During these stages you can manipulate your entity or add more entities like we do in the PageBuilder for instance. If you want to add your own builder,
 simply tag it with ```kunstmaan_fixtures.builder```

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/GroupFixtures.php
@@ -65,10 +65,8 @@ class GroupFixtures extends AbstractFixture implements OrderedFixtureInterface
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 2;
     }

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/RoleFixtures.php
@@ -60,10 +60,8 @@ class RoleFixtures extends AbstractFixture implements OrderedFixtureInterface
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/DataFixtures/ORM/UserFixtures.php
@@ -103,10 +103,8 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/defaultsite/DataFixtures/ORM/DefaultSiteGenerator/DefaultSiteFixtures.php
@@ -753,10 +753,8 @@ class DefaultSiteFixtures extends AbstractFixture implements OrderedFixtureInter
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 51;
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/searchpage/DataFixtures/ORM/SearchPageGenerator/SearchFixtures.php
@@ -85,10 +85,8 @@ class SearchFixtures extends AbstractFixture implements OrderedFixtureInterface,
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 70;
     }

--- a/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
+++ b/src/Kunstmaan/MediaBundle/DataFixtures/ORM/FolderFixtures.php
@@ -125,10 +125,8 @@ class FolderFixtures extends AbstractFixture implements OrderedFixtureInterface
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/Kunstmaan/TranslatorBundle/DataFixtures/ORM/TranslationFixtures.php
+++ b/src/Kunstmaan/TranslatorBundle/DataFixtures/ORM/TranslationFixtures.php
@@ -71,10 +71,8 @@ class TranslationFixtures extends AbstractFixture implements OrderedFixtureInter
 
     /**
      * Get the order of this fixture
-     *
-     * @return int
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Compile Error: Declaration of Kunstmaan\MediaBundle\DataFixtures\ORM\FolderFixtures::getOrder() must be compatible with Doctrine\Common\DataFixtures\OrderedFixtureInterface::getOrder(): int