### PR TITLE
[AdminBundle] Match the decoded path in AdminRouteHelper::isAdminRoute()

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/AdminRouteHelper.php
@@ -41,7 +41,9 @@ class AdminRouteHelper
             return false;
         }
 
-        preg_match(sprintf(self::$ADMIN_MATCH_REGEX, $this->adminKey), $url, $matches);
+        $path = rawurldecode(explode('?', $url, 2)[0]);
+
+        preg_match(sprintf(self::$ADMIN_MATCH_REGEX, $this->adminKey), $path, $matches);
 
         // Check if path is part of admin area
         if (\count($matches) === 0) {

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/AdminRouteHelperTest.php
@@ -65,6 +65,29 @@ class AdminRouteHelperTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * @dataProvider encodedUrlProvider
+     */
+    public function testIsAdminRouteMatchesTheDecodedPath(string $url, bool $expected)
+    {
+        $adminRouteHelper = $this->getAdminRouteHelper(self::$ADMIN_KEY);
+
+        $this->assertSame($expected, $adminRouteHelper->isAdminRoute($url));
+    }
+
+    public function encodedUrlProvider(): iterable
+    {
+        yield 'encoded admin key' => ['/%61dmin/nodes', true];
+        yield 'fully encoded admin key' => ['/%61%64%6d%69%6e/nodes', true];
+        yield 'encoded admin key with locale' => ['/en/%61dmin/nodes', true];
+        yield 'encoded admin key with front controller' => ['/app_dev.php/%61dmin/nodes', true];
+        yield 'encoded slash' => ['/en%2Fadmin/nodes', true];
+        yield 'query string' => ['/admin/nodes?foo=bar', true];
+        yield 'admin key only in query string' => ['/en/some_path?redirect=/admin/nodes', false];
+        yield 'double encoded admin key' => ['/%2561dmin/nodes', false];
+        yield 'encoded frontend url' => ['/en/%73ome_path/admin/nodes', false];
+    }
+
     public function testIsAdminRouteWorksWhenNoRequestInRequeststack()
     {
         $adminRouteHelper = new AdminRouteHelper(self::$ADMIN_KEY, new RequestStack());


### PR DESCRIPTION
`AdminRouteHelper::isAdminRoute()` matched the raw request uri, while the Symfony router matches the url-decoded path. A request to `/%61dmin/...` was therefore routed to the admin controllers but not recognised as an admin route, which skipped every listener that relies on this helper: `PasswordCheckListener` (the forced password change could be bypassed entirely), `AdminLocaleListener`, `ToolbarListener` and the multi domain `HostOverrideListener`. Symfony's `access_control` is not affected as it decodes the path itself.

The path is now decoded the same way the router does and the query string is dropped before matching, so both agree on what an admin request is. The added test cases for encoded urls fail on the previous code.

Note for the `7.x` merge: #3563 touched the same method, expect a trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
