### PR TITLE
[MediaBundle] Add file content type to storage

### DIFF
--- a/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
+++ b/src/Kunstmaan/MediaBundle/Helper/File/FileHandler.php
@@ -222,7 +222,9 @@ class FileHandler extends AbstractMediaHandler
         }
 
         $originalFile = $this->getOriginalFile($media);
-        $originalFile->setContent(file_get_contents($media->getContent()->getRealPath()));
+        $originalFile->setContent(file_get_contents($media->getContent()->getRealPath()), [
+            'contentType' => $media->getContentType(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

We have a custom Symfony mime type guesser but the storage adapters calculates the mimetype again. Apply content type from media object.
