### PR TITLE
[MediaBundle] Harden the bulk upload file name handling

### DIFF
--- a/src/Kunstmaan/MediaBundle/Controller/MediaController.php
+++ b/src/Kunstmaan/MediaBundle/Controller/MediaController.php
@@ -9,6 +9,7 @@ use Kunstmaan\MediaBundle\Entity\Media;
 use Kunstmaan\MediaBundle\Form\BulkMoveMediaType;
 use Kunstmaan\MediaBundle\Helper\FolderManager;
 use Kunstmaan\MediaBundle\Helper\MediaManager;
+use Kunstmaan\UtilitiesBundle\Helper\SlugifierInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -153,6 +154,12 @@ final class MediaController extends AbstractController
         } else {
             $fileName = \uniqid('file_', false);
         }
+
+        $fileName = $this->getSafeUploadFileName((string) $fileName);
+        if (null === $fileName) {
+            return $this->returnJsonError('107', 'Invalid file name');
+        }
+
         $filePath = $targetDir . DIRECTORY_SEPARATOR . $fileName;
 
         $chunk = 0;
@@ -255,6 +262,36 @@ final class MediaController extends AbstractController
         );
 
         return $response;
+    }
+
+    /**
+     * Strip any path information from a client supplied file name and normalise what is left.
+     *
+     * @return string|null The safe file name, or null when nothing usable remains
+     */
+    private function getSafeUploadFileName(string $fileName): ?string
+    {
+        $fileName = str_replace(['\\', "\0"], '', basename($fileName));
+
+        $parts = pathinfo($fileName);
+        $safeName = $this->container->get('kunstmaan_utilities.slugifier')->slugify($parts['filename'] ?? '');
+
+        if ('' === $safeName) {
+            return null;
+        }
+
+        if (isset($parts['extension']) && '' !== $parts['extension']) {
+            $safeName .= '.' . strtolower($parts['extension']);
+        }
+
+        return $safeName;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'kunstmaan_utilities.slugifier' => SlugifierInterface::class,
+        ] + parent::getSubscribedServices();
     }
 
     private function returnJsonError($code, $message)

--- a/src/Kunstmaan/MediaBundle/Tests/Controller/MediaControllerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Controller/MediaControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Kunstmaan\MediaBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Kunstmaan\MediaBundle\Controller\MediaController;
+use Kunstmaan\MediaBundle\Helper\FolderManager;
+use Kunstmaan\MediaBundle\Helper\MediaManager;
+use Kunstmaan\UtilitiesBundle\Helper\Slugifier;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class MediaControllerTest extends TestCase
+{
+    /** @var MediaController */
+    private $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = new MediaController(
+            $this->createMock(MediaManager::class),
+            $this->createMock(FolderManager::class),
+            $this->createMock(TranslatorInterface::class),
+            $this->createMock(EntityManagerInterface::class)
+        );
+
+        $this->controller->setContainer(new ServiceLocator([
+            'kunstmaan_utilities.slugifier' => static function () {
+                return new Slugifier();
+            },
+        ]));
+    }
+
+    private function getSafeUploadFileName(string $fileName): ?string
+    {
+        $method = new \ReflectionMethod(MediaController::class, 'getSafeUploadFileName');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->controller, $fileName);
+    }
+
+    /**
+     * The bulk upload file name comes straight from the request and was concatenated into a path
+     * without any sanitisation, so it could point outside the temp upload directory.
+     *
+     * @dataProvider dataTraversalFileNames
+     */
+    public function testPathInformationIsStripped(string $fileName, string $expected)
+    {
+        $this->assertSame($expected, $this->getSafeUploadFileName($fileName));
+    }
+
+    public function dataTraversalFileNames(): array
+    {
+        return [
+            'relative traversal' => ['../../foo.jpg', 'foo.jpg'],
+            'absolute path' => ['/etc/passwd', 'passwd'],
+            'nested path' => ['a/b/c.png', 'c.png'],
+            'windows separators' => ['..\\..\\foo.jpg', 'foo.jpg'],
+            'null byte' => ["foo\0.jpg", 'foo.jpg'],
+            'traversal without extension' => ['../../foo', 'foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataRejectedFileNames
+     */
+    public function testFileNamesWithoutAnythingUsableAreRejected(string $fileName)
+    {
+        $this->assertNull($this->getSafeUploadFileName($fileName));
+    }
+
+    public function dataRejectedFileNames(): array
+    {
+        return [
+            'empty' => [''],
+            'current dir' => ['.'],
+            'parent dir' => ['..'],
+            'only separators' => ['/'],
+            'only whitespace' => ['   '],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNormalFileNames
+     */
+    public function testRegularFileNamesAreNormalised(string $fileName, string $expected)
+    {
+        $this->assertSame($expected, $this->getSafeUploadFileName($fileName));
+    }
+
+    public function dataNormalFileNames(): array
+    {
+        return [
+            'simple' => ['photo.jpg', 'photo.jpg'],
+            'spaces' => ['My Holiday Photo.jpg', 'my-holiday-photo.jpg'],
+            'uppercase extension' => ['photo.JPG', 'photo.jpg'],
+            'accents' => ['évidence.png', 'evidence.png'],
+            'no extension' => ['README', 'readme'],
+        ];
+    }
+}


### PR DESCRIPTION
The bulk upload action used the file name from the request as-is when building the plupload temp path.

The name is now normalised before it is used: any path information is stripped and what is left is slugified, keeping the extension intact because it is used to determine the media type. When nothing usable remains the request is rejected. Tests are added for the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)