### PR TITLE
[MediaBundle] Fix image mime type check in the media validator

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
@@ -83,6 +83,32 @@ class MediaValidatorTest extends ConstraintValidatorTestCase
         }
     }
 
+    /**
+     * @dataProvider dataNonImageContentTypes
+     */
+    public function testDimensionsAreNotCheckedForNonImages(string $contentType)
+    {
+        $constraint = new Media(['minWidth' => 200]);
+        $media = (new MediaObject())
+            ->setMetadataValue('original_width', 100)
+            ->setMetadataValue('original_height', 100)
+            ->setContentType($contentType);
+
+        $this->validator->validate($media, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function dataNonImageContentTypes()
+    {
+        return [
+            'contains image' => ['application/x-image-thing'],
+            'no slash at all' => ['notanimageatall'],
+            'plain text' => ['text/plain'],
+            'pdf' => ['application/pdf'],
+        ];
+    }
+
     public function dataMimeTypes()
     {
         return [

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
@@ -43,7 +43,7 @@ class MediaValidator extends ConstraintValidator
             }
         }
 
-        if (!preg_match('^image\/*^', $mimeType) || $mimeType === 'image/svg+xml') {
+        if (!str_starts_with((string) $mimeType, 'image/') || $mimeType === 'image/svg+xml') {
             return;
         }
 


### PR DESCRIPTION
The pattern used `^` as its delimiter, so it matched an unanchored `image` instead of a mime type starting with `image/`. Media with a content type that merely contained `image`, such as `application/x-image-thing`, was treated as an image and checked for dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)