### PR TITLE
[AdminBundle] Optimize the admin route match regex

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminRouteHelper
 {
-    protected static $ADMIN_MATCH_REGEX = '/^\/(app_[a-zA-Z]+\.php\/)?([a-zA-Z_-]{2,5}\/)?%s\/(.*)/';
+    protected static $ADMIN_MATCH_REGEX = '/^\/(?:index\.php\/)?(?:[a-zA-Z_-]{2,5}\/)?%s\//';
 
     /**
      * @var string
@@ -41,14 +41,8 @@ class AdminRouteHelper
             return false;
         }
 
-        preg_match(sprintf(self::$ADMIN_MATCH_REGEX, $this->adminKey), $url, $matches);
-
         // Check if path is part of admin area
-        if (\count($matches) === 0) {
-            return false;
-        }
-
-        return true;
+        return preg_match(sprintf(self::$ADMIN_MATCH_REGEX, $this->adminKey), $url) === 1;
     }
 
     /**

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
@@ -18,6 +18,10 @@ class AdminRouteHelperTest extends TestCase
 
     protected static $ADMIN_URL = '/en/%s/nodes';
 
+    protected static $ADMIN_URL_WITHOUT_LOCALE = '/%s/nodes';
+
+    protected static $ADMIN_URL_WITH_FRONT_CONTROLLER = '/index.php/en/%s/nodes';
+
     protected static $PREVIEW_ADMIN_URL = '/en/%s/preview/blog/page/1';
 
     /**
@@ -31,6 +35,34 @@ class AdminRouteHelperTest extends TestCase
 
         $adminRouteHelper = $this->getAdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY);
         $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL, self::$ALTERNATIVE_ADMIN_KEY));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @covers \Kunstmaan\AdminBundle\Helper\AdminRouteHelper::isAdminRoute
+     */
+    public function testIsAdminRouteReturnsTrueWhenAdminUrlWithoutLocale()
+    {
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL_WITHOUT_LOCALE, self::$ADMIN_KEY));
+        $this->assertTrue($result);
+
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL_WITHOUT_LOCALE, self::$ALTERNATIVE_ADMIN_KEY));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @covers \Kunstmaan\AdminBundle\Helper\AdminRouteHelper::isAdminRoute
+     */
+    public function testIsAdminRouteReturnsTrueWhenAdminUrlWithFrontController()
+    {
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL_WITH_FRONT_CONTROLLER, self::$ADMIN_KEY));
+        $this->assertTrue($result);
+
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ALTERNATIVE_ADMIN_KEY);
+        $result = $adminRouteHelper->isAdminRoute(sprintf(self::$ADMIN_URL_WITH_FRONT_CONTROLLER, self::$ALTERNATIVE_ADMIN_KEY));
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3461

The front controller part of the `AdminRouteHelper` regex only matched the Symfony 2/3 `app_*.php` front controllers. Since this version requires Symfony `^6.4|^7.2` those can no longer exist, while `/index.php/en/admin/...` (a setup without url rewriting) was silently *not* detected as an admin route.

```diff
- '/^\/(app_[a-zA-Z]+\.php\/)?([a-zA-Z_-]{2,5}\/)?%s\/(.*)/'
+ '/^\/(?:index\.php\/)?(?:[a-zA-Z_-]{2,5}\/)?%s\//'
```

While at it the capturing groups and the trailing `(.*)` are dropped, as only the presence of a match was used and never the captured values. `isAdminRoute()` now returns the `preg_match()` result directly instead of building a matches array and counting it.

No `preg_quote()` is needed on the `%s` placeholder, `KunstmaanAdminExtension::normalizeUrlSlice()` already quotes the admin prefix at container build time.

Tests were added for an admin url without a locale prefix and for one with the `index.php` front controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)