### PR TITLE
KUN-10436 | add legacypassword interface so salt is used for old pass…

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\GroupInterface;
 use Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictions;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -15,7 +16,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 /**
  * NEXT_MAJOR implement EquatableInterface
  */
-abstract class BaseUser implements UserInterface
+abstract class BaseUser implements UserInterface, LegacyPasswordAuthenticatedUserInterface
 {
     /**
      * @ORM\Id


### PR DESCRIPTION
Add legacypassword interface so salt is used for old passwords

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | KUN-10436
