### PR TITLE
[AdminBundle] Enforce the password restrictions in the password reset form

### DIFF
--- a/src/Kunstmaan/AdminBundle/Form/Authentication/NewPasswordType.php
+++ b/src/Kunstmaan/AdminBundle/Form/Authentication/NewPasswordType.php
@@ -2,10 +2,12 @@
 
 namespace Kunstmaan\AdminBundle\Form\Authentication;
 
+use Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 final class NewPasswordType extends AbstractType
 {
@@ -16,6 +18,10 @@ final class NewPasswordType extends AbstractType
                 'type' => PasswordType::class,
                 'required' => true,
                 'invalid_message' => 'errors.password.dontmatch',
+                'constraints' => [
+                    new NotBlank(),
+                    new PasswordRestrictions(),
+                ],
                 'first_options' => [
                     'label' => 'settings.user.password',
                 ],

--- a/src/Kunstmaan/AdminBundle/Tests/Form/Authentication/NewPasswordTypeTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Form/Authentication/NewPasswordTypeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kunstmaan\AdminBundle\Tests\Form\Authentication;
+
+use Kunstmaan\AdminBundle\Form\Authentication\NewPasswordType;
+use Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictions;
+use Kunstmaan\AdminBundle\Validator\Constraints\PasswordRestrictionsValidator;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\Validation;
+
+class NewPasswordTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        $validatorFactory = new class extends ConstraintValidatorFactory {
+            public function getInstance(Constraint $constraint): \Symfony\Component\Validator\ConstraintValidatorInterface
+            {
+                if ($constraint instanceof PasswordRestrictions) {
+                    return new PasswordRestrictionsValidator(null, null, null, 8, null);
+                }
+
+                return parent::getInstance($constraint);
+            }
+        };
+
+        $validator = Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory($validatorFactory)
+            ->getValidator();
+
+        return [
+            new ValidatorExtension($validator),
+        ];
+    }
+
+    public function testValidPasswordIsAccepted(): void
+    {
+        $form = $this->factory->create(NewPasswordType::class);
+        $form->submit(['plainPassword' => ['first' => 'LongEnough1!', 'second' => 'LongEnough1!']]);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid());
+        $this->assertSame('LongEnough1!', $form->get('plainPassword')->getData());
+    }
+
+    public function testPasswordRestrictionsAreEnforced(): void
+    {
+        $form = $this->factory->create(NewPasswordType::class);
+        $form->submit(['plainPassword' => ['first' => 'short', 'second' => 'short']]);
+
+        $this->assertFalse($form->isValid());
+        $this->assertSame(PasswordRestrictions::INVALID_MIN_LENGTH_ERROR, $form->getErrors(true)[0]->getCause()->getCode());
+    }
+
+    public function testEmptyPasswordIsRejected(): void
+    {
+        $form = $this->factory->create(NewPasswordType::class);
+        $form->submit(['plainPassword' => ['first' => '', 'second' => '']]);
+
+        $this->assertFalse($form->isValid());
+        $this->assertCount(1, $form->getErrors(true));
+    }
+
+    public function testNonMatchingPasswordsAreRejected(): void
+    {
+        $form = $this->factory->create(NewPasswordType::class);
+        $form->submit(['plainPassword' => ['first' => 'LongEnough1!', 'second' => 'LongEnough2!']]);
+
+        $this->assertFalse($form->isValid());
+    }
+}


### PR DESCRIPTION
`NewPasswordType` is not bound to the user entity, so the `PasswordRestrictions` constraint declared in `BaseUser::loadValidatorMetadata()` was never applied when a password was set through a reset link. Any value was accepted regardless of the configured `password_restrictions`, and an empty submission caused a `TypeError` in `PasswordResetService::resetPassword()` because the form data is `null`.

The `NotBlank` and `PasswordRestrictions` constraints are now added to the field directly, so a reset password is held to the same policy as a password set anywhere else. The new `NewPasswordTypeTest` fails on the previous code for both the policy bypass and the empty submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
