### PR TITLE
[AdminListBundle] Fix broken orderBy sanitization and restrict sorting to sortable fields

### DIFF
--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractAdminListConfigurator.php
@@ -744,8 +744,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
         $adminListName = 'listconfig_' . $request->attributes->get('_route');
 
         $this->page = $request->query->getInt('page', 1);
-        // Allow alphanumeric, _ & . in order by parameter!
-        $this->orderBy = preg_replace('/[^[a-zA-Z0-9\_\.]]/', '', $request->query->get('orderBy', ''));
+        $this->orderBy = $this->sanitizeOrderBy($request->query->get('orderBy', ''));
         $this->orderDirection = $request->query->getAlpha('orderDirection');
 
         // there is a session and the filter param is not set
@@ -756,7 +755,7 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
             }
 
             if (!$query->has('orderBy')) {
-                $this->orderBy = $adminListSessionData['orderBy'];
+                $this->orderBy = $this->sanitizeOrderBy($adminListSessionData['orderBy'] ?? '');
             }
 
             if (!$query->has('orderDirection')) {
@@ -785,6 +784,27 @@ abstract class AbstractAdminListConfigurator implements AdminListConfiguratorInt
     public function getPage()
     {
         return $this->page;
+    }
+
+    /**
+     * Only allow sorting on fields that were explicitly marked as sortable.
+     * The value is used unescaped in the ORDER BY clause of the query, so any
+     * value that is not a known sort field is discarded.
+     */
+    protected function sanitizeOrderBy($orderBy): string
+    {
+        if (!\is_string($orderBy) || $orderBy === '') {
+            return '';
+        }
+
+        // Allow alphanumeric, _ & . in order by parameter!
+        $orderBy = preg_replace('/[^a-zA-Z0-9_.]/', '', $orderBy);
+
+        if (!\in_array($orderBy, $this->getSortFields(), true)) {
+            return '';
+        }
+
+        return $orderBy;
     }
 
     /**

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractAdminListConfiguratorTest.php
@@ -17,6 +17,7 @@ use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class AbstractAdminListConfiguratorTest extends TestCase
 {
@@ -488,6 +489,61 @@ class AbstractAdminListConfiguratorTest extends TestCase
         ;
 
         $abstractAdminListConfMock->bindRequest($requestMock);
+    }
+
+    /**
+     * @dataProvider orderByProvider
+     */
+    public function testBindRequestOnlyAllowsSortableFieldsAsOrderBy(string $orderBy, string $expected)
+    {
+        $request = new Request(['orderBy' => $orderBy], [], ['_route' => 'testroute']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $this->adminListConfigurator->buildFields();
+        $this->adminListConfigurator->bindRequest($request);
+
+        $this->assertSame($expected, $this->adminListConfigurator->getOrderBy());
+        $this->assertSame($expected, $request->getSession()->get('listconfig_testroute')['orderBy']);
+    }
+
+    public function orderByProvider(): iterable
+    {
+        yield 'sortable field' => ['hello', 'hello'];
+        yield 'other sortable field' => ['world', 'world'];
+        yield 'empty' => ['', ''];
+        yield 'unknown field' => ['password', ''];
+        yield 'sql injection' => ['hello, (SELECT SLEEP(5))', ''];
+        yield 'sql injection with closing bracket' => ['hello) DESC, (SELECT 1]', ''];
+        yield 'quote' => ["hello' OR 1=1", ''];
+    }
+
+    public function testBindRequestSanitizesOrderByFromSession()
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('listconfig_testroute', ['page' => 1, 'orderBy' => 'hello; DROP TABLE users', 'orderDirection' => 'DESC']);
+
+        $request = new Request([], [], ['_route' => 'testroute']);
+        $request->setSession($session);
+
+        $this->adminListConfigurator->buildFields();
+        $this->adminListConfigurator->bindRequest($request);
+
+        $this->assertSame('', $this->adminListConfigurator->getOrderBy());
+        $this->assertSame('DESC', $this->adminListConfigurator->getOrderDirection());
+    }
+
+    public function testBindRequestKeepsValidOrderByFromSession()
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('listconfig_testroute', ['page' => 1, 'orderBy' => 'world', 'orderDirection' => 'ASC']);
+
+        $request = new Request([], [], ['_route' => 'testroute']);
+        $request->setSession($session);
+
+        $this->adminListConfigurator->buildFields();
+        $this->adminListConfigurator->bindRequest($request);
+
+        $this->assertSame('world', $this->adminListConfigurator->getOrderBy());
     }
 
     public function testGetPage()

--- a/src/Kunstmaan/AdminListBundle/Tests/Traits/ChangeableLimitTraitTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/Traits/ChangeableLimitTraitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kunstmaan\AdminListBundle\Tests\Traits;
+
+use Kunstmaan\AdminListBundle\AdminList\FilterBuilder;
+use Kunstmaan\AdminListBundle\Traits\ChangeableLimitTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class ChangeableLimitTraitTest extends TestCase
+{
+    /**
+     * @dataProvider orderByProvider
+     */
+    public function testBindRequestOnlyAllowsSortableFieldsAsOrderBy(string $orderBy, string $expected)
+    {
+        $request = new Request(['orderBy' => $orderBy], [], ['_route' => 'testroute']);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $configurator = $this->createConfigurator();
+        $configurator->bindRequest($request);
+
+        $this->assertSame($expected, $configurator->orderBy);
+        $this->assertSame($expected, $request->getSession()->get('listconfig_testroute')['orderBy']);
+    }
+
+    public function orderByProvider(): iterable
+    {
+        yield 'sortable field' => ['hello', 'hello'];
+        yield 'empty' => ['', ''];
+        yield 'unknown field' => ['password', ''];
+        yield 'sql injection' => ['hello, (SELECT SLEEP(5))', ''];
+        yield 'sql injection with closing bracket' => ['hello) DESC, (SELECT 1]', ''];
+    }
+
+    public function testBindRequestSanitizesOrderByFromSession()
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('listconfig_testroute', ['page' => 1, 'limit' => 10, 'orderBy' => 'hello; DROP TABLE users', 'orderDirection' => 'DESC']);
+
+        $request = new Request([], [], ['_route' => 'testroute']);
+        $request->setSession($session);
+
+        $configurator = $this->createConfigurator();
+        $configurator->bindRequest($request);
+
+        $this->assertSame('', $configurator->orderBy);
+    }
+
+    /**
+     * The trait must not depend on AbstractAdminListConfigurator, only on
+     * AdminListConfiguratorInterface methods (getSortFields, getFilterBuilder).
+     */
+    private function createConfigurator(): object
+    {
+        return new class {
+            use ChangeableLimitTrait;
+
+            public $page;
+            public $orderBy = '';
+            public $orderDirection = '';
+
+            public function getSortFields(): array
+            {
+                return ['hello', 'world'];
+            }
+
+            public function getFilterBuilder(): FilterBuilder
+            {
+                return new FilterBuilder();
+            }
+        };
+    }
+}

--- a/src/Kunstmaan/AdminListBundle/Traits/ChangeableLimitTrait.php
+++ b/src/Kunstmaan/AdminListBundle/Traits/ChangeableLimitTrait.php
@@ -33,8 +33,7 @@ trait ChangeableLimitTrait
             $this->page = 1;
         }
 
-        // Allow alphanumeric, _ & . in order by parameter!
-        $this->orderBy = preg_replace('/[^[a-zA-Z0-9\_\.]]/', '', $request->query->get('orderBy', ''));
+        $this->orderBy = $this->sanitizeOrderBy($request->query->get('orderBy', ''));
         $this->orderDirection = $request->query->getAlpha('orderDirection');
 
         // there is a session and the filter param is not set
@@ -44,7 +43,7 @@ trait ChangeableLimitTrait
             }
 
             if (!$query->has('orderBy')) {
-                $this->orderBy = $adminListSessionData['orderBy'];
+                $this->orderBy = $this->sanitizeOrderBy($adminListSessionData['orderBy'] ?? '');
             }
 
             if (!$query->has('orderDirection')) {
@@ -66,6 +65,31 @@ trait ChangeableLimitTrait
         // Remove limit from query param so it doesn't affect the session of the filter builder
         $request->query->remove('limit');
         $this->getFilterBuilder()->bindRequest($request);
+    }
+
+    /**
+     * Only allow sorting on fields that were explicitly marked as sortable.
+     * The value is used unescaped in the ORDER BY clause of the query, so any
+     * value that is not a known sort field is discarded.
+     *
+     * Kept in the trait (instead of relying on AbstractAdminListConfigurator) so
+     * the trait keeps working for configurators that only implement
+     * AdminListConfiguratorInterface.
+     */
+    protected function sanitizeOrderBy($orderBy): string
+    {
+        if (!\is_string($orderBy) || $orderBy === '') {
+            return '';
+        }
+
+        // Allow alphanumeric, _ & . in order by parameter!
+        $orderBy = preg_replace('/[^a-zA-Z0-9_.]/', '', $orderBy);
+
+        if (!\in_array($orderBy, $this->getSortFields(), true)) {
+            return '';
+        }
+
+        return $orderBy;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (see note below)
| Deprecations? | no
| Fixed tickets | -
| License       | MIT

## What's wrong

The regex that sanitizes the `orderBy` request parameter in both `AbstractAdminListConfigurator::bindRequest()` and `ChangeableLimitTrait::bindRequest()` has a stray pair of brackets:

```php
preg_replace('/[^[a-zA-Z0-9\_\.]]/', '', $request->query->get('orderBy', ''));
```

PCRE reads this as "a character not in `[a-zA-Z0-9_.[]` **followed by a literal `]`**", so it only strips two-character `<bad char>]` sequences. Practically any payload passes through untouched:

```
"name; DROP TABLE x"            => "name; DROP TABLE x"
"b.id) DESC, (SELECT SLEEP(5)"  => "b.id) DESC, (SELECT SLEEP(5)"
```

The value is then concatenated verbatim into the `ORDER BY` clause by `AbstractDoctrineDBALAdminListConfigurator` (raw SQL → SQL injection) and `AbstractDoctrineORMAdminListConfigurator` (DQL → arbitrary sort expressions, incl. blind sorting on fields not exposed in the list, e.g. password hashes). It is also stored in the session and re-applied on later requests without re-checking.

Independently, `orderBy` was never validated against the fields actually registered as sortable, so even with a correct regex any column name could be used.

Requires an authenticated backend user, since adminlists live behind the admin firewall.

## Fix

- New `sanitizeOrderBy()` helper that fixes the regex (`/[^a-zA-Z0-9_.]/`) **and** only accepts values present in `getSortFields()` (fields added with `addField(..., $sort = true)`). Anything else falls back to `''` (unsorted).
- Applied to both the query-string value and the value restored from the session, so stale session values from before this fix are neutralised too.
- `ChangeableLimitTrait` carries its own copy of the helper, relying only on `AdminListConfiguratorInterface::getSortFields()`, so the trait keeps working for configurators that don't extend `AbstractAdminListConfigurator`.

## Tests

- `AbstractAdminListConfiguratorTest`: data provider with valid sortable fields, an unknown field and SQL-injection payloads (including one using the `]` the old regex actually required), plus session-sourced valid/invalid values.
- New `ChangeableLimitTraitTest`: same cases against a plain class using the trait without extending the abstract configurator.

AdminListBundle / MediaBundle / TranslatorBundle suites, PHPStan and php-cs-fixer all pass.

## Behaviour note

Hand-crafted `?orderBy=<field>` URLs for columns **not** marked sortable now yield the unsorted list instead of sorting. This is intended; sortable columns exposed in the UI are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
