### PR TITLE
[MediaBundle] Use named arguments for the Media constraint in tests

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Validator/Constraints/MediaValidatorTest.php
@@ -89,7 +89,7 @@ class MediaValidatorTest extends ConstraintValidatorTestCase
      */
     public function testDimensionsAreNotCheckedForNonImages(string $contentType)
     {
-        $constraint = new Media(['minWidth' => 200]);
+        $constraint = new Media(minWidth: 200);
         $media = (new MediaObject())
             ->setMetadataValue('original_width', 100)
             ->setMetadataValue('original_height', 100)
@@ -118,7 +118,7 @@ class MediaValidatorTest extends ConstraintValidatorTestCase
      */
     public function testDimensionsAreCheckedRegardlessOfContentTypeCase(string $contentType)
     {
-        $constraint = new Media(['minWidth' => 200]);
+        $constraint = new Media(minWidth: 200);
         $media = (new MediaObject())
             ->setMetadataValue('original_width', 100)
             ->setMetadataValue('original_height', 100)
@@ -147,7 +147,7 @@ class MediaValidatorTest extends ConstraintValidatorTestCase
      */
     public function testSvgIsNotTestedForDimensionsRegardlessOfCase(string $contentType)
     {
-        $constraint = new Media(['minHeight' => 100]);
+        $constraint = new Media(minHeight: 100);
         $media = (new MediaObject())->setContentType($contentType);
 
         $this->validator->validate($media, $constraint);


### PR DESCRIPTION
The `Media` constraint already supports named arguments (`#[HasNamedArguments]`), but `MediaValidatorTest` still configured it with an array of options in three places.

That tripped two deprecations per call in the test suite:
- the bundle's own `Passing an array of options to configure the "Kunstmaan\MediaBundle\Validator\Constraints\Media" constraint is deprecated, use named arguments instead.`
- and, through `parent::__construct($options, ...)`, `Since symfony/validator 7.4: Support for evaluating options in the base Constraint class is deprecated.` (see https://symfony.com/blog/new-in-symfony-7-3-validator-improvements#deprecated-option-arrays)

Switching the three call sites to named arguments takes the suite from 11 self deprecation notices to 1, and removes 10 direct notices. Tests still pass (1228 tests, 2487 assertions).

The remaining self deprecation (`AclVoter::vote()` requiring `Vote|null $vote`) is left as is: `Kunstmaan\AdminBundle\Helper\Security\Acl\Voter\AclVoter` already uses the conditional-trait pattern for the Symfony 8 signature, and upstream `symfony/security-acl`'s own `AclVoter` emits the identical notice in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)