### PR TITLE
[MenuBundle] Add space to menu parent field

### DIFF
--- a/src/Kunstmaan/MenuBundle/Entity/BaseMenuItem.php
+++ b/src/Kunstmaan/MenuBundle/Entity/BaseMenuItem.php
@@ -330,15 +330,13 @@ abstract class BaseMenuItem implements EntityInterface
      */
     public function getDisplayTitle()
     {
-        if ($this->getType() == self::TYPE_PAGE_LINK) {
-            if (!\is_null($this->getTitle())) {
-                return $this->getTitle();
-            }
+        $repeat = str_repeat("\xC2\xA0", $this->getLvl() * 2);
 
-            return $this->getNodeTranslation()->getTitle();
+        if ($this->getType() == self::TYPE_PAGE_LINK) {
+            return $repeat . ($this->getTitle() ?? $this->getNodeTranslation()->getTitle());
         }
 
-        return $this->getTitle();
+        return $repeat . $this->getTitle();
     }
 
     /**

--- a/src/Kunstmaan/MenuBundle/Resources/views/AdminList/menu-item-title.html.twig
+++ b/src/Kunstmaan/MenuBundle/Resources/views/AdminList/menu-item-title.html.twig
@@ -1,5 +1,5 @@
 {% set marginDefinition = 60 %}
 {% set marginLeft = ((item.lvl + 1) * marginDefinition) - marginDefinition %}
 <div style="margin-left: {{ marginLeft }}px;{% if not item.online%}color:#999;{% endif %}">
-    {% if item.lvl > 0 %}∟ {% endif %}{{ item.displayTitle }}
+    {% if item.lvl > 0 %}∟ {% endif %}{{ item.displayTitle|trim('\xC2\xA0') }}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

So that it is easier to see what the parent is. Parent field is now a tree.

![image](https://github.com/user-attachments/assets/df0d1236-f691-407f-a4e3-f6cbdcc60aff)
