### PR TITLE
[FormBundle] Remove duplicate image extensions from the upload allow list

### DIFF
--- a/src/Kunstmaan/FormBundle/DependencyInjection/Configuration.php
+++ b/src/Kunstmaan/FormBundle/DependencyInjection/Configuration.php
@@ -23,7 +23,6 @@ class Configuration implements ConfigurationInterface
                             ->scalarPrototype()->end()
                             ->defaultValue([
                                 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp', 'txt', 'csv', 'rtf', 'zip',
-                                'jpg', 'jpeg', 'png', 'gif', 'webp',
                                 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'jxl',
                             ])
                         ->end()


### PR DESCRIPTION
The image extensions were listed twice in the form upload configuration, the first line is fully covered by the second one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)