### PR TITLE
[MediaBundle] Compare the image mime type case insensitively

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
@@ -109,6 +109,60 @@ class MediaValidatorTest extends ConstraintValidatorTestCase
         ];
     }
 
+    /**
+     * The allowed mime types are compared case insensitively, but the image check below it was not,
+     * so an uppercase content type passed the allow list and then skipped the dimension check.
+     *
+     * @dataProvider dataUppercaseImageContentTypes
+     */
+    public function testDimensionsAreCheckedRegardlessOfContentTypeCase(string $contentType)
+    {
+        $constraint = new Media(['minWidth' => 200]);
+        $media = (new MediaObject())
+            ->setMetadataValue('original_width', 100)
+            ->setMetadataValue('original_height', 100)
+            ->setContentType($contentType);
+
+        $this->validator->validate($media, $constraint);
+
+        $this->buildViolation($constraint->minWidthMessage)
+            ->setParameter('{{ width }}', 100)
+            ->setParameter('{{ min_width }}', 200)
+            ->setCode(Media::TOO_NARROW_ERROR)
+            ->assertRaised();
+    }
+
+    public function dataUppercaseImageContentTypes()
+    {
+        return [
+            'fully uppercase' => ['IMAGE/PNG'],
+            'uppercase type' => ['IMAGE/png'],
+            'mixed case' => ['Image/Jpeg'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataSvgContentTypes
+     */
+    public function testSvgIsNotTestedForDimensionsRegardlessOfCase(string $contentType)
+    {
+        $constraint = new Media(['minHeight' => 100]);
+        $media = (new MediaObject())->setContentType($contentType);
+
+        $this->validator->validate($media, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function dataSvgContentTypes()
+    {
+        return [
+            'lowercase' => ['image/svg+xml'],
+            'uppercase' => ['IMAGE/SVG+XML'],
+            'mixed case' => ['Image/Svg+Xml'],
+        ];
+    }
+
     public function dataMimeTypes()
     {
         return [

--- a/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
+++ b/src/Kunstmaan/MediaBundle/Validator/Constraints/MediaValidator.php
@@ -28,6 +28,7 @@ class MediaValidator extends ConstraintValidator
         }
 
         $mimeType = $value->getContentType();
+        $normalizedMimeType = strtolower((string) $mimeType);
 
         if ($constraint->mimeTypes) {
             $mimeTypes = (array) $constraint->mimeTypes;
@@ -43,7 +44,7 @@ class MediaValidator extends ConstraintValidator
             }
         }
 
-        if (!str_starts_with((string) $mimeType, 'image/') || $mimeType === 'image/svg+xml') {
+        if (!str_starts_with($normalizedMimeType, 'image/') || $normalizedMimeType === 'image/svg+xml') {
             return;
         }
 


### PR DESCRIPTION
Builds on #3560 — please merge that one first, the diff here is against it and touches the same line.

The configured mime types are compared case insensitively in `validateMimeType()`, but the image check that guards the dimension validation was not. A media item with a content type like `IMAGE/PNG` passed a configured `image/*` allow list and then silently skipped the dimension validation.

The content type is now lowercased once for both comparisons, which also makes the svg exclusion case insensitive. The original value is kept for the violation message so the reported type still matches what was stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)