### PR TITLE
[NodeBundle] | (fix) nullable nodetranslation in slugtype

### DIFF
--- a/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
+++ b/src/Kunstmaan/NodeBundle/Form/Type/SlugType.php
@@ -50,7 +50,7 @@ class SlugType extends AbstractType
         $view->vars['prefix'] = '';
         if ($parentNode !== null) {
             $nodeTranslation = $parentNode->getNodeTranslation($nodeTranslation->getLang(), true);
-            $slug = $nodeTranslation->getSlugPart();
+            $slug = $nodeTranslation?->getSlugPart();
             if (!empty($slug)) {
                 $slug = rtrim($slug, '/') . '/';
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

The buildView method in SlugType can throw a 500 error when a nodeTranslation is not found in  parentNode->getNodeTranslation(). Adding a simple nullcheck resolves this. 
This bug occurs when a multilangual site had a subpage under a parent node which is not translated. This can be resolved by creating the parent node translation but shouldn't crash the CMS
