### PR TITLE
[SeoBundle][CookieBundle] Rename Twitter to X in translations

### DIFF
--- a/src/Kunstmaan/CookieBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/CookieBundle/Resources/translations/messages.en.yml
@@ -226,7 +226,7 @@ kuma:
             description: >
                 <p>Etiam porta sem malesuada magna mollis euismod. Donec ullamcorper nulla non metus auctor fringilla. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
           5:
-            name: Twitter
+            name: X (Twitter)
             description: >
                 <p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
 

--- a/src/Kunstmaan/CookieBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/CookieBundle/Resources/translations/messages.fr.yml
@@ -188,7 +188,7 @@ kuma:
             description: >
                 <p>Etiam porta sem malesuada magna mollis euismod. Donec ullamcorper nulla non metus auctor fringilla. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
           5:
-            name: Twitter
+            name: X (Twitter)
             description: >
                 <p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
 

--- a/src/Kunstmaan/CookieBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/CookieBundle/Resources/translations/messages.nl.yml
@@ -226,7 +226,7 @@ kuma:
             description: >
                 <p>Etiam porta sem malesuada magna mollis euismod. Donec ullamcorper nulla non metus auctor fringilla. Curabitur blandit tempus porttitor. Sed posuere consectetur est at lobortis. Nulla vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
           5:
-            name: Twitter
+            name: X (Twitter)
             description: >
                 <p>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nulla vitae elit libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel eu leo. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
 

--- a/src/Kunstmaan/SeoBundle/Form/SocialType.php
+++ b/src/Kunstmaan/SeoBundle/Form/SocialType.php
@@ -103,7 +103,7 @@ class SocialType extends AbstractType
                 'label' => 'seo.form.twitter.creatorhandle',
                 'required' => false,
                 'attr' => [
-                    'info_text' => 'Twitter handle of your page publisher.',
+                    'info_text' => 'seo.form.twitter.creatorhandle_info_text',
                 ],
             ])
             ->add('twitterImage', MediaType::class, [

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.de.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.de.yml
@@ -22,11 +22,11 @@ seo:
         section: OG Artikelbereich
     twitter:
       title: Titel
-      title_info_text: Der Titel der Twitter-Karte. Falls nicht angeben, wird der SEO Titel verwendet.
+      title_info_text: Der Titel der X (Twitter)-Karte. Falls nicht angeben, wird der SEO Titel verwendet.
       description: Beschreibung
-      description_info_text: Die Beschreibung der Twitter-Karte. Falls nicht angeben, wird die SEO Beschreibung verwendet
+      description_info_text: Die Beschreibung der X (Twitter)-Karte. Falls nicht angeben, wird die SEO Beschreibung verwendet
       sitehandle: Seiten-@-Benutzername
-      sitehandle_info_text: Twitter-@-Nutzername der Website-Organisation. Dieser Wert ist erforderlich, damit Twitter-Karten funktionieren.
+      sitehandle_info_text: X (Twitter)-@-Nutzername der Website-Organisation. Dieser Wert ist erforderlich, damit X (Twitter)-Karten funktionieren.
       creatorhandle: Ersteller-@-Benutzername
       creatorhandle_info_text: '@-Benutzername des Veröffentlichers'
       image: Bild
@@ -50,7 +50,7 @@ seo:
         label: Extra Metadaten
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter-Karten
+    twittercards: X (Twitter)-Karten
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.en.yml
@@ -24,13 +24,13 @@ seo:
                 section:    OG Article Section
         twitter:
             title: Title
-            title_info_text: The title of your twitter card. Falls back to SEO Meta title
+            title_info_text: The title of your X (Twitter) card. Falls back to SEO Meta title
             description: Description
-            description_info_text: The description of your twitter card. Falls back to SEO Meta description
+            description_info_text: The description of your X (Twitter) card. Falls back to SEO Meta description
             sitehandle: Site Handle
-            sitehandle_info_text: Twitter handle of your website organisation. This value is required for twitter cards to work.
+            sitehandle_info_text: X (Twitter) handle of your website organisation. This value is required for X (Twitter) cards to work.
             creatorhandle: Creator Handle
-            creatorhandle_info_text: Twitter handle of your page publisher.
+            creatorhandle_info_text: X (Twitter) handle of your page publisher.
             image: Image
         robots:
             noindex: No index
@@ -53,7 +53,7 @@ seo:
 
     pagetabs:
         opengraph: Open Graph
-        twittercards: Twitter Cards
+        twittercards: X (Twitter) Cards
 
     tab:
         seo:

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.es.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.es.yml
@@ -22,13 +22,13 @@ seo:
         section: OG Article Section
     twitter:
       title: Title
-      title_info_text: The title of your twitter card. Falls back to SEO Meta title
+      title_info_text: The title of your X (Twitter) card. Falls back to SEO Meta title
       description: Description
-      description_info_text: The description of your twitter card. Falls back to SEO Meta description
+      description_info_text: The description of your X (Twitter) card. Falls back to SEO Meta description
       sitehandle: Site Handle
-      sitehandle_info_text: Twitter handle of your website organisation. This value is required for twitter cards to work.
+      sitehandle_info_text: X (Twitter) handle of your website organisation. This value is required for X (Twitter) cards to work.
       creatorhandle: Creator Handle
-      creatorhandle_info_text: Twitter handle of your page publisher.
+      creatorhandle_info_text: X (Twitter) handle of your page publisher.
       image: Image
     robots:
       noindex: No index
@@ -50,7 +50,7 @@ seo:
         label: Extra metadata
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter Cards
+    twittercards: X (Twitter) Cards
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.fr.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.fr.yml
@@ -22,13 +22,13 @@ seo:
         section: OG Article Section
     twitter:
       title: Title
-      title_info_text: The title of your twitter card. Falls back to SEO Meta title
+      title_info_text: The title of your X (Twitter) card. Falls back to SEO Meta title
       description: Description
-      description_info_text: The description of your twitter card. Falls back to SEO Meta description
+      description_info_text: The description of your X (Twitter) card. Falls back to SEO Meta description
       sitehandle: Site Handle
-      sitehandle_info_text: Twitter handle of your website organisation. This value is required for twitter cards to work.
+      sitehandle_info_text: X (Twitter) handle of your website organisation. This value is required for X (Twitter) cards to work.
       creatorhandle: Creator Handle
-      creatorhandle_info_text: Twitter handle of your page publisher.
+      creatorhandle_info_text: X (Twitter) handle of your page publisher.
       image: Image
     robots:
       noindex: No index
@@ -50,7 +50,7 @@ seo:
         label: Extra metadata
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter Cards
+    twittercards: X (Twitter) Cards
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.hu.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.hu.yml
@@ -22,13 +22,13 @@ seo:
         section: OG cikk szekció
     twitter:
       title: Cím
-      title_info_text: A Twitter kártyád címe. Háttérbe szorítja a SEO Meta címet
+      title_info_text: Az X (Twitter) kártyád címe. Háttérbe szorítja a SEO Meta címet
       description: Leírás
-      description_info_text: A twitter kártyád leírása. Háttérbe szorítja a SEO Meta leírást
+      description_info_text: Az X (Twitter) kártyád leírása. Háttérbe szorítja a SEO Meta leírást
       sitehandle: Oldal kezelője
-      sitehandle_info_text: A weblap tulajdonos Twitter kezelője. Ez az érték szükséges ahhoz, hogy működjenek a twitter kártyák.
+      sitehandle_info_text: A weblap tulajdonos X (Twitter) kezelője. Ez az érték szükséges ahhoz, hogy működjenek az X (Twitter) kártyák.
       creatorhandle: Oldal létrehozója
-      creatorhandle_info_text: A page publisher Twitter handle-je.
+      creatorhandle_info_text: A page publisher X (Twitter) handle-je.
       image: Kép
     robots:
       noindex: No index
@@ -50,7 +50,7 @@ seo:
         label: Extra meta adat
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter
+    twittercards: X (Twitter)
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.it.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.it.yml
@@ -22,13 +22,13 @@ seo:
         section: OG Article Section
     twitter:
       title: Title
-      title_info_text: The title of your twitter card. Falls back to SEO Meta title
+      title_info_text: The title of your X (Twitter) card. Falls back to SEO Meta title
       description: Description
-      description_info_text: The description of your twitter card. Falls back to SEO Meta description
+      description_info_text: The description of your X (Twitter) card. Falls back to SEO Meta description
       sitehandle: Site Handle
-      sitehandle_info_text: Twitter handle of your website organisation. This value is required for twitter cards to work.
+      sitehandle_info_text: X (Twitter) handle of your website organisation. This value is required for X (Twitter) cards to work.
       creatorhandle: Creator Handle
-      creatorhandle_info_text: Twitter handle of your page publisher.
+      creatorhandle_info_text: X (Twitter) handle of your page publisher.
       image: Image
     robots:
       noindex: No index
@@ -50,7 +50,7 @@ seo:
         label: Extra metadata
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter Cards
+    twittercards: X (Twitter) Cards
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.nl.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.nl.yml
@@ -22,13 +22,13 @@ seo:
         section: OG hoofdstuk
     twitter:
       title: Titel
-      title_info_text: De titel van uw twitter card. Falls back to SEO Meta title
+      title_info_text: De titel van uw X (Twitter) card. Falls back to SEO Meta title
       description: Omschrijving
-      description_info_text: De omschrijving van uw twitter card. Falls back to SEO Meta description
-      sitehandle: Twitter site
-      sitehandle_info_text: Twitter handle van de website of uw organisatie. Deze waarde is verplicht om twitter cards te laten werken.
-      creatorhandle: Twitter auteur
-      creatorhandle_info_text: Twitter handle van de publisher van uw pagina.
+      description_info_text: De omschrijving van uw X (Twitter) card. Falls back to SEO Meta description
+      sitehandle: X (Twitter) site
+      sitehandle_info_text: X (Twitter) handle van de website of uw organisatie. Deze waarde is verplicht om X (Twitter) cards te laten werken.
+      creatorhandle: X (Twitter) auteur
+      creatorhandle_info_text: X (Twitter) handle van de publisher van uw pagina.
       image: Foto
     robots:
       noindex: Geen index
@@ -50,7 +50,7 @@ seo:
         label: Extra metadata
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter Cards
+    twittercards: X (Twitter) Cards
   tab:
     seo:
       title: SEO

--- a/src/Kunstmaan/SeoBundle/Resources/translations/messages.pl.yml
+++ b/src/Kunstmaan/SeoBundle/Resources/translations/messages.pl.yml
@@ -22,13 +22,13 @@ seo:
         section: OG Sekcja artykułu
     twitter:
       title: Tytuł
-      title_info_text: Tytuł wyświetlany na karcie twitter-a
+      title_info_text: Tytuł wyświetlany na karcie X (Twitter)
       description: Opis
-      description_info_text: Opis wyświetlany na karcie twitter-a
+      description_info_text: Opis wyświetlany na karcie X (Twitter)
       sitehandle: Witryna
-      sitehandle_info_text: Twoja strona Twitter. To pole jest wymagane aby uruchomić kartę Twitter.
+      sitehandle_info_text: Twoja strona X (Twitter). To pole jest wymagane aby uruchomić kartę X (Twitter).
       creatorhandle: Twórca
-      creatorhandle_info_text: Zarządca twojej strony Twitter.
+      creatorhandle_info_text: Zarządca twojej strony X (Twitter).
       image: Zdjęcie
     robots:
       noindex: Blokuj indeksowanie
@@ -50,7 +50,7 @@ seo:
         label: Dodatkowe meta dane
   pagetabs:
     opengraph: Open Graph
-    twittercards: Twitter
+    twittercards: X (Twitter)
   tab:
     seo:
       title: SEO


### PR DESCRIPTION
Fixes #3305

As discussed in the issue, only the translations are changed. The user facing "Twitter" labels now read "X (Twitter)", keeping the "(Twitter)" suffix as a transition period so editors still recognise the fields.

Translation keys, entity properties, database columns and the `twitter:*` meta tags are left untouched, as those are still the actual spec names.

Changes:
* SeoBundle translations (en, nl, de, fr, es, it, hu, pl): the "Twitter cards" page tab, the field labels and the info texts. The non english strings were adapted grammatically instead of a blind search & replace (eg. de `X (Twitter)-Karten`, hu `Az X (Twitter) kártyád címe`, pl `na karcie X (Twitter)`).
* CookieBundle translations (en, fr, nl): the `Twitter` sample social cookie name.
* `SocialType`: the creator handle info text was hardcoded in english instead of using a translation key, so it would keep saying "Twitter" in every locale. It now uses the already existing `seo.form.twitter.creatorhandle_info_text` key (the form theme runs `|trans` on `info_text` and the key is present in all locale files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)