### PR TITLE
[AdminBundle] Use the trusted client ip in the session security listener

### DIFF
--- a/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
+++ b/src/Kunstmaan/AdminBundle/EventListener/SessionSecurityListener.php
@@ -108,19 +108,7 @@ class SessionSecurityListener
     private function getIp(Request $request): string
     {
         if (!$this->ip) {
-            $forwarded = $request->server->get('HTTP_X_FORWARDED_FOR');
-            if (\strlen($forwarded) > 0) {
-                $parts = explode(',', $forwarded);
-                $parts = array_map('trim', $parts);
-                $parts = array_filter($parts);
-                if (\count($parts) > 0) {
-                    $ip = $parts[0];
-                }
-            }
-            if (empty($ip)) {
-                $ip = $request->getClientIp();
-            }
-            $this->ip = $ip;
+            $this->ip = (string) $request->getClientIp();
         }
 
         return $this->ip;

--- a/src/Kunstmaan/AdminBundle/Tests/EventListener/SessionSecurityListenerTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/EventListener/SessionSecurityListenerTest.php
@@ -5,11 +5,10 @@ namespace Kunstmaan\AdminBundle\Tests\EventListener;
 use Kunstmaan\AdminBundle\EventListener\SessionSecurityListener;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ServerBag;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -17,76 +16,158 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class SessionSecurityListenerTest extends TestCase
 {
-    public function testOnKernelRequest()
+    protected function tearDown(): void
     {
-        $logger = $this->createMock(LoggerInterface::class);
-        $request = $this->createMock(Request::class);
-        $request->server = $this->createMock(ServerBag::class);
-        $request->headers = $this->createMock(HeaderBag::class);
-
-        $kernel = $this->createMock(KernelInterface::class);
-        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
-        $session = $this->createMock(Session::class);
-
-        $request->expects($this->once())->method('hasSession')->willReturn(true);
-        $request->expects($this->exactly(2))->method('getSession')->willReturn($session);
-        $request->server->expects($this->any())->method('get')->will($this->onConsecutiveCalls('Session ip', 'kuma_ua'));
-        $request->headers->expects($this->any())->method('get')->willReturn('kuma_ua');
-        $session->expects($this->once())->method('isStarted')->willReturn(true);
-        $session->expects($this->any())->method('has')->willReturn(true);
-
-        $listener = new SessionSecurityListener(true, true, $logger);
-        $listener->onKernelRequest($event);
-
-        $event = new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
-        $listener->onKernelRequest($event);
+        Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
     }
 
-    public function testOnKernelResponse()
+    public function testResponseStoresClientIpAndUserAgentInSession(): void
     {
-        $logger = $this->createMock(LoggerInterface::class);
-        $request = $this->createMock(Request::class);
-        $request->server = $this->createMock(ServerBag::class);
-        $request->headers = $this->createMock(HeaderBag::class);
+        $session = $this->createSession();
+        $request = $this->createRequest($session, '10.0.0.1', 'Browser/1.0');
 
-        $kernel = $this->createMock(KernelInterface::class);
-        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, new Response());
-        $session = $this->createMock(Session::class);
+        $this->createListener()->onKernelResponse($this->createResponseEvent($request));
 
-        $request->expects($this->once())->method('hasSession')->willReturn(true);
-        $request->expects($this->exactly(2))->method('getSession')->willReturn($session);
-        $request->server->expects($this->any())->method('get')->will($this->onConsecutiveCalls('Session ip', 'kuma_ua'));
-        $request->headers->expects($this->any())->method('get')->willReturn('kuma_ua');
-        $session->expects($this->once())->method('isStarted')->willReturn(true);
-        $session->expects($this->exactly(2))->method('has')->willReturn(false);
-
-        $listener = new SessionSecurityListener(true, true, $logger);
-        $listener->onKernelResponse($event);
-
-        $event = new ResponseEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST, new Response());
-        $listener->onKernelResponse($event);
+        $this->assertSame('10.0.0.1', $session->get('kuma_ip'));
+        $this->assertSame('Browser/1.0', $session->get('kuma_ua'));
     }
 
-    public function testInvalidateSessionWithNoIpSet()
+    public function testResponseDoesNotOverwriteExistingSessionValues(): void
     {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0']);
+        $request = $this->createRequest($session, '10.0.0.2', 'Browser/2.0');
+
+        $this->createListener()->onKernelResponse($this->createResponseEvent($request));
+
+        $this->assertSame('10.0.0.1', $session->get('kuma_ip'));
+        $this->assertSame('Browser/1.0', $session->get('kuma_ua'));
+    }
+
+    public function testRequestFromSameClientKeepsSession(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0']);
+        $request = $this->createRequest($session, '10.0.0.1', 'Browser/1.0');
+
+        $this->createListener()->onKernelRequest($this->createRequestEvent($request));
+
+        $this->assertSame('10.0.0.1', $session->get('kuma_ip'));
+    }
+
+    public function testRequestFromOtherIpInvalidatesSession(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '10.0.0.2', 'Browser/1.0');
+
         $logger = $this->createMock(LoggerInterface::class);
-        $request = $this->createMock(Request::class);
-        $request->server = $this->createMock(ServerBag::class);
-        $request->headers = $this->createMock(HeaderBag::class);
+        $logger->expects($this->once())->method('error')->with($this->stringContains("Session ip '10.0.0.1' does not match with request ip '10.0.0.2'"));
 
-        $kernel = $this->createMock(KernelInterface::class);
-        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, new Response());
-        $session = $this->createMock(Session::class);
+        $this->createListener($logger)->onKernelRequest($this->createRequestEvent($request));
 
-        $request->expects($this->once())->method('hasSession')->willReturn(true);
-        $request->expects($this->exactly(2))->method('getSession')->willReturn($session);
-        $request->expects($this->once())->method('getClientIp')->willReturn('95.154.243.5');
-        $request->server->expects($this->any())->method('get')->willReturn('');
-        $request->headers->expects($this->any())->method('get')->willReturn('kuma_ua');
-        $session->expects($this->once())->method('isStarted')->willReturn(true);
-        $session->expects($this->exactly(2))->method('has')->willReturn(false);
+        $this->assertFalse($session->has('user_data'));
+        $this->assertSame('10.0.0.2', $session->get('kuma_ip'));
+    }
 
-        $listener = new SessionSecurityListener(true, true, $logger);
-        $listener->onKernelResponse($event);
+    public function testRequestFromOtherUserAgentInvalidatesSession(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '10.0.0.1', 'Browser/2.0');
+
+        $this->createListener()->onKernelRequest($this->createRequestEvent($request));
+
+        $this->assertFalse($session->has('user_data'));
+        $this->assertSame('Browser/2.0', $session->get('kuma_ua'));
+    }
+
+    public function testForwardedForHeaderIsIgnoredWithoutTrustedProxies(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '10.0.0.2', 'Browser/1.0', '10.0.0.1');
+
+        $this->createListener()->onKernelRequest($this->createRequestEvent($request));
+
+        $this->assertFalse($session->has('user_data'));
+        $this->assertSame('10.0.0.2', $session->get('kuma_ip'));
+    }
+
+    public function testForwardedForHeaderIsUsedFromTrustedProxy(): void
+    {
+        Request::setTrustedProxies(['192.168.0.1'], Request::HEADER_X_FORWARDED_FOR);
+
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '192.168.0.1', 'Browser/1.0', '10.0.0.1');
+
+        $this->createListener()->onKernelRequest($this->createRequestEvent($request));
+
+        $this->assertTrue($session->has('user_data'));
+    }
+
+    public function testDisabledChecksAreSkipped(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '10.0.0.2', 'Browser/2.0');
+
+        $this->createListener(null, false, false)->onKernelRequest($this->createRequestEvent($request));
+
+        $this->assertTrue($session->has('user_data'));
+    }
+
+    public function testRequestWithoutSessionIsIgnored(): void
+    {
+        $listener = $this->createListener();
+        $request = Request::create('/');
+
+        $listener->onKernelRequest($this->createRequestEvent($request));
+        $listener->onKernelResponse($this->createResponseEvent($request));
+
+        $this->assertFalse($request->hasSession());
+    }
+
+    public function testSubRequestIsIgnored(): void
+    {
+        $session = $this->createSession(['kuma_ip' => '10.0.0.1', 'kuma_ua' => 'Browser/1.0', 'user_data' => 'secret']);
+        $request = $this->createRequest($session, '10.0.0.2', 'Browser/2.0');
+
+        $this->createListener()->onKernelRequest($this->createRequestEvent($request, HttpKernelInterface::SUB_REQUEST));
+
+        $this->assertTrue($session->has('user_data'));
+    }
+
+    private function createListener(?LoggerInterface $logger = null, bool $ipCheck = true, bool $userAgentCheck = true): SessionSecurityListener
+    {
+        return new SessionSecurityListener($ipCheck, $userAgentCheck, $logger ?? $this->createMock(LoggerInterface::class));
+    }
+
+    private function createSession(array $data = []): Session
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+        foreach ($data as $key => $value) {
+            $session->set($key, $value);
+        }
+
+        return $session;
+    }
+
+    private function createRequest(Session $session, string $remoteAddr, string $userAgent, ?string $forwardedFor = null): Request
+    {
+        $server = ['REMOTE_ADDR' => $remoteAddr, 'HTTP_USER_AGENT' => $userAgent];
+        if (null !== $forwardedFor) {
+            $server['HTTP_X_FORWARDED_FOR'] = $forwardedFor;
+        }
+
+        $request = Request::create('/', 'GET', [], [], [], $server);
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    private function createRequestEvent(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent($this->createMock(KernelInterface::class), $request, $type);
+    }
+
+    private function createResponseEvent(Request $request): ResponseEvent
+    {
+        return new ResponseEvent($this->createMock(KernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, new Response());
     }
 }


### PR DESCRIPTION
The ip check of `SessionSecurityListener` (`session_security.ip_check`) read the `X-Forwarded-For` header straight from the server bag and preferred it over `Request::getClientIp()`, regardless of the trusted proxies configuration. Anyone holding a stolen session cookie could pass the check by sending the header with the ip the session was started from, which defeats the purpose of binding the session to an ip.

`Request::getClientIp()` already returns the forwarded ip when the request comes from a trusted proxy and the remote address otherwise, so it is now the single source. The listener tests are rewritten with real requests and a mock session storage (the previous ones only exercised the header path through mocked requests) and cover both the trusted and untrusted proxy case; the untrusted case fails on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
