### PR TITLE
[TranslatorBundle] Don't alias the data collector when the bundle is disabled

### DIFF
--- a/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
+++ b/src/Kunstmaan/TranslatorBundle/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPass.php
@@ -51,7 +51,7 @@ class KunstmaanTranslatorCompilerPass implements CompilerPassInterface
             $container->getDefinition('kunstmaan_translator.service.exporter.exporter')->addMethodCall('setExporters', [$exporterRefs]);
         }
 
-        if ($container->has('translator.data_collector')) {
+        if ($container->hasDefinition('kunstmaan_translator.datacollector') && $container->has('translator.data_collector')) {
             $container->setAlias('translator.data_collector', 'kunstmaan_translator.datacollector');
         }
     }

--- a/src/Kunstmaan/TranslatorBundle/Tests/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPassTest.php
+++ b/src/Kunstmaan/TranslatorBundle/Tests/DependencyInjection/Compiler/KunstmaanTranslatorCompilerPassTest.php
@@ -31,6 +31,8 @@ class KunstmaanTranslatorCompilerPassTest extends AbstractCompilerPassTestCase
         ]));
 
         $this->setDefinition('kunstmaan_translator.service.exporter.exporter', new Definition());
+        $this->setDefinition('kunstmaan_translator.datacollector', new Definition(\stdClass::class));
+        $this->setDefinition('translator.data_collector', new Definition(\stdClass::class));
 
         $this->compile();
 
@@ -51,5 +53,16 @@ class KunstmaanTranslatorCompilerPassTest extends AbstractCompilerPassTestCase
             'setExporters',
             [['someAlias' => new Reference($svcId)]]
         );
+
+        $this->assertContainerBuilderHasAlias('translator.data_collector', 'kunstmaan_translator.datacollector');
+    }
+
+    public function testDataCollectorIsNotAliasedWhenBundleIsDisabled()
+    {
+        $this->setDefinition('translator.data_collector', new Definition(\stdClass::class));
+
+        $this->compile();
+
+        $this->assertFalse($this->container->hasAlias('translator.data_collector'));
     }
 }


### PR DESCRIPTION
Fixes #3436

When the translator bundle is disabled via `kuma_translator.enabled: false`, `KunstmaanTranslatorExtension::load()` returns early and never loads `services.yml`, so `kunstmaan_translator.datacollector` is never defined. `KunstmaanTranslatorCompilerPass` nevertheless aliased Symfony's `translator.data_collector` to it, and because `data_collector.translation` depends on `translator.data_collector`, the container fails to compile:

```
The service "data_collector.translation" has a dependency on a non-existent service "kunstmaan_translator.datacollector".
```

The alias is now guarded on our own definition being present, matching the `hasDefinition()` guards the same compiler pass already uses for the importer, translator and exporter services.

A regression test covers the disabled case (it fails without the fix), and the enabled path now asserts the alias is still created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)