### PR TITLE
[AdminBundle] Fix eraseCredentials deprecation

### DIFF
--- a/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
+++ b/src/Kunstmaan/AdminBundle/Entity/BaseUser.php
@@ -434,7 +434,10 @@ abstract class BaseUser implements UserInterface, EquatableInterface, PasswordAu
 
     /**
      * Removes sensitive data from the user.
+     *
+     * NEXT_MAJOR: Remove this method when only Symfony 8 is supported.
      */
+    #[\Deprecated('This method is deprecated by Symfony, no replacement will be provided.', 'kunstmaan/admin-bundle:7.4')]
     public function eraseCredentials(): void
     {
         $this->plainPassword = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Deprecation resolved as per https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.3.md#security