### PR TITLE
[MediaBundle] Remove deprecated ReflectionMethod::setAccessible() calls

### DIFF
--- a/src/Kunstmaan/MediaBundle/Tests/Controller/MediaControllerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Controller/MediaControllerTest.php
@@ -35,7 +35,6 @@ class MediaControllerTest extends TestCase
     private function getSafeUploadFileName(string $fileName): ?string
     {
         $method = new \ReflectionMethod(MediaController::class, 'getSafeUploadFileName');
-        $method->setAccessible(true);
 
         return $method->invoke($this->controller, $fileName);
     }

--- a/src/Kunstmaan/MediaBundle/Tests/Helper/File/FileHandlerTest.php
+++ b/src/Kunstmaan/MediaBundle/Tests/Helper/File/FileHandlerTest.php
@@ -120,7 +120,6 @@ class FileHandlerTest extends TestCase
         $media->setOriginalFilename('My Photo.JPG');
 
         $method = new \ReflectionMethod(FileHandler::class, 'getFileFolderPath');
-        $method->setAccessible(true);
 
         $this->assertSame('abc123/', $method->invoke($this->object, $media));
     }
@@ -131,7 +130,6 @@ class FileHandlerTest extends TestCase
         $media->setOriginalFilename('orphan.jpg');
 
         $method = new \ReflectionMethod(FileHandler::class, 'getFileFolderPath');
-        $method->setAccessible(true);
 
         $this->assertSame('', $method->invoke($this->object, $media));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

`ReflectionMethod::setAccessible()` is deprecated as of PHP 8.5, since it has had no effect from PHP 8.1 onwards — reflection gained access to private and protected members by default there. This branch requires PHP >= 8.2, so the calls are dead code and can simply be dropped.

This silences 18 deprecation notices in the PHP 8.5 CI job:

```
18x: Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect
  6x in MediaControllerTest::testPathInformationIsStripped
  5x in MediaControllerTest::testFileNamesWithoutAnythingUsableAreRejected
  5x in MediaControllerTest::testRegularFileNamesAreNormalised
  1x in FileHandlerTest::testGetFileFolderPathReturnsTheUuidFolder
  1x in FileHandlerTest::testGetFileFolderPathIsEmptyWithoutUuid
```

Test-only change, no behaviour difference. Full suite stays green on PHP 8.5 (1228 tests, 2479 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)