### PR TITLE
[SeoBundle] Supress getimagesize warnings

### DIFF
--- a/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
+++ b/src/Kunstmaan/SeoBundle/Twig/SeoTwigExtension.php
@@ -227,12 +227,12 @@ final class SeoTwigExtension extends AbstractExtension
         try {
             $cache = $this->getRequestCache();
             if (null === $cache) {
-                return getimagesize($src);
+                return @getimagesize($src);
             }
 
             $cachedImageSizes = $cache->getItem(md5($src));
             if (!$cachedImageSizes->isHit()) {
-                $sizes = getimagesize($src);
+                $sizes = @getimagesize($src);
 
                 $cachedImageSizes->set($sizes);
                 $cache->save($cachedImageSizes);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | comma separated list of tickets fixed by the PR

Supress warnings like this Warning: getimagesize("https://example.com"): Failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found